### PR TITLE
[Logs] Print detailed errors in BFT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -231,7 +231,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -242,7 +242,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -453,7 +453,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -681,7 +681,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1024,7 +1024,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1058,7 +1058,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "strsim",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1072,7 +1072,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "strsim",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1083,7 +1083,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1094,7 +1094,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1149,7 +1149,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "structmeta 0.3.0",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1160,7 +1160,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1181,7 +1181,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1224,7 +1224,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1348,7 +1348,7 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1558,7 +1558,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2240,7 +2240,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2667,7 +2667,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2767,7 +2767,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2863,7 +2863,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2984,7 +2984,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3078,7 +3078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3130,7 +3130,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3413,7 +3413,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3630,15 +3630,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3850,7 +3841,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3927,7 +3918,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4515,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -4538,7 +4529,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4566,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "blst",
  "cc",
@@ -4577,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4591,7 +4582,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4601,7 +4592,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4611,7 +4602,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4621,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "indexmap 2.12.0",
  "itertools 0.14.0",
@@ -4639,12 +4630,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4655,7 +4646,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4669,7 +4660,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4684,7 +4675,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4697,7 +4688,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4706,7 +4697,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4716,7 +4707,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4728,7 +4719,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4740,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4751,7 +4742,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4763,7 +4754,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4776,7 +4767,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4787,7 +4778,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -4802,7 +4793,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4813,7 +4804,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -4833,7 +4824,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4851,7 +4842,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4872,7 +4863,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4887,7 +4878,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4898,7 +4889,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4906,7 +4897,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4916,7 +4907,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4927,7 +4918,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4938,7 +4929,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4949,7 +4940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4960,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4974,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4991,7 +4982,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5021,7 +5012,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -5033,7 +5024,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "anyhow",
  "indexmap 2.12.0",
@@ -5055,7 +5046,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "anyhow",
  "indexmap 2.12.0",
@@ -5074,7 +5065,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -5087,7 +5078,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "indexmap 2.12.0",
  "rayon",
@@ -5100,7 +5091,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "indexmap 2.12.0",
  "rayon",
@@ -5113,7 +5104,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5124,7 +5115,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "indexmap 2.12.0",
  "rayon",
@@ -5139,7 +5130,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5152,7 +5143,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -5161,7 +5152,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5181,7 +5172,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5204,7 +5195,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5221,7 +5212,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -5243,12 +5234,13 @@ dependencies = [
  "snarkvm-synthesizer-program",
  "snarkvm-synthesizer-snark",
  "snarkvm-utilities",
+ "tracing",
 ]
 
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5266,7 +5258,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "metrics",
 ]
@@ -5274,7 +5266,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5297,7 +5289,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5331,7 +5323,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "aleo-std",
  "colored 3.0.0",
@@ -5356,7 +5348,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "enum-iterator",
  "indexmap 2.12.0",
@@ -5375,7 +5367,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "bincode",
  "serde_json",
@@ -5388,11 +5380,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
+ "colored 3.0.0",
  "num-bigint",
  "num_cpus",
  "rand 0.8.5",
@@ -5410,11 +5403,11 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=ca6ce3cdf#ca6ce3cdf3ccf7bb6fa22f859698ddea6f052bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=678e81396#678e8139666b8443dc17fb46d9b8307c404a7722"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5493,7 +5486,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "structmeta-derive 0.2.0",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5505,7 +5498,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "structmeta-derive 0.3.0",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5516,7 +5509,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5527,7 +5520,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5549,7 +5542,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "rustversion",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5582,9 +5575,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.109"
+version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f17c7e013e88258aa9543dcbe81aca68a667a9ac37cd69c9fbc07858bfe0e2f"
+checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
@@ -5617,7 +5610,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5679,7 +5672,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "structmeta 0.2.0",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5692,7 +5685,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "structmeta 0.3.0",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5721,7 +5714,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5732,7 +5725,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5864,7 +5857,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -6114,7 +6107,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -6174,7 +6167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -6260,9 +6253,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.1.2"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ba1025f18a4a3fc3e9b48c868e9beb4f24f4b4b1a325bada26bd4119f46537"
+checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
@@ -6270,7 +6263,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -6433,7 +6425,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
  "wasm-bindgen-shared",
 ]
 
@@ -6550,7 +6542,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -6561,7 +6553,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -6831,7 +6823,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
  "synstructure",
 ]
 
@@ -6852,7 +6844,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -6872,7 +6864,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
  "synstructure",
 ]
 
@@ -6893,7 +6885,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -6926,7 +6918,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "ca6ce3cdf"
+rev = "678e81396" 
 #version = "=4.3.0"
 default-features = false
 

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -40,9 +40,11 @@ use snarkvm::{
         puzzle::{Solution, SolutionID},
     },
     prelude::{Field, Network, Result, bail, ensure},
+    utilities::flatten_error,
 };
 
 use aleo_std::StorageMode;
+use anyhow::Context;
 use colored::Colorize;
 use indexmap::{IndexMap, IndexSet};
 #[cfg(feature = "locktick")]
@@ -280,8 +282,12 @@ impl<N: Network> BFT<N> {
         // If the BFT is ready, then update to the next round.
         if is_ready {
             // Update to the next round in storage.
-            if let Err(e) = self.storage().increment_to_next_round(current_round) {
-                warn!("BFT failed to increment to the next round from round {current_round} - {e}");
+            if let Err(err) = self
+                .storage()
+                .increment_to_next_round(current_round)
+                .with_context(|| format!("BFT failed to increment to the next round from round {current_round}"))
+            {
+                warn!("{}", &flatten_error(err));
                 return false;
             }
             // Update the timer for the leader certificate.
@@ -323,8 +329,11 @@ impl<N: Network> BFT<N> {
         // Retrieve the committee lookback of the current round.
         let committee_lookback = match self.ledger().get_committee_lookback_for_round(current_round) {
             Ok(committee) => committee,
-            Err(e) => {
-                error!("BFT failed to retrieve the committee lookback for the even round {current_round} - {e}");
+            Err(err) => {
+                let err = err.context(format!(
+                    "BFT failed to retrieve the committee lookback for the even round {current_round}"
+                ));
+                warn!("{}", &flatten_error(err));
                 return false;
             }
         };
@@ -335,8 +344,10 @@ impl<N: Network> BFT<N> {
                 // Compute the leader for the current round.
                 let computed_leader = match committee_lookback.get_leader(current_round) {
                     Ok(leader) => leader,
-                    Err(e) => {
-                        error!("BFT failed to compute the leader for the even round {current_round} - {e}");
+                    Err(err) => {
+                        let err =
+                            err.context(format!("BFT failed to compute the leader for the even round {current_round}"));
+                        error!("{}", &flatten_error(err));
                         return false;
                     }
                 };
@@ -414,8 +425,11 @@ impl<N: Network> BFT<N> {
         // Retrieve the committee lookback for the current round.
         let committee_lookback = match self.ledger().get_committee_lookback_for_round(current_round) {
             Ok(committee) => committee,
-            Err(e) => {
-                error!("BFT failed to retrieve the committee lookback for the odd round {current_round} - {e}");
+            Err(err) => {
+                let err = err.context(format!(
+                    "BFT failed to retrieve the committee lookback for the odd round {current_round}"
+                ));
+                error!("{}", &flatten_error(err));
                 return false;
             }
         };
@@ -423,7 +437,7 @@ impl<N: Network> BFT<N> {
         let authors = current_certificates.clone().into_iter().map(|c| c.author()).collect();
         // Check if quorum threshold is reached.
         if !committee_lookback.is_quorum_threshold_reached(&authors) {
-            trace!("BFT failed reach quorum threshold in odd round {current_round}. ");
+            trace!("BFT failed reach quorum threshold in odd round {current_round}.");
             return false;
         }
         // Retrieve the leader certificate.
@@ -584,23 +598,19 @@ impl<N: Network> BFT<N> {
             for round in (self.dag.read().last_committed_round() + 2..=leader_round.saturating_sub(2)).rev().step_by(2)
             {
                 // Retrieve the previous committee for the leader round.
-                let previous_committee_lookback = match self.ledger().get_committee_lookback_for_round(round) {
-                    Ok(committee) => committee,
-                    Err(e) => {
-                        bail!("BFT failed to retrieve a previous committee lookback for the even round {round} - {e}");
-                    }
-                };
+                let previous_committee_lookback =
+                    self.ledger().get_committee_lookback_for_round(round).with_context(|| {
+                        format!("BFT failed to retrieve a previous committee lookback for the even round {round}")
+                    })?;
+
                 // Either retrieve the cached leader or compute it.
                 let leader = match self.ledger().latest_leader() {
                     Some((cached_round, cached_leader)) if cached_round == round => cached_leader,
                     _ => {
                         // Compute the leader for the commit round.
-                        let computed_leader = match previous_committee_lookback.get_leader(round) {
-                            Ok(leader) => leader,
-                            Err(e) => {
-                                bail!("BFT failed to compute the leader for the even round {round} - {e}");
-                            }
-                        };
+                        let computed_leader = previous_committee_lookback
+                            .get_leader(round)
+                            .with_context(|| format!("BFT failed to compute the leader for the even round {round}"))?;
 
                         // Cache the computed leader.
                         self.ledger().update_latest_leader(round, computed_leader);
@@ -721,12 +731,16 @@ impl<N: Network> BFT<N> {
                     // Await the callback to continue.
                     match callback_receiver.await {
                         Ok(Ok(())) => (), // continue
-                        Ok(Err(e)) => {
-                            error!("BFT failed to advance the subdag for round {anchor_round} - {e}");
+                        Ok(Err(err)) => {
+                            let err = err.context(format!("BFT failed to advance the subdag for round {anchor_round}"));
+                            error!("{}", &flatten_error(err));
                             return Ok(());
                         }
-                        Err(e) => {
-                            error!("BFT failed to receive the callback for round {anchor_round} - {e}");
+                        Err(err) => {
+                            let err: anyhow::Error = err.into();
+                            let err =
+                                err.context(format!("BFT failed to receive the callback for round {anchor_round}"));
+                            error!("{}", flatten_error(err));
                             return Ok(());
                         }
                     }

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -33,7 +33,7 @@ use snarkvm::{
     },
     ledger::{authority::Authority, block::Block, narwhal::BatchCertificate},
     prelude::{cfg_into_iter, cfg_iter},
-    utilities::log_error,
+    utilities::flatten_error,
 };
 
 use anyhow::{Result, anyhow, bail};
@@ -318,7 +318,7 @@ impl<N: Network> Sync<N> {
             Ok(None) => {}
             Err(err) => {
                 // Abort and retry later.
-                log_error(&err);
+                error!("{}", &flatten_error(err));
                 return;
             }
         }

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -44,7 +44,7 @@ use snarkvm::{
         store::ConsensusStorage,
     },
     prelude::{VM, block::Transaction},
-    utilities::log_error,
+    utilities::flatten_error,
 };
 
 use aleo_std::StorageMode;
@@ -328,7 +328,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
             Ok(None) => {}
             Err(err) => {
                 // Abort and retry later.
-                log_error(&err);
+                error!("{}", flatten_error(&err));
                 return;
             }
         }

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -34,7 +34,7 @@ use snarkos_node_tcp::{Connection, ConnectionSide, Tcp};
 use snarkvm::{
     console::network::{ConsensusVersion, Network},
     ledger::{block::Transaction, narwhal::Data},
-    utilities::{log_error, log_warning},
+    utilities::flatten_error,
 };
 
 use std::{io, net::SocketAddr};
@@ -184,7 +184,8 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Client<N, C> {
         let latest_consensus_version = match N::CONSENSUS_VERSION(end_height.saturating_sub(1)) {
             Ok(version) => version,
             Err(err) => {
-                log_error(err.context("Failed to retrieve consensus version"));
+                let err = err.context("Failed to retrieve consensus version");
+                error!("{}", flatten_error(&err));
                 return false;
             }
         };
@@ -193,7 +194,9 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Client<N, C> {
         let blocks = match self.ledger.get_blocks(*start_height..*end_height) {
             Ok(blocks) => DataBlocks(blocks),
             Err(error) => {
-                error!("Failed to retrieve blocks {start_height} to {end_height} from the ledger - {error}");
+                let err =
+                    error.context(format!("Failed to retrieve blocks {start_height} to {end_height} from the ledger"));
+                error!("{}", flatten_error(&err));
                 return false;
             }
         };
@@ -213,7 +216,7 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Client<N, C> {
     ) -> bool {
         // We do not need to explicitly sync here because insert_block_response, will wake up the sync task.
         if let Err(err) = self.sync.insert_block_responses(peer_ip, blocks, latest_consensus_version) {
-            log_warning(err.context("Failed to insert block response"));
+            warn!("{}", flatten_error(err.context("Failed to insert block response")));
             false
         } else {
             true
@@ -225,8 +228,8 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Client<N, C> {
         // If block locators were provided, then update the peer in the sync pool.
         if let Some(block_locators) = message.block_locators {
             // Check the block locators are valid, and update the peer in the sync pool.
-            if let Err(error) = self.sync.update_peer_locators(peer_ip, &block_locators) {
-                warn!("Peer '{peer_ip}' sent invalid block locators: {error}");
+            if let Err(err) = self.sync.update_peer_locators(peer_ip, &block_locators) {
+                warn!("{}", flatten_error(err.context(format!("Peer '{peer_ip}' sent invalid block locators"))));
                 return false;
             }
 
@@ -250,8 +253,9 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Client<N, C> {
         // Retrieve the latest epoch hash.
         let epoch_hash = match self.ledger.latest_epoch_hash() {
             Ok(epoch_hash) => epoch_hash,
-            Err(error) => {
-                error!("Failed to prepare a puzzle request for '{peer_ip}': {error}");
+            Err(err) => {
+                let err = err.context(format!("Failed to prepare a puzzle request for '{peer_ip}'"));
+                error!("{}", flatten_error(err));
                 return false;
             }
         };

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -30,7 +30,7 @@ use snarkos_node_tcp::{Connection, ConnectionSide, Tcp};
 use snarkvm::{
     console::network::{ConsensusVersion, Network},
     ledger::{block::Transaction, narwhal::Data},
-    utilities::{error, log_error},
+    utilities::{flatten_error, io_error},
 };
 
 use std::{io, net::SocketAddr};
@@ -50,7 +50,7 @@ impl<N: Network, C: ConsensusStorage<N>> Handshake for Validator<N, C> {
         let peer_addr = connection.addr();
         let conn_side = connection.side();
         let stream = self.borrow_stream(&mut connection);
-        let genesis_header = self.ledger.get_header(0).map_err(|e| error(format!("{e}")))?;
+        let genesis_header = self.ledger.get_header(0).map_err(io_error)?;
         let restrictions_id = self.ledger.vm().restrictions().restrictions_id();
         self.router.handshake(peer_addr, stream, conn_side, genesis_header, restrictions_id).await?;
 
@@ -180,7 +180,7 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Validator<N, C> {
         let latest_consensus_version = match N::CONSENSUS_VERSION(end_height.saturating_sub(1)) {
             Ok(version) => version,
             Err(err) => {
-                log_error(err.context("Failed to retrieve consensus version"));
+                error!("{}", flatten_error(err.context("Failed to retrieve consensus version")));
                 return false;
             }
         };
@@ -188,8 +188,10 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Validator<N, C> {
         // Retrieve the blocks within the requested range.
         let blocks = match self.ledger.get_blocks(*start_height..*end_height) {
             Ok(blocks) => DataBlocks(blocks),
-            Err(error) => {
-                error!("Failed to retrieve blocks {start_height} to {end_height} from the ledger - {error}");
+            Err(err) => {
+                let err =
+                    err.context(format!("Failed to retrieve blocks {start_height} to {end_height} from the ledger"));
+                error!("{}", flatten_error(err));
                 return false;
             }
         };


### PR DESCRIPTION
This PR is a replacement for #3978. It updates the logging code in `bft.rs` to show more detailed error messages.

Additionally, the PR updates the snarkVM dependency to the most recent commit and adjusts some of the logging code due to the changes in https://github.com/ProvableHQ/snarkVM/pull/3007. 