### PR TITLE
[Fix] Handle missing account in `snarkos dev execute`

### DIFF
--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -36,7 +36,7 @@ use snarkvm::{
 };
 
 use aleo_std::StorageMode;
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use clap::{Parser, builder::NonEmptyStringValueParser};
 use colored::Colorize;
 use std::str::FromStr;
@@ -188,7 +188,13 @@ impl Execute {
             // Fetch the public balance.
             let address = Address::try_from(&private_key)?;
             let public_balance = Developer::get_public_balance::<N>(&endpoint, &address)
-                .with_context(|| "Failed to check for sufficient funds to send transaction")?;
+                .with_context(|| "Failed to check for sufficient funds to send transaction")?
+                .ok_or_else(|| {
+                    anyhow!(
+                        "No public balance found for sending account `{}`. It may not exist.",
+                        address.to_string().bold()
+                    )
+                })?;
 
             // Check if the public balance is sufficient.
             let storage_cost = transaction

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -361,20 +361,23 @@ impl Developer {
     }
 
     /// Gets the public account balance of an Aleo Address (in microcredits).
-    fn get_public_balance<N: Network>(endpoint: &Uri, address: &Address<N>) -> Result<u64> {
+    fn get_public_balance<N: Network>(endpoint: &Uri, address: &Address<N>) -> Result<Option<u64>> {
         // Initialize the program id and account identifier.
         let account_mapping = Identifier::<N>::from_str("account")?;
         let credits = ProgramID::<N>::from_str("credits.aleo")?;
 
-        // Send a request to the query node.
+        // Request the balance from the endpoint.
+        // If no such balance/account exists, the node returns status code 200 with `null` as the response body.
+        // Nodes should never return 404 for this endpoint.
         let result: Option<Value<N>> =
-            Self::http_get_json::<N, _>(endpoint, &format!("program/{credits}/mapping/{account_mapping}/{address}"))?;
+            Self::http_get_json::<N, _>(endpoint, &format!("program/{credits}/mapping/{account_mapping}/{address}"))?
+                .ok_or_else(|| anyhow!("Got unexpected 404 error when fetching public balance"))?;
 
         // Return the balance in microcredits.
         match result {
-            Some(Value::Plaintext(Plaintext::Literal(Literal::<N>::U64(amount), _))) => Ok(*amount),
+            Some(Value::Plaintext(Plaintext::Literal(Literal::<N>::U64(amount), _))) => Ok(Some(*amount)),
             Some(..) => bail!("Failed to deserialize balance for {address}"),
-            None => Ok(0),
+            None => Ok(None),
         }
     }
 


### PR DESCRIPTION
### Bug / Current Behavior

Fetching the balance for a missing account creates a confusing error message.
(The private key and account ID here are newly generated solely testing and do not exist on any of the chains)

```
~> snarkos developer execute --dry-run --private-key APrivateKey1zkpB4H8Y2r2cG6H84VPntqJURSzt2iDE2WKF8NCSN3KzeyP credits.aleo transfer_public aleo134qladey67xw5080t089z4yqj6ynzdlnz9n5cs9m3wmpxe6mc59qcv26dz 1u64
📦 Creating execution transaction for 'credits.aleo/transfer_public'...

⚠️ Failed to check for sufficient funds to send transaction
     ↳ Failed to parse JSON response
     ↳ json: invalid type: null, expected a string at line 1 column 4

Use `--help` for instructions on how to use this command
```

### New Behavior

With the changes in this PR, the CLI now handles `null` being returned correctly. It might be better for nodes to return 404 in such cases, but changing the REST API would be more complicated and might break existing use cases.

```
~> snarkos developer execute --dry-run --private-key APrivateKey1zkpB4H8Y2r2cG6H84VPntqJURSzt2iDE2WKF8NCSN3KzeyP credits.aleo transfer_public aleo134qladey67xw5080t089z4yqj6ynzdlnz9n5cs9m3wmpxe6mc59qcv26dz 1u64
📦 Creating execution transaction for 'credits.aleo/transfer_public'...

⚠️ No public balance found for sending account `aleo134qladey67xw5080t089z4yqj6ynzdlnz9n5cs9m3wmpxe6mc59qcv26dz`. It may not exist.

Use `--help` for instructions on how to use this command
```

### Misc
* [c1990f2](https://github.com/ProvableHQ/snarkOS/pull/4003/commits/c1990f2fe1af50e75e82781476b7e0269dd3d244) disables logs for rustls, which can be very verbose
