### PR TITLE
[Fix] Ensure `dev execute` works with a v1 API

### DIFF
--- a/.ci/devnet_ci.sh
+++ b/.ci/devnet_ci.sh
@@ -15,6 +15,9 @@ total_clients=$2
 network_id=$3
 min_height=$4
 
+# The verobsity of snarkos nodes.
+NODE_VERBOSITY=1
+
 # Default values if not provided
 : "${total_validators:=4}"
 : "${total_clients:=2}"
@@ -49,7 +52,7 @@ trap 'echo "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" fail
 
 # Flags used by all nodes.
 common_flags=(
-  --nodisplay --nobanner --noupdater "--network=$network_id" --verbosity=1
+  --nodisplay --nobanner --noupdater "--network=$network_id" "--verbosity=$NODE_VERBOSITY"
   "--dev-num-validators=$total_validators"
 )
 
@@ -168,9 +171,10 @@ echo "{
 " > program/program.json
 
 # Deploy the test program and wait for the deployment to be processed.
+echo "● Testing program deployment..."
 _deploy_result=$(cd program && snarkos developer deploy --dev-key 0 --network "$network_id" --endpoint=localhost:3030 --broadcast --wait --timeout 20 "$program_name")
 
-# Ensure we are able to fetch the program fromn the node.
+# Ensure we are able to fetch the program from the node.
 status_code=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:3030/v2/$network_name/program/${program_name}/0")
 if (( status_code == 200 )); then
   echo "✅ Program exists on the node"
@@ -180,19 +184,16 @@ else
 fi
 
 # Ensure the latest edition is indeed 0.
+echo "● Testing retrieval of program editions..."
 edition=$(curl -s -o /dev/null "http://localhost:3030/v2/$network_name/program/${program_name}/latest_edition")
-if (( edition == 0 )); then
-  echo "✅ Only program edition 0 exists on the node"
-else
+if (( edition != 0 )); then
   echo "❌ Test failed! Invalid latest edition {} for test program returned, not 0."
   exit 1
 fi
 
 # Also check that the latest edition for the default program (credits.aleo) is 0.
 edition=$(curl -s -o /dev/null "http://localhost:3030/v2/$network_name/program/credits.aleo/latest_edition")
-if (( edition == 0 )); then
-  echo "✅ Only program edition 0 exists on the node"
-else
+if (( edition != 0 )); then
   echo "❌ Test failed! Invalid latest edition {} for credits.aleo returned, not 0."
   exit 1
 fi
@@ -207,9 +208,9 @@ else
 fi
 
 # Execute a function in the deployed program and wait for the execution to be processed.
-# Use the old flags here `--query` and `--broadcast=URL` to test they still work.
-# Also, use the v1 API to test it still works.
-execute_result=$(cd program && snarkos developer execute --dev-key 0 --network "$network_id" --query=localhost:3030 "--broadcast=http://localhost:3030/v1/$network_name/transaction/broadcast" "$program_name" main 1u32 1u32 --wait --timeout 20)
+echo "● Testing program execution with V2 API..."
+execute_result=$(cd program && snarkos developer execute --dev-key 0 --network "$network_id" --broadcast --endpoint=http://localhost:3030 \
+    "$program_name" main 1u32 1u32 --wait --timeout 10)
 
 # Fail if the execution transaction does not exist.
 tx=$(echo "$execute_result" | tail -n 1)
@@ -223,7 +224,26 @@ else
   echo "✅ Transaction executed successfully: $execute_result"
 fi
 
+# Use the old flags here `--query` and `--broadcast=URL` to test they still work.
+# Also, use the v1 API to test it still works.
+echo "● Testing program execution with V1 API..."
+execute_result=$(cd program && snarkos developer execute --dev-key 0 --network "$network_id" --query=http://localhost:3030/v1 \
+    "--broadcast=http://localhost:3030/v1/$network_name/transaction/broadcast" "$program_name" main 1u32 1u32 --wait --timeout 10)
+
+# Fail if the execution transaction does not exist.
+tx=$(echo "$execute_result" | tail -n 1)
+found=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:3030/v1/$network_name/transaction/$tx")
+# Fail if the HTTP response is not 2XX.
+if (( found < 200 || found >= 300 )); then
+  printf "❌ Test failed! Transaction does not exist or contains an error: \nexecute_result: %s\nfound: %s\n" \
+    "$execute_result" "$found"
+  exit 1
+else
+  echo "✅ Transaction executed successfully: $execute_result"
+fi
+
 # Fail if status does not exist or is not set to "accepted".
+echo "● Testing confirmed transaction endpoint..."
 rest_confirmed=$(curl -s "http://localhost:3030/v2/$network_name/transaction/confirmed/$tx")
 
 rest_status=$(jq --raw-output '.status' <<< "$rest_confirmed")
@@ -235,9 +255,10 @@ fi
 echo "ℹ️Testing REST API and REST Error Handling"
 
 # Test invalid transaction data (JsonDataError) returns 422 Unprocessable Content
-echo "Testing invalid transaction data returns 422 status code..."
-(cd program && snarkos developer execute --dev-key 0 --network "$network_id" --endpoint=localhost:3030 \
-  --store txn_data.json --store-format=string "$program_name" main 1u32 1u32)
+echo "● Testing invalid transaction data returns 422 status code..."
+(cd program && snarkos developer execute --dev-key 0 --network "$network_id" \
+  --endpoint=localhost:3030  --store txn_data.json --store-format=string \
+  "$program_name" main 1u32 1u32)
 
 # Modify the proof data
 # This changes the last three characters in the hash but keeps the correct length.
@@ -300,7 +321,7 @@ fi
 echo "✅ Malformed JSON returns properly formatted RestError with JSON syntax error message"
 
 # Test invalid Content-Type header returns 400 Bad Request
-echo "Testing missing Content-Type header returns 400 status code..."
+echo "● Testing missing Content-Type header returns 400 status code..."
 missing_content_type_response=$(curl -s -w "%{http_code}" -X POST \
   -d '{"valid": "json"}' \
   "http://localhost:3030/v2/$network_name/transaction/broadcast" \
@@ -314,7 +335,8 @@ else
 fi
 
 # Test that missing Content-Type returns a properly formatted RestError
-echo "Testing missing Content-Type returns valid RestError format..."
+echo "● Testing missing Content-Type returns valid RestError format..."
+
 missing_content_type_error=$(curl -s -X POST \
   -d '{"valid": "json"}' \
   "http://localhost:3030/v2/$network_name/transaction/broadcast")
@@ -334,6 +356,8 @@ fi
 echo "✅ Missing Content-Type returns properly formatted RestError with Content-Type error message"
 
 # Scan the network for records.
+echo "● Testing `snarkos developer scan`..."
+
 scan_result=$(snarkos developer scan --dev-key 0 --network "$network_id" --start 0 --endpoint=localhost:3030)
 num_records=$(echo "$scan_result" | grep -c "owner")
 # Fail if the scan did not return 4 records.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.52"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8120877db0e5c011242f96806ce3c94e0737ab8108532a76a3300a01db2ab8"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -662,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.52"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02576b399397b659c26064fbc92a75fede9d18ffd5f80ca1cd74ddab167016e1"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -231,7 +231,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -242,7 +242,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -267,7 +267,7 @@ dependencies = [
  "axum-core 0.4.5",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
@@ -294,7 +294,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
@@ -326,7 +326,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -345,7 +345,7 @@ checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -367,7 +367,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "headers",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -453,7 +453,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -587,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.46"
+version = "1.2.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97463e1064cb1b1c1384ad0a0b9c8abd0988e2a91f52606c80ef14aadb63e36"
+checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -681,7 +681,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -822,7 +822,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "log",
  "serde",
  "serde_derive",
@@ -1024,7 +1024,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1058,7 +1058,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "strsim",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1072,7 +1072,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "strsim",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1083,7 +1083,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1094,7 +1094,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1149,7 +1149,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "structmeta 0.3.0",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1160,7 +1160,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1181,7 +1181,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1224,7 +1224,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1348,7 +1348,7 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1558,7 +1558,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1723,8 +1723,8 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
- "indexmap 2.12.0",
+ "http 1.4.0",
+ "indexmap 2.12.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1759,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1790,7 +1790,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "headers-core",
- "http 1.3.1",
+ "http 1.4.0",
  "httpdate",
  "mime",
  "sha1",
@@ -1802,7 +1802,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.3.1",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1854,12 +1854,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1881,7 +1880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1892,7 +1891,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1955,7 +1954,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -1973,7 +1972,7 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.3.1",
+ "http 1.4.0",
  "hyper 1.8.1",
  "hyper-util",
  "rustls",
@@ -2037,7 +2036,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "hyper 1.8.1",
  "ipnet",
@@ -2197,12 +2196,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "rayon",
  "serde",
  "serde_core",
@@ -2240,7 +2239,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2510,7 +2509,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
 dependencies = [
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2575,7 +2574,7 @@ dependencies = [
  "base64 0.21.7",
  "hyper 0.14.32",
  "hyper-tls 0.5.0",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "ipnet",
  "metrics",
  "metrics-util",
@@ -2667,7 +2666,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2767,7 +2766,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2863,7 +2862,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2984,7 +2983,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3078,7 +3077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3130,7 +3129,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3413,7 +3412,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3473,7 +3472,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
@@ -3841,7 +3840,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3850,7 +3849,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itoa",
  "memchr",
  "ryu",
@@ -3900,7 +3899,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "schemars 0.9.0",
  "schemars 1.1.0",
  "serde_core",
@@ -3918,7 +3917,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3981,9 +3980,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
 dependencies = [
  "libc",
 ]
@@ -4098,7 +4097,7 @@ dependencies = [
  "colored 3.0.0",
  "console-subscriber",
  "crossterm 0.29.0",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "nix",
  "num_cpus",
@@ -4151,8 +4150,8 @@ dependencies = [
  "colored 3.0.0",
  "deadline",
  "futures-util",
- "http 1.3.1",
- "indexmap 2.12.0",
+ "http 1.4.0",
+ "indexmap 2.12.1",
  "locktick",
  "lru 0.16.2",
  "num_cpus",
@@ -4197,7 +4196,7 @@ dependencies = [
  "colored 3.0.0",
  "deadline",
  "futures",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itertools 0.14.0",
  "locktick",
  "lru 0.16.2",
@@ -4239,7 +4238,7 @@ version = "4.3.0"
 dependencies = [
  "anyhow",
  "bytes",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "proptest",
  "serde",
  "snarkos-node-network",
@@ -4257,7 +4256,7 @@ version = "4.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "parking_lot",
  "rand 0.8.5",
@@ -4274,7 +4273,7 @@ version = "4.3.0"
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "lru 0.16.2",
  "parking_lot",
@@ -4289,7 +4288,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "colored 3.0.0",
- "http 1.3.1",
+ "http 1.4.0",
  "locktick",
  "parking_lot",
  "rayon",
@@ -4310,7 +4309,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "colored 3.0.0",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itertools 0.14.0",
  "locktick",
  "lru 0.16.2",
@@ -4366,8 +4365,8 @@ dependencies = [
  "axum-extra",
  "base64 0.22.1",
  "built",
- "http 1.3.1",
- "indexmap 2.12.0",
+ "http 1.4.0",
+ "indexmap 2.12.1",
  "jsonwebtoken",
  "locktick",
  "once_cell",
@@ -4448,7 +4447,7 @@ version = "4.3.0"
 dependencies = [
  "anyhow",
  "futures",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itertools 0.14.0",
  "locktick",
  "parking_lot",
@@ -4480,7 +4479,7 @@ name = "snarkos-node-sync-locators"
 version = "4.3.0"
 dependencies = [
  "anyhow",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "serde",
  "snarkvm",
  "tracing",
@@ -4538,7 +4537,7 @@ dependencies = [
  "fxhash",
  "hashbrown 0.15.5",
  "hex",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itertools 0.14.0",
  "num-traits",
  "rand 0.8.5",
@@ -4614,7 +4613,7 @@ name = "snarkvm-circuit-environment"
 version = "4.3.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itertools 0.14.0",
  "nom",
  "num-traits",
@@ -4808,7 +4807,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608fe
 dependencies = [
  "anyhow",
  "enum-iterator",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "lazy_static",
  "paste",
  "serde",
@@ -4847,7 +4846,7 @@ dependencies = [
  "enum-iterator",
  "enum_index",
  "enum_index_derive",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "num-derive",
  "num-traits",
  "seq-macro",
@@ -4986,7 +4985,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608fe
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "lru 0.16.2",
  "parking_lot",
@@ -5027,7 +5026,7 @@ version = "4.3.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "anyhow",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -5049,7 +5048,7 @@ version = "4.3.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "anyhow",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "proptest",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -5080,7 +5079,7 @@ name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.3.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -5093,7 +5092,7 @@ name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.3.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -5117,7 +5116,7 @@ name = "snarkvm-ledger-narwhal-subdag"
 version = "4.3.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -5157,7 +5156,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "lru 0.16.2",
  "parking_lot",
@@ -5177,7 +5176,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "colored 3.0.0",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "lru 0.16.2",
  "parking_lot",
@@ -5217,7 +5216,7 @@ dependencies = [
  "aleo-std-storage",
  "anyhow",
  "bincode",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "parking_lot",
  "rayon",
@@ -5293,7 +5292,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608fe
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itertools 0.14.0",
  "locktick",
  "lru 0.16.2",
@@ -5327,7 +5326,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608fe
 dependencies = [
  "aleo-std",
  "colored 3.0.0",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "parking_lot",
  "rand 0.8.5",
@@ -5351,7 +5350,7 @@ version = "4.3.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
 dependencies = [
  "enum-iterator",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "paste",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -5407,7 +5406,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608fe
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5486,7 +5485,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "structmeta-derive 0.2.0",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5498,7 +5497,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "structmeta-derive 0.3.0",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5509,7 +5508,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5520,7 +5519,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5542,7 +5541,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "rustversion",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5575,9 +5574,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
@@ -5610,7 +5609,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5672,7 +5671,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "structmeta 0.2.0",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5685,7 +5684,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "structmeta 0.3.0",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5714,7 +5713,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5725,7 +5724,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5857,7 +5856,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5932,7 +5931,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -5977,7 +5976,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
@@ -6033,15 +6032,15 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "http-range-header",
@@ -6080,7 +6079,7 @@ dependencies = [
  "axum 0.8.7",
  "forwarded-header-value",
  "governor",
- "http 1.3.1",
+ "http 1.4.0",
  "pin-project",
  "thiserror 2.0.17",
  "tower 0.5.2",
@@ -6107,7 +6106,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6167,7 +6166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6273,12 +6272,12 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b4531c118335662134346048ddb0e54cc86bd7e81866757873055f0e38f5d2"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
  "base64 0.22.1",
- "http 1.3.1",
+ "http 1.4.0",
  "httparse",
  "log",
 ]
@@ -6425,7 +6424,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
@@ -6542,7 +6541,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6553,7 +6552,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6799,28 +6798,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6840,7 +6839,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -6861,7 +6860,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6894,7 +6893,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6908,7 +6907,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "memchr",
  "thiserror 2.0.17",
  "time",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -162,6 +162,10 @@ default-features = true
 version = "1"
 features = [ "derive" ]
 
+[dev-dependencies.snarkvm]
+workspace = true
+features = [ "test-helpers" ]
+
 [target."cfg(target_family = \"unix\")".dependencies.nix]
 version = "0.30"
 default-features = false

--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -152,7 +152,7 @@ impl Execute {
             let vm = VM::from(store)?;
 
             if !is_static_query && program_id != ProgramID::from_str("credits.aleo")? {
-                let height = query.current_block_height()?;
+                let height = query.current_block_height().with_context(|| "Failed to retrieve current block height")?;
                 let version = N::CONSENSUS_VERSION(height)?;
                 debug!("At block height {height} and consensus {version:?}");
                 let edition = Developer::get_latest_edition(&endpoint, &program_id)

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -199,16 +199,17 @@ impl Developer {
         ensure!(!route.starts_with('/'), "path cannot start with a slash");
 
         // If the route already ends with a version segment (v1 or v2), don't prepend a version.
-        let (route_has_version_suffix, api_version) = {
+        let api_version = {
             let r = base_url.path().trim_end_matches('/');
 
             if r.ends_with(API_VERSION_V1) {
-                (true, ApiVersion::V1)
+                ApiVersion::V1
             } else if r.ends_with(API_VERSION_V2) {
-                (true, ApiVersion::V2)
+                ApiVersion::V2
             } else {
-                // Default to v2.
-                (false, ApiVersion::V2)
+                // Default to v1.
+                // Note: If the snarkos-node-rest switches default to v2, this needs to be updated.
+                ApiVersion::V1
             }
         };
 
@@ -218,13 +219,7 @@ impl Developer {
         let sep = if base_url.path().ends_with('/') { "" } else { "/" };
 
         // Build "{base}/{maybe_version}/{network}/{route}"
-        let prefix = if route_has_version_suffix {
-            format!("{}/", N::SHORT_NAME)
-        } else {
-            format!("{}/{}/", API_VERSION_V2, N::SHORT_NAME)
-        };
-
-        let full_uri = format!("{base_url}{sep}{prefix}{route}");
+        let full_uri = format!("{base_url}{sep}{network}/{route}", network = N::SHORT_NAME);
         Ok((full_uri, api_version))
     }
 
@@ -529,6 +524,21 @@ mod tests {
 
     use snarkvm::ledger::test_helpers::CurrentNetwork;
 
+    /// Test that the default endpoints (V1) work as expected.
+    ///
+    /// Note, if the default endpoint ever changes, this test needs to be updated.
+    #[test]
+    fn test_build_endpoint_default_v1() {
+        let base_uri_str = "http://localhost:3030";
+        let base_uri = Uri::try_from(base_uri_str).unwrap();
+        let (endpoint, api_version) =
+            Developer::build_endpoint::<CurrentNetwork>(&base_uri, "transaction/broadcast").unwrap();
+
+        assert_eq!(endpoint, format!("{base_uri_str}/{}/transaction/broadcast", CurrentNetwork::SHORT_NAME));
+        assert_eq!(api_version, ApiVersion::V1);
+    }
+
+    /// Ensure that the V1 endpoints work as expected.
     #[test]
     fn test_build_endpoint_v1() {
         let base_uri_str = "http://localhost:3030/v1";
@@ -540,6 +550,7 @@ mod tests {
         assert_eq!(api_version, ApiVersion::V1);
     }
 
+    /// Ensure that the V2 endpoints work as expected.
     #[test]
     fn test_build_endpoint_v2() {
         let base_uri_str = "http://localhost:3030/v2";

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -43,6 +43,7 @@ use std::{
     thread,
     time::{Duration, Instant},
 };
+use tracing::debug;
 use ureq::http::{self, Uri};
 
 /// The format to store a generated transaction as.
@@ -50,6 +51,13 @@ use ureq::http::{self, Uri};
 pub enum StoreFormat {
     String,
     Bytes,
+}
+
+/// The API version used by an endpoint
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ApiVersion {
+    V1,
+    V2,
 }
 
 /// Commands to deploy and execute transactions
@@ -183,14 +191,25 @@ impl Developer {
     /// # Arguments
     ///  - `base_url`: the hostname (and path prefix) of the node to query. this must exclude the network name.
     ///  - `route`: the route to the endpoint (e.g., `stateRoot/latest`). This cannot start with a slash.
-    fn build_endpoint<N: Network>(base_url: &http::Uri, route: &str) -> Result<String> {
+    ///
+    /// # Returns
+    /// The full endpoint Uri and the API version used by it.
+    fn build_endpoint<N: Network>(base_url: &http::Uri, route: &str) -> Result<(String, ApiVersion)> {
         // This function is only called internally but check for additional sanity.
         ensure!(!route.starts_with('/'), "path cannot start with a slash");
 
         // If the route already ends with a version segment (v1 or v2), don't prepend a version.
-        let route_has_version_suffix = {
+        let (route_has_version_suffix, api_version) = {
             let r = base_url.path().trim_end_matches('/');
-            r.ends_with(API_VERSION_V1) || r.ends_with(API_VERSION_V2)
+
+            if r.ends_with(API_VERSION_V1) {
+                (true, ApiVersion::V1)
+            } else if r.ends_with(API_VERSION_V2) {
+                (true, ApiVersion::V2)
+            } else {
+                // Default to v2.
+                (false, ApiVersion::V2)
+            }
         };
 
         // Work around a bug in the `http` crate where empty paths will be set to '/'
@@ -205,12 +224,16 @@ impl Developer {
             format!("{}/{}/", API_VERSION_V2, N::SHORT_NAME)
         };
 
-        Ok(format!("{base_url}{sep}{prefix}{route}"))
+        let full_uri = format!("{base_url}{sep}{prefix}{route}");
+        Ok((full_uri, api_version))
     }
 
     /// Converts the returned JSON error (if any) into an anyhow Error chain.
     /// If the error was 404, this simply returns `Ok(None)`.
-    fn handle_ureq_result(result: Result<http::Response<ureq::Body>>) -> Result<Option<ureq::Body>> {
+    fn handle_ureq_result(
+        result: Result<http::Response<ureq::Body>>,
+        api_version: ApiVersion,
+    ) -> Result<Option<ureq::Body>> {
         let response = result?;
 
         if response.status().is_success() {
@@ -218,19 +241,49 @@ impl Developer {
         } else if response.status() == http::StatusCode::NOT_FOUND {
             Ok(None)
         } else {
-            let rest_error: RestError =
-                response.into_body().read_json().with_context(|| "Failed to parse error JSON")?;
+            match api_version {
+                ApiVersion::V1 => {
+                    // V1 returns the error message a string.
+                    let err_msg = response.into_body().read_to_string()?;
+                    Err(anyhow!(err_msg))
+                }
+                ApiVersion::V2 => {
+                    // V2 returns the error in JSON format.
+                    let rest_error: RestError =
+                        response.into_body().read_json().with_context(|| "Failed to parse error JSON")?;
 
-            Err(rest_error.parse())
+                    Err(rest_error.parse())
+                }
+            }
+        }
+    }
+
+    /// Extracts the API version from a custom endpoint.
+    fn parse_custom_endpoint<N: Network>(url: &Uri) -> (String, ApiVersion) {
+        // Determine API version for custom endpoint.
+        if let Some(pq) = url.path_and_query()
+            && pq.path().ends_with(&format!("{API_VERSION_V1}/{}/transaction/broadcast", N::SHORT_NAME))
+        {
+            debug!("Custom endpoint contains `v1`. Will fall back V1 API handling.");
+            (url.to_string(), ApiVersion::V1)
+        } else {
+            // Default to API version 2
+            (url.to_string(), ApiVersion::V2)
         }
     }
 
     /// Helper function to send a POST request with a JSON body to an endpoint and await a JSON response.
-    fn http_post_json<I: Serialize, O: DeserializeOwned>(path: &str, arg: &I) -> Result<Option<O>> {
+    fn http_post_json<I: Serialize, O: DeserializeOwned>(
+        path: &str,
+        arg: &I,
+        api_version: ApiVersion,
+    ) -> Result<Option<O>> {
+        debug!("Issuing POST request ({api_version:?}) to \"{path}\"");
+
         let result =
             ureq::post(path).config().http_status_as_error(false).build().send_json(arg).map_err(|err| err.into());
 
-        match Self::handle_ureq_result(result).with_context(|| "HTTP POST request failed")? {
+        match Self::handle_ureq_result(result, api_version).with_context(|| "HTTP POST request failed")? {
             Some(mut body) => {
                 let json = body.read_json().with_context(|| "Failed to parse JSON response")?;
                 Ok(Some(json))
@@ -241,10 +294,12 @@ impl Developer {
 
     /// Helper function to send a GET request to an endpoint and await a JSON response.
     fn http_get_json<N: Network, O: DeserializeOwned>(base_url: &http::Uri, route: &str) -> Result<Option<O>> {
-        let endpoint = Self::build_endpoint::<N>(base_url, route)?;
+        let (endpoint, api_version) = Self::build_endpoint::<N>(base_url, route)?;
+        debug!("Issuing GET request ({api_version:?}) to \"{endpoint}\"");
+
         let result = ureq::get(&endpoint).config().http_status_as_error(false).build().call().map_err(|err| err.into());
 
-        match Self::handle_ureq_result(result).with_context(|| "HTTP GET request failed")? {
+        match Self::handle_ureq_result(result, api_version).with_context(|| "HTTP GET request failed")? {
             Some(mut body) => {
                 let json = body.read_json().with_context(|| "Failed to parse JSON response")?;
                 Ok(Some(json))
@@ -255,10 +310,12 @@ impl Developer {
 
     /// Helper function to send a GET request to an endpoint and await the response.
     fn http_get<N: Network>(base_url: &http::Uri, route: &str) -> Result<Option<ureq::Body>> {
-        let endpoint = Self::build_endpoint::<N>(base_url, route)?;
+        let (endpoint, api_version) = Self::build_endpoint::<N>(base_url, route)?;
+        debug!("Issuing GET request ({api_version:?}) to \"{endpoint}\"");
+
         let result = ureq::get(&endpoint).config().http_status_as_error(false).build().call().map_err(|err| err.into());
 
-        Self::handle_ureq_result(result).with_context(|| "HTTP GET request failed")
+        Self::handle_ureq_result(result, api_version).with_context(|| "HTTP GET request failed")
     }
 
     /// Wait for a transaction to be confirmed by the network.
@@ -266,6 +323,7 @@ impl Developer {
         endpoint: &Uri,
         transaction_id: &N::TransactionID,
         timeout_seconds: u64,
+        api_version: ApiVersion,
     ) -> Result<()> {
         let start_time = Instant::now();
         let timeout_duration = Duration::from_secs(timeout_seconds);
@@ -273,16 +331,31 @@ impl Developer {
 
         while start_time.elapsed() < timeout_duration {
             // Check if transaction exists in a confirmed block
-            let result = Self::http_get::<N>(endpoint, &format!("transaction/{transaction_id}"))
-                .with_context(|| "Failed to check transaction status")?;
+            let result = Self::http_get::<N>(endpoint, &format!("transaction/{transaction_id}"));
 
-            match result {
-                Some(_) => return Ok(()),
-                None => {
-                    // Transaction not found yet, continue polling.
-                    thread::sleep(poll_interval);
+            match api_version {
+                ApiVersion::V1 => match result {
+                    Ok(Some(_)) => return Ok(()),
+                    Ok(None) => {
+                        // Transaction not found yet, continue polling.
+                    }
+                    Err(err) => {
+                        // The V1 API returns 500 on missing transactions. Retroy on any error.
+                        eprintln!("Got error when fetching transaction ({err}). Will retry...");
+                    }
+                },
+                ApiVersion::V2 => {
+                    // With the V2 API, we can differentiate between benign errors and fatal errors.
+                    match result.with_context(|| "Failed to check transaction status")? {
+                        Some(_) => return Ok(()),
+                        None => {
+                            // Transaction not found yet, continue polling.
+                        }
+                    }
                 }
             }
+
+            thread::sleep(poll_interval);
         }
 
         // Timeout reached
@@ -368,13 +441,14 @@ impl Developer {
 
         // Determine if the transaction should be broadcast to the network.
         if let Some(broadcast_value) = broadcast {
-            let broadcast_endpoint = if let Some(url) = broadcast_value {
-                url.to_string()
+            let (broadcast_endpoint, api_version) = if let Some(url) = broadcast_value {
+                debug!("Using custom endpoint for broadcasting: {url}");
+                Self::parse_custom_endpoint::<N>(url)
             } else {
                 Self::build_endpoint::<N>(endpoint, "transaction/broadcast")?
             };
 
-            let result: Result<String> = match Self::http_post_json(&broadcast_endpoint, &transaction) {
+            let result: Result<String> = match Self::http_post_json(&broadcast_endpoint, &transaction, api_version) {
                 Ok(Some(s)) => Ok(s),
                 Ok(None) => Err(anyhow!("Got unexpected 404 error")),
                 Err(err) => Err(err),
@@ -408,7 +482,7 @@ impl Developer {
                     // If wait is enabled, wait for transaction confirmation
                     if wait {
                         println!("⏳ Waiting for transaction confirmation (timeout: {timeout}s)...");
-                        Self::wait_for_transaction_confirmation::<N>(endpoint, &transaction_id, timeout)?;
+                        Self::wait_for_transaction_confirmation::<N>(endpoint, &transaction_id, timeout, api_version)?;
 
                         match transaction {
                             Transaction::Deploy(..) => {
@@ -446,5 +520,56 @@ impl Developer {
         } else {
             Ok("".to_string())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use snarkvm::ledger::test_helpers::CurrentNetwork;
+
+    #[test]
+    fn test_build_endpoint_v1() {
+        let base_uri_str = "http://localhost:3030/v1";
+        let base_uri = Uri::try_from(base_uri_str).unwrap();
+        let (endpoint, api_version) =
+            Developer::build_endpoint::<CurrentNetwork>(&base_uri, "transaction/broadcast").unwrap();
+
+        assert_eq!(endpoint, format!("{base_uri_str}/{}/transaction/broadcast", CurrentNetwork::SHORT_NAME));
+        assert_eq!(api_version, ApiVersion::V1);
+    }
+
+    #[test]
+    fn test_build_endpoint_v2() {
+        let base_uri_str = "http://localhost:3030/v2";
+        let base_uri = Uri::try_from(base_uri_str).unwrap();
+        let (endpoint, api_version) =
+            Developer::build_endpoint::<CurrentNetwork>(&base_uri, "transaction/broadcast").unwrap();
+
+        assert_eq!(endpoint, format!("{base_uri_str}/{}/transaction/broadcast", CurrentNetwork::SHORT_NAME));
+        assert_eq!(api_version, ApiVersion::V2);
+    }
+
+    #[test]
+    fn test_custom_endpoint_v1() {
+        let endpoint_str = "http://localhost:3030/v1/mainnet/transaction/broadcast";
+        let endpoint = Uri::try_from(endpoint_str).unwrap();
+
+        let (parsed, api_version) = Developer::parse_custom_endpoint::<CurrentNetwork>(&endpoint);
+
+        assert_eq!(parsed, endpoint_str);
+        assert_eq!(api_version, ApiVersion::V1);
+    }
+
+    #[test]
+    fn test_custom_endpoint_v2() {
+        let endpoint_str = "http://localhost:3030/v2/mainnet/transaction/broadcast";
+        let endpoint = Uri::try_from(endpoint_str).unwrap();
+
+        let (parsed, api_version) = Developer::parse_custom_endpoint::<CurrentNetwork>(&endpoint);
+
+        assert_eq!(parsed, endpoint_str);
+        assert_eq!(api_version, ApiVersion::V2);
     }
 }

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -225,10 +225,7 @@ impl Developer {
 
     /// Converts the returned JSON error (if any) into an anyhow Error chain.
     /// If the error was 404, this simply returns `Ok(None)`.
-    fn handle_ureq_result(
-        result: Result<http::Response<ureq::Body>>,
-        api_version: ApiVersion,
-    ) -> Result<Option<ureq::Body>> {
+    fn handle_ureq_result(result: Result<http::Response<ureq::Body>>) -> Result<Option<ureq::Body>> {
         let response = result?;
 
         if response.status().is_success() {
@@ -236,19 +233,23 @@ impl Developer {
         } else if response.status() == http::StatusCode::NOT_FOUND {
             Ok(None)
         } else {
-            match api_version {
-                ApiVersion::V1 => {
-                    // V1 returns the error message a string.
-                    let err_msg = response.into_body().read_to_string()?;
-                    Err(anyhow!(err_msg))
-                }
-                ApiVersion::V2 => {
-                    // V2 returns the error in JSON format.
-                    let rest_error: RestError =
-                        response.into_body().read_json().with_context(|| "Failed to parse error JSON")?;
+            // V2 returns the error in JSON format.
+            let is_json = response
+                .headers()
+                .get(http::header::CONTENT_TYPE)
+                .and_then(|h| h.to_str().ok())
+                .map(|ct| ct.contains("json"))
+                .unwrap_or(false);
 
-                    Err(rest_error.parse())
-                }
+            if is_json {
+                let rest_error: RestError =
+                    response.into_body().read_json().with_context(|| "Failed to parse error JSON")?;
+
+                Err(rest_error.parse())
+            } else {
+                // V1 returns the error message a string.
+                let err_msg = response.into_body().read_to_string()?;
+                Err(anyhow!(err_msg))
             }
         }
     }
@@ -257,28 +258,22 @@ impl Developer {
     fn parse_custom_endpoint<N: Network>(url: &Uri) -> (String, ApiVersion) {
         // Determine API version for custom endpoint.
         if let Some(pq) = url.path_and_query()
-            && pq.path().ends_with(&format!("{API_VERSION_V1}/{}/transaction/broadcast", N::SHORT_NAME))
+            && pq.path().ends_with(&format!("{API_VERSION_V2}/{}/transaction/broadcast", N::SHORT_NAME))
         {
-            debug!("Custom endpoint contains `v1`. Will fall back V1 API handling.");
-            (url.to_string(), ApiVersion::V1)
-        } else {
-            // Default to API version 2
             (url.to_string(), ApiVersion::V2)
+        } else {
+            (url.to_string(), ApiVersion::V1)
         }
     }
 
     /// Helper function to send a POST request with a JSON body to an endpoint and await a JSON response.
-    fn http_post_json<I: Serialize, O: DeserializeOwned>(
-        path: &str,
-        arg: &I,
-        api_version: ApiVersion,
-    ) -> Result<Option<O>> {
-        debug!("Issuing POST request ({api_version:?}) to \"{path}\"");
+    fn http_post_json<I: Serialize, O: DeserializeOwned>(path: &str, arg: &I) -> Result<Option<O>> {
+        debug!("Issuing POST request to \"{path}\"");
 
         let result =
             ureq::post(path).config().http_status_as_error(false).build().send_json(arg).map_err(|err| err.into());
 
-        match Self::handle_ureq_result(result, api_version).with_context(|| "HTTP POST request failed")? {
+        match Self::handle_ureq_result(result).with_context(|| "HTTP POST request failed")? {
             Some(mut body) => {
                 let json = body.read_json().with_context(|| "Failed to parse JSON response")?;
                 Ok(Some(json))
@@ -289,12 +284,12 @@ impl Developer {
 
     /// Helper function to send a GET request to an endpoint and await a JSON response.
     fn http_get_json<N: Network, O: DeserializeOwned>(base_url: &http::Uri, route: &str) -> Result<Option<O>> {
-        let (endpoint, api_version) = Self::build_endpoint::<N>(base_url, route)?;
-        debug!("Issuing GET request ({api_version:?}) to \"{endpoint}\"");
+        let (endpoint, _api_version) = Self::build_endpoint::<N>(base_url, route)?;
+        debug!("Issuing GET request to \"{endpoint}\"");
 
         let result = ureq::get(&endpoint).config().http_status_as_error(false).build().call().map_err(|err| err.into());
 
-        match Self::handle_ureq_result(result, api_version).with_context(|| "HTTP GET request failed")? {
+        match Self::handle_ureq_result(result).with_context(|| "HTTP GET request failed")? {
             Some(mut body) => {
                 let json = body.read_json().with_context(|| "Failed to parse JSON response")?;
                 Ok(Some(json))
@@ -305,12 +300,12 @@ impl Developer {
 
     /// Helper function to send a GET request to an endpoint and await the response.
     fn http_get<N: Network>(base_url: &http::Uri, route: &str) -> Result<Option<ureq::Body>> {
-        let (endpoint, api_version) = Self::build_endpoint::<N>(base_url, route)?;
-        debug!("Issuing GET request ({api_version:?}) to \"{endpoint}\"");
+        let (endpoint, _api_version) = Self::build_endpoint::<N>(base_url, route)?;
+        debug!("Issuing GET request to \"{endpoint}\"");
 
         let result = ureq::get(&endpoint).config().http_status_as_error(false).build().call().map_err(|err| err.into());
 
-        Self::handle_ureq_result(result, api_version).with_context(|| "HTTP GET request failed")
+        Self::handle_ureq_result(result).with_context(|| "HTTP GET request failed")
     }
 
     /// Wait for a transaction to be confirmed by the network.
@@ -443,7 +438,7 @@ impl Developer {
                 Self::build_endpoint::<N>(endpoint, "transaction/broadcast")?
             };
 
-            let result: Result<String> = match Self::http_post_json(&broadcast_endpoint, &transaction, api_version) {
+            let result: Result<String> = match Self::http_post_json(&broadcast_endpoint, &transaction) {
                 Ok(Some(s)) => Ok(s),
                 Ok(None) => Err(anyhow!("Got unexpected 404 error")),
                 Err(err) => Err(err),

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -198,7 +198,7 @@ impl Developer {
         // This function is only called internally but check for additional sanity.
         ensure!(!route.starts_with('/'), "path cannot start with a slash");
 
-        // If the route already ends with a version segment (v1 or v2), don't prepend a version.
+        // Determine the API version we are interacting with.
         let api_version = {
             let r = base_url.path().trim_end_matches('/');
 

--- a/cli/src/commands/developer/scan.rs
+++ b/cli/src/commands/developer/scan.rs
@@ -150,10 +150,10 @@ impl Scan {
             end
         } else {
             // If not end height was given, request the latest block height from the endpoint.
-            let (endpoint, api_version) = Developer::build_endpoint::<N>(endpoint, "block/height/latest")?;
+            let (endpoint, _api_version) = Developer::build_endpoint::<N>(endpoint, "block/height/latest")?;
             let result = ureq::get(&endpoint).call().map_err(|e| e.into());
-            let end: u32 = Developer::handle_ureq_result(result, api_version)?
-                .ok_or(anyhow!("Endpoint returned 404 for latest block height"))?
+            let end: u32 = Developer::handle_ureq_result(result)
+                .and_then(|body| body.ok_or(anyhow!("Endpoint returned 404 for latest block height")))?
                 .read_to_string()?
                 .parse()?;
 

--- a/cli/src/commands/developer/scan.rs
+++ b/cli/src/commands/developer/scan.rs
@@ -28,7 +28,7 @@ use snarkvm::{
 #[cfg(not(feature = "test_targets"))]
 use snarkvm::prelude::FromBytes;
 
-use anyhow::{Context, Result, bail, ensure};
+use anyhow::{Context, Result, anyhow, bail, ensure};
 use clap::{Parser, builder::NonEmptyStringValueParser};
 #[cfg(feature = "locktick")]
 use locktick::parking_lot::RwLock;
@@ -39,6 +39,7 @@ use std::{
     str::FromStr,
     sync::Arc,
 };
+use tracing::debug;
 use ureq::http::Uri;
 use zeroize::Zeroize;
 
@@ -144,35 +145,42 @@ impl Scan {
 
     /// Returns the `start` and `end` blocks to scan.
     fn parse_block_range<N: Network>(&self, endpoint: &Uri) -> Result<(u32, u32)> {
-        match (self.start, self.end, self.last) {
-            (Some(start), Some(end), None) => {
-                ensure!(end > start, "The given scan range is invalid (start = {start}, end = {end})");
+        // Compute the end height.
+        let end = if let Some(end) = self.end {
+            end
+        } else {
+            // If not end height was given, request the latest block height from the endpoint.
+            let (endpoint, api_version) = Developer::build_endpoint::<N>(endpoint, "block/height/latest")?;
+            let result = ureq::get(&endpoint).call().map_err(|e| e.into());
+            let end: u32 = Developer::handle_ureq_result(result, api_version)?
+                .ok_or(anyhow!("Endpoint returned 404 for latest block height"))?
+                .read_to_string()?
+                .parse()?;
 
-                Ok((start, end))
-            }
-            (Some(start), None, None) => {
-                // Request the latest block height from the endpoint.
-                let endpoint = Developer::build_endpoint::<N>(endpoint, "block/height/latest")?;
-                let latest_height = u32::from_str(&ureq::get(&endpoint).call()?.into_body().read_to_string()?)?;
+            debug!("Set end height to {end} based on latest block height of the endpoint");
+            end
+        };
 
-                // Print a warning message if the user is attempting to scan the whole chain.
-                if start == 0 {
-                    println!("⚠️  Attention - Scanning the entire chain. This may take a while...\n");
-                }
+        // Compute the start height.
+        let start = if let Some(start) = self.start {
+            start
+        } else if let Some(last) = self.last {
+            let start = end.saturating_sub(last);
+            debug!("Setting start height to {start} (based on last={last} and end={end})");
+            start
+        } else {
+            debug!("Picking default value (0) for start height");
+            0
+        };
 
-                Ok((start, latest_height))
-            }
-            (None, Some(end), None) => Ok((0, end)),
-            (None, None, Some(last)) => {
-                // Request the latest block height from the endpoint.
-                let endpoint = Developer::build_endpoint::<N>(endpoint, "block/height/latest")?;
-                let latest_height = u32::from_str(&ureq::get(&endpoint).call()?.into_body().read_to_string()?)?;
+        ensure!(end > start, "The given scan range is invalid (start = {start}, end = {end})");
 
-                Ok((latest_height.saturating_sub(last), latest_height))
-            }
-            (None, None, None) => bail!("Missing data about block range."),
-            _ => bail!("`last` flags can't be used with `start` or `end`"),
+        // Print a warning message if the user is attempting to scan the whole chain.
+        if start == 0 && self.end.is_none() {
+            println!("⚠️  Attention - Scanning the entire chain. This may take a while...\n");
         }
+
+        Ok((start, end))
     }
 
     /// Returns the CDN to prefetch initial blocks from, from the given configurations.
@@ -215,8 +223,11 @@ impl Scan {
         #[cfg(not(feature = "test_targets"))]
         let is_development_network = {
             // Fetch the genesis block from the endpoint.
-            let endpoint = Developer::build_endpoint::<N>(endpoint, "block/0")?;
-            let endpoint_genesis_block: Block<N> = ureq::get(endpoint).call()?.into_body().read_json()?;
+            let endpoint_genesis_block: Block<N> = match Developer::http_get_json::<N, _>(endpoint, "block/0")? {
+                Some(block) => block,
+                None => bail!("Enpoint returend 404 for genesis block"),
+            };
+
             // If the endpoint's block differs from our (production) block, it is on a development network.
             endpoint_genesis_block != Block::from_bytes_le(N::genesis_bytes())?
         };
@@ -255,12 +266,11 @@ impl Scan {
                 std::cmp::min(MAX_BLOCK_RANGE, end_height.saturating_sub(request_start).saturating_add(1));
             let request_end = request_start.saturating_add(num_blocks_to_request);
 
-            // Establish the endpoint.
-            let blocks_endpoint =
-                Developer::build_endpoint::<N>(endpoint, &format!("blocks?start={request_start}&end={request_end}"))?;
-            // Fetch blocks
-            let blocks: Vec<Block<N>> = (|| ureq::get(&blocks_endpoint).call()?.into_body().read_json())()
-                .with_context(|| format!("Failed to fetch blocks range {request_start}..{request_end}"))?;
+            // Fetch blocks.
+            let blocks: Vec<Block<N>> =
+                Developer::http_get_json::<N, _>(endpoint, &format!("blocks?start={request_start}&end={request_end}"))
+                    .and_then(|blocks| blocks.ok_or(anyhow!("Enpoint returend 404 for the specified block range")))
+                    .with_context(|| format!("Failed to fetch blocks range {request_start}..{request_end}"))?;
 
             // Scan the blocks for owned records.
             for block in &blocks {
@@ -385,7 +395,8 @@ impl Scan {
             let serial_number = Record::<N, Plaintext<N>>::serial_number(private_key, commitment)?;
 
             // Establish the endpoint.
-            let endpoint = Developer::build_endpoint::<N>(endpoint, &format!("find/transitionID/{serial_number}"))?;
+            let (endpoint, _api_version) =
+                Developer::build_endpoint::<N>(endpoint, &format!("find/transitionID/{serial_number}"))?;
 
             // Check if the record is spent.
             match ureq::get(&endpoint).call() {

--- a/cli/src/helpers/logger.rs
+++ b/cli/src/helpers/logger.rs
@@ -71,6 +71,7 @@ fn parse_log_verbosity(verbosity: u8) -> Result<EnvFilter> {
             .add_directive("tower=warn".parse().unwrap())
             .add_directive("axum=warn".parse().unwrap())
             .add_directive("ureq=warn".parse().unwrap())
+            .add_directive("rustls=warn".parse().unwrap())
     } else {
         let filter = filter.add_directive("snarkos_node_bft::gateway=debug".parse().unwrap());
 
@@ -85,6 +86,7 @@ fn parse_log_verbosity(verbosity: u8) -> Result<EnvFilter> {
             .add_directive("tower=off".parse().unwrap())
             .add_directive("axum=off".parse().unwrap())
             .add_directive("ureq=off".parse().unwrap())
+            .add_directive("rustls=off".parse().unwrap())
     };
 
     let filter = if verbosity >= 5 {


### PR DESCRIPTION
The PR detects the API version in a given endpoint and adjust its logic accordingly. Depends on https://github.com/ProvableHQ/snarkVM/pull/3036.

### Overview of changes
* Adds a new `parse_custom_endpoint` method with unit tests.
* Expects errors as JSON for V2 and as strings for V1.
* Improvements to the `devnet_ci.sh` script, such as better log messages and a new test for the V2 API.
* Ensures that `--wait` works correctly for V1, which returns `500` not `404` for a missing transaction.

### Notes
* Some of the version parsing logic is also done in the corresponding snarkVM PR. I wanted to add as little on the snarkVM side as possible, though, so the `cli` does its own parsing of the version number.
* I simplified `parse_block_range` as it had two different branches that were fetching the latest block height.