### PR TITLE
[Fix] Make repo sha in handshake backwards compatible

### DIFF
--- a/node/bft/events/src/challenge_request.rs
+++ b/node/bft/events/src/challenge_request.rs
@@ -15,27 +15,19 @@
 
 use super::*;
 
-use snarkos_node_network::built_info;
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ChallengeRequest<N: Network> {
     pub version: u32,
     pub listener_port: u16,
     pub address: Address<N>,
     pub nonce: u64,
-    pub snarkos_sha: String,
+    pub snarkos_sha: Option<String>,
 }
 
 impl<N: Network> ChallengeRequest<N> {
     /// Creates a new `ChallengeRequest` event.
-    pub fn new(listener_port: u16, address: Address<N>, nonce: u64) -> Self {
-        Self {
-            version: Event::<N>::VERSION,
-            listener_port,
-            address,
-            nonce,
-            snarkos_sha: built_info::GIT_COMMIT_HASH.unwrap_or_default().into(),
-        }
+    pub fn new(listener_port: u16, address: Address<N>, nonce: u64, snarkos_sha: Option<String>) -> Self {
+        Self { version: Event::<N>::VERSION, listener_port, address, nonce, snarkos_sha }
     }
 }
 
@@ -53,7 +45,10 @@ impl<N: Network> ToBytes for ChallengeRequest<N> {
         self.listener_port.write_le(&mut writer)?;
         self.address.write_le(&mut writer)?;
         self.nonce.write_le(&mut writer)?;
-        self.snarkos_sha.as_bytes().write_le(&mut writer)?;
+
+        if let Some(snarkos_sha) = &self.snarkos_sha {
+            snarkos_sha.as_bytes().write_le(&mut writer)?;
+        }
 
         Ok(())
     }
@@ -70,7 +65,7 @@ impl<N: Network> FromBytes for ChallengeRequest<N> {
             .map_err(|_| error("Invalid snarkOS SHA"))?
             .to_owned();
 
-        Ok(Self { version, listener_port, address, nonce, snarkos_sha })
+        Ok(Self { version, listener_port, address, nonce, snarkos_sha: Some(snarkos_sha) })
     }
 }
 
@@ -102,7 +97,7 @@ pub mod prop_tests {
                 nonce,
                 version,
                 listener_port,
-                snarkos_sha: sha.into_iter().map(|b| b as char).collect(),
+                snarkos_sha: Some(sha.into_iter().map(|b| b as char).collect()),
             })
             .boxed()
     }
@@ -115,7 +110,7 @@ pub mod prop_tests {
         let mut deserialized: ChallengeRequest<CurrentNetwork> =
             ChallengeRequest::read_le(buf.into_inner().reader()).unwrap();
         // Upon deserialization, unsupplied SHA is registered as "unknown".
-        if deserialized.snarkos_sha == "unknown" {
+        if deserialized.snarkos_sha.as_ref().unwrap() == "unknown" {
             deserialized.snarkos_sha = original.snarkos_sha.clone();
         }
         assert_eq!(original, deserialized);

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -50,6 +50,7 @@ use snarkos_node_network::{
     PeerPoolHandling,
     Resolver,
     bootstrap_peers,
+    built_info,
     log_repo_sha_comparison,
 };
 use snarkos_node_sync::{MAX_BLOCKS_BEHIND, communication_service::CommunicationService};
@@ -1412,8 +1413,14 @@ impl<N: Network> Gateway<N> {
 
         // Sample a random nonce.
         let our_nonce = rng.r#gen();
+        // Determine the snarkOS SHA to send to the peer.
+        let current_block_height = self.ledger.latest_block_height();
+        let consensus_version = N::CONSENSUS_VERSION(current_block_height).unwrap();
+        let snarkos_sha = (consensus_version >= ConsensusVersion::V12)
+            .then(|| built_info::GIT_COMMIT_HASH.unwrap_or_default().into());
         // Send a challenge request to the peer.
-        let our_request = ChallengeRequest::new(self.local_ip().port(), self.account.address(), our_nonce);
+        let our_request =
+            ChallengeRequest::new(self.local_ip().port(), self.account.address(), our_nonce, snarkos_sha.clone());
         send_event(&mut framed, peer_addr, Event::ChallengeRequest(our_request)).await?;
 
         /* Step 2: Receive the peer's challenge response followed by the challenge request. */
@@ -1522,8 +1529,13 @@ impl<N: Network> Gateway<N> {
 
         // Sample a random nonce.
         let our_nonce = rng.r#gen();
+        // Determine the snarkOS SHA to send to the peer.
+        let current_block_height = self.ledger.latest_block_height();
+        let consensus_version = N::CONSENSUS_VERSION(current_block_height).unwrap();
+        let snarkos_sha = (consensus_version >= ConsensusVersion::V12)
+            .then(|| built_info::GIT_COMMIT_HASH.unwrap_or_default().into());
         // Send the challenge request.
-        let our_request = ChallengeRequest::new(self.local_ip().port(), self.account.address(), our_nonce);
+        let our_request = ChallengeRequest::new(self.local_ip().port(), self.account.address(), our_nonce, snarkos_sha);
         send_event(&mut framed, peer_addr, Event::ChallengeRequest(our_request)).await?;
 
         /* Step 3: Receive the challenge response. */
@@ -1546,7 +1558,7 @@ impl<N: Network> Gateway<N> {
     fn verify_challenge_request(&self, peer_addr: SocketAddr, event: &ChallengeRequest<N>) -> Option<DisconnectReason> {
         // Retrieve the components of the challenge request.
         let &ChallengeRequest { version, listener_port, address, nonce: _, ref snarkos_sha } = event;
-        log_repo_sha_comparison(peer_addr, snarkos_sha, CONTEXT);
+        log_repo_sha_comparison(peer_addr, snarkos_sha.as_ref(), CONTEXT);
 
         let listener_addr = SocketAddr::new(peer_addr.ip(), listener_port);
 

--- a/node/bft/tests/gateway_e2e.rs
+++ b/node/bft/tests/gateway_e2e.rs
@@ -107,7 +107,7 @@ async fn handshake_responder_side_invalid_challenge_request() {
     let listener_port = test_peer.listening_addr().port();
     let address = accounts.get(1).unwrap().address();
     let nonce = rng.r#gen();
-    let snarkos_sha = String::new();
+    let snarkos_sha = None;
     // Set the wrong version so the challenge request is invalid.
     let challenge_request = ChallengeRequest { version: 0, listener_port, address, nonce, snarkos_sha };
 
@@ -147,7 +147,7 @@ async fn handshake_responder_side_invalid_challenge_response() {
     let listener_port = test_peer.listening_addr().port();
     let address = accounts.get(1).unwrap().address();
     let our_nonce = rng.r#gen();
-    let snarkos_sha = String::new();
+    let snarkos_sha = None;
     let version = Event::<CurrentNetwork>::VERSION;
     let challenge_request = ChallengeRequest { version, listener_port, address, nonce: our_nonce, snarkos_sha };
 

--- a/node/network/src/lib.rs
+++ b/node/network/src/lib.rs
@@ -80,9 +80,11 @@ pub fn bootstrap_peers<N: Network>(is_dev: bool) -> Vec<SocketAddr> {
 }
 
 /// Logs the peer's snarkOS repo SHA and how it compares to ours.
-pub fn log_repo_sha_comparison(peer_addr: SocketAddr, peer_sha: &str, ctx: &str) {
+pub fn log_repo_sha_comparison(peer_addr: SocketAddr, peer_sha: Option<&String>, ctx: &str) {
     let our_sha = built_info::GIT_COMMIT_HASH.unwrap_or_default();
-    let sha_cmp = if peer_sha == "unknown" {
+    let unknown_sha = "unknown".to_owned();
+    let peer_sha = peer_sha.unwrap_or(&unknown_sha);
+    let sha_cmp = if peer_sha == &unknown_sha {
         " with an unknown repo SHA".to_owned()
     } else if peer_sha == our_sha {
         format!("@{peer_sha} (same as us)")

--- a/node/router/messages/src/challenge_request.rs
+++ b/node/router/messages/src/challenge_request.rs
@@ -15,7 +15,7 @@
 
 use super::*;
 
-use snarkos_node_network::{NodeType, built_info};
+use snarkos_node_network::NodeType;
 use snarkvm::prelude::{FromBytes, ToBytes};
 
 use std::borrow::Cow;
@@ -27,7 +27,7 @@ pub struct ChallengeRequest<N: Network> {
     pub node_type: NodeType,
     pub address: Address<N>,
     pub nonce: u64,
-    pub snarkos_sha: String,
+    pub snarkos_sha: Option<String>,
 }
 
 impl<N: Network> MessageTrait for ChallengeRequest<N> {
@@ -45,7 +45,10 @@ impl<N: Network> ToBytes for ChallengeRequest<N> {
         self.node_type.write_le(&mut writer)?;
         self.address.write_le(&mut writer)?;
         self.nonce.write_le(&mut writer)?;
-        self.snarkos_sha.as_bytes().write_le(&mut writer)?;
+
+        if let Some(snarkos_sha) = &self.snarkos_sha {
+            snarkos_sha.as_bytes().write_le(&mut writer)?;
+        }
 
         Ok(())
     }
@@ -63,20 +66,19 @@ impl<N: Network> FromBytes for ChallengeRequest<N> {
             .map_err(|_| error("Invalid snarkOS SHA"))?
             .to_owned();
 
-        Ok(Self { version, listener_port, node_type, address, nonce, snarkos_sha })
+        Ok(Self { version, listener_port, node_type, address, nonce, snarkos_sha: Some(snarkos_sha) })
     }
 }
 
 impl<N: Network> ChallengeRequest<N> {
-    pub fn new(listener_port: u16, node_type: NodeType, address: Address<N>, nonce: u64) -> Self {
-        Self {
-            version: Message::<N>::latest_message_version(),
-            listener_port,
-            node_type,
-            address,
-            nonce,
-            snarkos_sha: built_info::GIT_COMMIT_HASH.unwrap_or_default().into(),
-        }
+    pub fn new(
+        listener_port: u16,
+        node_type: NodeType,
+        address: Address<N>,
+        nonce: u64,
+        snarkos_sha: Option<String>,
+    ) -> Self {
+        Self { version: Message::<N>::latest_message_version(), listener_port, node_type, address, nonce, snarkos_sha }
     }
 }
 
@@ -121,7 +123,7 @@ pub mod prop_tests {
                 version,
                 listener_port,
                 node_type,
-                snarkos_sha: sha.into_iter().map(|b| b as char).collect(),
+                snarkos_sha: Some(sha.into_iter().map(|b| b as char).collect()),
             })
             .boxed()
     }
@@ -134,7 +136,7 @@ pub mod prop_tests {
         let mut deserialized: ChallengeRequest<CurrentNetwork> =
             ChallengeRequest::read_le(buf.into_inner().reader()).unwrap();
         // Upon deserialization, unsupplied SHA is registered as "unknown".
-        if deserialized.snarkos_sha == "unknown" {
+        if deserialized.snarkos_sha.as_ref().unwrap() == "unknown" {
             deserialized.snarkos_sha = original.snarkos_sha.clone();
         }
         assert_eq!(original, deserialized);

--- a/node/router/src/handshake.rs
+++ b/node/router/src/handshake.rs
@@ -20,11 +20,11 @@ use crate::{
     Router,
     messages::{ChallengeRequest, ChallengeResponse, DisconnectReason, Message, MessageCodec, MessageTrait},
 };
-use snarkos_node_network::log_repo_sha_comparison;
+use snarkos_node_network::{built_info, log_repo_sha_comparison};
 use snarkos_node_tcp::{ConnectionSide, P2P, Tcp};
 use snarkvm::{
     ledger::narwhal::Data,
-    prelude::{Address, Field, Network, block::Header, error},
+    prelude::{Address, ConsensusVersion, Field, Network, block::Header, error},
 };
 
 use anyhow::{Result, bail};
@@ -188,12 +188,19 @@ impl<N: Network> Router<N> {
         // Initialize an RNG.
         let rng = &mut OsRng;
 
+        // Determine the snarkOS SHA to send to the peer.
+        let current_block_height = self.ledger.latest_block_height();
+        let consensus_version = N::CONSENSUS_VERSION(current_block_height).unwrap();
+        let snarkos_sha = (consensus_version >= ConsensusVersion::V12)
+            .then(|| built_info::GIT_COMMIT_HASH.unwrap_or_default().into());
+
         /* Step 1: Send the challenge request. */
 
         // Sample a random nonce.
         let our_nonce = rng.r#gen();
         // Send a challenge request to the peer.
-        let our_request = ChallengeRequest::new(self.local_ip().port(), self.node_type, self.address(), our_nonce);
+        let our_request =
+            ChallengeRequest::new(self.local_ip().port(), self.node_type, self.address(), our_nonce, snarkos_sha);
         send(&mut framed, peer_addr, Message::ChallengeRequest(our_request)).await?;
 
         /* Step 2: Receive the peer's challenge response followed by the challenge request. */
@@ -262,6 +269,12 @@ impl<N: Network> Router<N> {
         // Listen for the challenge request message.
         let peer_request = expect_message!(Message::ChallengeRequest, framed, peer_addr);
 
+        // Determine the snarkOS SHA to send to the peer.
+        let current_block_height = self.ledger.latest_block_height();
+        let consensus_version = N::CONSENSUS_VERSION(current_block_height).unwrap();
+        let snarkos_sha = (consensus_version >= ConsensusVersion::V12)
+            .then(|| built_info::GIT_COMMIT_HASH.unwrap_or_default().into());
+
         // Obtain the peer's listening address.
         *listener_addr = Some(SocketAddr::new(peer_addr.ip(), peer_request.listener_port));
         let listener_addr = listener_addr.unwrap();
@@ -306,7 +319,8 @@ impl<N: Network> Router<N> {
         // Sample a random nonce.
         let our_nonce = rng.r#gen();
         // Send the challenge request.
-        let our_request = ChallengeRequest::new(self.local_ip().port(), self.node_type, self.address(), our_nonce);
+        let our_request =
+            ChallengeRequest::new(self.local_ip().port(), self.node_type, self.address(), our_nonce, snarkos_sha);
         send(&mut framed, peer_addr, Message::ChallengeRequest(our_request)).await?;
 
         /* Step 3: Receive the challenge response. */
@@ -354,7 +368,7 @@ impl<N: Network> Router<N> {
     ) -> Option<DisconnectReason> {
         // Retrieve the components of the challenge request.
         let &ChallengeRequest { version, listener_port: _, node_type, address, nonce: _, ref snarkos_sha } = message;
-        log_repo_sha_comparison(peer_addr, snarkos_sha, Self::OWNER);
+        log_repo_sha_comparison(peer_addr, snarkos_sha.as_ref(), Self::OWNER);
 
         // Ensure the message protocol version is not outdated.
         if !self.is_valid_message_version(version) {

--- a/node/src/bootstrap_client/handshake.rs
+++ b/node/src/bootstrap_client/handshake.rs
@@ -234,6 +234,8 @@ impl<N: Network> BootstrapClient<N> {
 
         // Sample a random nonce.
         let our_nonce: u64 = rng.r#gen();
+        // Do not send a snarkOS SHA as the bootstrap client is not aware of height.
+        let snarkos_sha = None;
         // Send the challenge request.
         if connection_mode == ConnectionMode::Router {
             let our_request = messages::ChallengeRequest::new(
@@ -241,11 +243,13 @@ impl<N: Network> BootstrapClient<N> {
                 NodeType::BootstrapClient,
                 self.account.address(),
                 our_nonce,
+                snarkos_sha,
             );
             let msg = Message::ChallengeRequest(our_request);
             send_msg!(msg, framed, peer_addr)?;
         } else {
-            let our_request = events::ChallengeRequest::new(self.local_ip().port(), self.account.address(), our_nonce);
+            let our_request =
+                events::ChallengeRequest::new(self.local_ip().port(), self.account.address(), our_nonce, snarkos_sha);
             let msg = Event::ChallengeRequest(our_request);
             send_msg!(msg, framed, peer_addr)?;
         }
@@ -277,7 +281,7 @@ impl<N: Network> BootstrapClient<N> {
     ) -> io::Result<bool> {
         match request {
             MessageOrEvent::Message(Message::ChallengeRequest(msg)) => {
-                log_repo_sha_comparison(peer_addr, &msg.snarkos_sha, Self::OWNER);
+                log_repo_sha_comparison(peer_addr, msg.snarkos_sha.as_ref(), Self::OWNER);
 
                 if msg.version < Message::<N>::latest_message_version() {
                     let msg = Message::Disconnect::<N>(messages::DisconnectReason::OutdatedClientVersion.into());
@@ -299,7 +303,7 @@ impl<N: Network> BootstrapClient<N> {
                 }
             }
             MessageOrEvent::Event(Event::ChallengeRequest(msg)) => {
-                log_repo_sha_comparison(peer_addr, &msg.snarkos_sha, Self::OWNER);
+                log_repo_sha_comparison(peer_addr, msg.snarkos_sha.as_ref(), Self::OWNER);
 
                 if msg.version < Event::<N>::VERSION {
                     let msg = Event::Disconnect::<N>(events::DisconnectReason::OutdatedClientVersion.into());

--- a/node/tests/common/test_peer.rs
+++ b/node/tests/common/test_peer.rs
@@ -138,7 +138,8 @@ impl Handshake for TestPeer {
         match node_side {
             ConnectionSide::Initiator => {
                 // Send a challenge request to the peer.
-                let our_request = ChallengeRequest::new(local_ip.port(), self.node_type(), self.address(), rng.r#gen());
+                let our_request =
+                    ChallengeRequest::new(local_ip.port(), self.node_type(), self.address(), rng.r#gen(), None);
                 framed.send(Message::ChallengeRequest(our_request)).await?;
 
                 // Receive the peer's challenge bundle.
@@ -176,7 +177,8 @@ impl Handshake for TestPeer {
                     nonce: response_nonce,
                 };
                 framed.send(Message::ChallengeResponse(our_response)).await?;
-                let our_request = ChallengeRequest::new(local_ip.port(), self.node_type(), self.address(), rng.r#gen());
+                let our_request =
+                    ChallengeRequest::new(local_ip.port(), self.node_type(), self.address(), rng.r#gen(), None);
                 framed.send(Message::ChallengeRequest(our_request)).await?;
 
                 // Listen for the challenge response.


### PR DESCRIPTION
## Motivation

Fixes an issue introduced in https://github.com/ProvableHQ/snarkOS/pull/3971
While upgraded nodes accept handshakes from old nodes without SHA, old nodes won't accept handshakes from new nodes.

## Test Plan

- [x] Run proper `update_validators_and_clients_one_by_one` E2E test
