### PR TITLE
Document optional CUDA install path and caveats for provers

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ cargo install --locked --path .
 
 #### Optional: CUDA Acceleration for Provers
 
-> **Heads-up:** This CUDA build is optional. The current snarkOS puzzle does not leverage CUDA acceleration—it is a leftover from a previous event, although CUDA may become relevant again with ARC-43.
+> This CUDA build is optional. The current snarkOS puzzle does not leverage CUDA acceleration—it is a leftover from a previous event, although CUDA may become relevant again with ARC-43.
+>
+> The CUDA feature is considered unstable and experimental; expect breaking changes.
 
 For prover operators who want to experiment with GPU support:
 ```

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ Lastly, install `snarkOS`:
 ```
 cargo install --locked --path .
 ```
+If you are running a prover and want to experiment with the optional CUDA feature, you can install with:
+```
+cargo install --locked --path . --features cuda
+```
+This CUDA build is not required for most users, and the current snarkOS puzzle does not leverage CUDA acceleration (the puzzle is a leftover from a previous event, though CUDA may become relevant again in the future because of ARC-43).
 
 Please ensure ports `4130/tcp` and `3030/tcp` are open on your router and OS firewall.
 ### 2.4 Port Configuration

--- a/README.md
+++ b/README.md
@@ -94,11 +94,15 @@ Lastly, install `snarkOS`:
 ```
 cargo install --locked --path .
 ```
-If you are running a prover and want to experiment with the optional CUDA feature, you can install with:
+
+#### Optional: CUDA Acceleration for Provers
+
+> **Heads-up:** This CUDA build is optional. The current snarkOS puzzle does not leverage CUDA acceleration—it is a leftover from a previous event, although CUDA may become relevant again with ARC-43.
+
+For prover operators who want to experiment with GPU support:
 ```
 cargo install --locked --path . --features cuda
 ```
-This CUDA build is not required for most users, and the current snarkOS puzzle does not leverage CUDA acceleration (the puzzle is a leftover from a previous event, though CUDA may become relevant again in the future because of ARC-43).
 
 Please ensure ports `4130/tcp` and `3030/tcp` are open on your router and OS firewall.
 ### 2.4 Port Configuration
@@ -460,7 +464,7 @@ By default, the metrics feature is turned on for some internal crates.
 * **telemetry** -
   Allows the node to upload telemetry data.
 * **cuda** -
-  Allows some operations to run on the (NVidia) GPU, instead of on the CPU. See above under [Enable CUDA acceleration](#cuda)
+  Allows some operations to run on the (NVidia) GPU, instead of on the CPU. See [CUDA acceleration for provers](#optional-cuda-acceleration-for-provers) for install tips and current puzzle status.
 * **locktick** -
   This feature turns on code for detecting deadlocks.
 * **test_targets** -


### PR DESCRIPTION
Motivation
Improve the README guidance for prover operators by documenting the optional CUDA installation command, clarifying that the current puzzle does not benefit from CUDA, and noting the feature’s experimental/unstable status. This should help prevent confusion for users poking at GPU acceleration.

Test Plan
Docs-only changes – no code to execute.

Documentation
Updated README.md directly; no other docs need changes.

Backwards compatibility
Not applicable – documentation-only update with no impact on consensus or runtime behavior.
