### PR TITLE
[Fix] Explicitely pause sync while committing leader certificate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -231,7 +231,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -242,7 +242,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -267,7 +267,7 @@ dependencies = [
  "axum-core 0.4.5",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
@@ -294,7 +294,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
@@ -326,7 +326,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -345,7 +345,7 @@ checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -367,7 +367,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "headers",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -453,7 +453,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -587,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.46"
+version = "1.2.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97463e1064cb1b1c1384ad0a0b9c8abd0988e2a91f52606c80ef14aadb63e36"
+checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -681,7 +681,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1024,7 +1024,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1058,7 +1058,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "strsim",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1072,7 +1072,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "strsim",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1083,7 +1083,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1094,7 +1094,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1149,7 +1149,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "structmeta 0.3.0",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1160,7 +1160,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1181,7 +1181,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1224,7 +1224,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1348,7 +1348,7 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1368,10 +1368,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
+]
 
 [[package]]
 name = "envmnt"
@@ -1558,7 +1579,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1723,7 +1744,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
+ "http 1.4.0",
  "indexmap 2.12.1",
  "slab",
  "tokio",
@@ -1790,7 +1811,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "headers-core",
- "http 1.3.1",
+ "http 1.4.0",
  "httpdate",
  "mime",
  "sha1",
@@ -1802,7 +1823,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.3.1",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1854,12 +1875,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1881,7 +1901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1892,7 +1912,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1955,7 +1975,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -1973,7 +1993,7 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.3.1",
+ "http 1.4.0",
  "hyper 1.8.1",
  "hyper-util",
  "rustls",
@@ -2037,7 +2057,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "hyper 1.8.1",
  "ipnet",
@@ -2240,7 +2260,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2667,7 +2687,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2767,7 +2787,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2863,7 +2883,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2984,7 +3004,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3078,7 +3098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3130,7 +3150,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3413,7 +3433,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3473,7 +3493,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
@@ -3841,7 +3861,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3918,7 +3938,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3981,9 +4001,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
 dependencies = [
  "libc",
 ]
@@ -4151,7 +4171,7 @@ dependencies = [
  "colored 3.0.0",
  "deadline",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "indexmap 2.12.1",
  "locktick",
  "lru 0.16.2",
@@ -4222,6 +4242,7 @@ dependencies = [
  "snarkos-node-sync",
  "snarkos-node-tcp",
  "snarkvm",
+ "test-log",
  "test-strategy 0.4.3",
  "time",
  "tokio",
@@ -4289,7 +4310,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "colored 3.0.0",
- "http 1.3.1",
+ "http 1.4.0",
  "locktick",
  "parking_lot",
  "rayon",
@@ -4366,7 +4387,7 @@ dependencies = [
  "axum-extra",
  "base64 0.22.1",
  "built",
- "http 1.3.1",
+ "http 1.4.0",
  "indexmap 2.12.1",
  "jsonwebtoken",
  "locktick",
@@ -5407,7 +5428,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pen
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5486,7 +5507,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "structmeta-derive 0.2.0",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5498,7 +5519,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "structmeta-derive 0.3.0",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5509,7 +5530,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5520,7 +5541,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5542,7 +5563,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "rustversion",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5575,9 +5596,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
@@ -5610,7 +5631,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5664,6 +5685,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "test-log"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e33b98a582ea0be1168eba097538ee8dd4bbe0f2b01b22ac92ea30054e5be7b"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451b374529930d7601b1eef8d32bc79ae870b6079b069401709c2a8bf9e75f36"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.42",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "test-strategy"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5672,7 +5715,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "structmeta 0.2.0",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5685,7 +5728,7 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "structmeta 0.3.0",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5714,7 +5757,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5725,7 +5768,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5857,7 +5900,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5977,7 +6020,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
@@ -6033,15 +6076,15 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "http-range-header",
@@ -6080,7 +6123,7 @@ dependencies = [
  "axum 0.8.7",
  "forwarded-header-value",
  "governor",
- "http 1.3.1",
+ "http 1.4.0",
  "pin-project",
  "thiserror 2.0.17",
  "tower 0.5.2",
@@ -6107,7 +6150,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6167,7 +6210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6273,12 +6316,12 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b4531c118335662134346048ddb0e54cc86bd7e81866757873055f0e38f5d2"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
  "base64 0.22.1",
- "http 1.3.1",
+ "http 1.4.0",
  "httparse",
  "log",
 ]
@@ -6425,7 +6468,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
@@ -6542,7 +6585,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6553,7 +6596,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6799,28 +6842,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.28"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fa6694ed34d6e57407afbccdeecfa268c470a7d2a5b0cf49ce9fcc345afb90"
+checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.28"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c640b22cd9817fae95be82f0d2f90b11f7605f6c319d16705c459b27ac2cbc26"
+checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6840,7 +6883,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -6861,7 +6904,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6894,7 +6937,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.52"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8120877db0e5c011242f96806ce3c94e0737ab8108532a76a3300a01db2ab8"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -662,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.52"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02576b399397b659c26064fbc92a75fede9d18ffd5f80ca1cd74ddab167016e1"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -822,7 +822,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "log",
  "serde",
  "serde_derive",
@@ -1724,7 +1724,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1759,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2197,12 +2197,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "rayon",
  "serde",
  "serde_core",
@@ -2510,7 +2510,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
 dependencies = [
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2575,7 +2575,7 @@ dependencies = [
  "base64 0.21.7",
  "hyper 0.14.32",
  "hyper-tls 0.5.0",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "ipnet",
  "metrics",
  "metrics-util",
@@ -3850,7 +3850,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itoa",
  "memchr",
  "ryu",
@@ -3900,7 +3900,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "schemars 0.9.0",
  "schemars 1.1.0",
  "serde_core",
@@ -4098,7 +4098,7 @@ dependencies = [
  "colored 3.0.0",
  "console-subscriber",
  "crossterm 0.29.0",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "nix",
  "num_cpus",
@@ -4152,7 +4152,7 @@ dependencies = [
  "deadline",
  "futures-util",
  "http 1.3.1",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "lru 0.16.2",
  "num_cpus",
@@ -4197,7 +4197,7 @@ dependencies = [
  "colored 3.0.0",
  "deadline",
  "futures",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itertools 0.14.0",
  "locktick",
  "lru 0.16.2",
@@ -4239,7 +4239,7 @@ version = "4.3.0"
 dependencies = [
  "anyhow",
  "bytes",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "proptest",
  "serde",
  "snarkos-node-network",
@@ -4257,7 +4257,7 @@ version = "4.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "parking_lot",
  "rand 0.8.5",
@@ -4274,7 +4274,7 @@ version = "4.3.0"
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "lru 0.16.2",
  "parking_lot",
@@ -4310,7 +4310,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "colored 3.0.0",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itertools 0.14.0",
  "locktick",
  "lru 0.16.2",
@@ -4367,7 +4367,7 @@ dependencies = [
  "base64 0.22.1",
  "built",
  "http 1.3.1",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "jsonwebtoken",
  "locktick",
  "once_cell",
@@ -4448,7 +4448,7 @@ version = "4.3.0"
 dependencies = [
  "anyhow",
  "futures",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itertools 0.14.0",
  "locktick",
  "parking_lot",
@@ -4480,7 +4480,7 @@ name = "snarkos-node-sync-locators"
 version = "4.3.0"
 dependencies = [
  "anyhow",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "serde",
  "snarkvm",
  "tracing",
@@ -4506,7 +4506,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -4529,7 +4529,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4538,7 +4538,7 @@ dependencies = [
  "fxhash",
  "hashbrown 0.15.5",
  "hex",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itertools 0.14.0",
  "num-traits",
  "rand 0.8.5",
@@ -4557,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "blst",
  "cc",
@@ -4568,7 +4568,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4582,7 +4582,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4592,7 +4592,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4602,7 +4602,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4612,9 +4612,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itertools 0.14.0",
  "nom",
  "num-traits",
@@ -4630,12 +4630,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4646,7 +4646,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4660,7 +4660,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4675,7 +4675,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4688,7 +4688,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4697,7 +4697,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4707,7 +4707,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4719,7 +4719,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4731,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4742,7 +4742,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4754,7 +4754,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4767,7 +4767,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4778,7 +4778,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -4793,7 +4793,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4804,11 +4804,11 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "anyhow",
  "enum-iterator",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "lazy_static",
  "paste",
  "serde",
@@ -4824,7 +4824,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4842,12 +4842,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "enum-iterator",
  "enum_index",
  "enum_index_derive",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "num-derive",
  "num-traits",
  "seq-macro",
@@ -4863,7 +4863,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4878,7 +4878,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4889,7 +4889,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4897,7 +4897,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4907,7 +4907,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4918,7 +4918,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4929,7 +4929,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4940,7 +4940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4951,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -4965,7 +4965,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4982,11 +4982,11 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "lru 0.16.2",
  "parking_lot",
@@ -5012,7 +5012,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -5024,10 +5024,10 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "anyhow",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -5046,10 +5046,10 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "anyhow",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "proptest",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -5065,7 +5065,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -5078,9 +5078,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -5091,9 +5091,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -5104,7 +5104,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5115,9 +5115,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -5130,7 +5130,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5143,7 +5143,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -5152,12 +5152,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "lru 0.16.2",
  "parking_lot",
@@ -5172,12 +5172,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "anyhow",
  "colored 3.0.0",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "lru 0.16.2",
  "parking_lot",
@@ -5195,7 +5195,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5212,12 +5212,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
  "bincode",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "parking_lot",
  "rayon",
@@ -5240,7 +5240,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5258,7 +5258,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "metrics",
 ]
@@ -5266,7 +5266,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5289,11 +5289,11 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "itertools 0.14.0",
  "locktick",
  "lru 0.16.2",
@@ -5323,11 +5323,11 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "colored 3.0.0",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "locktick",
  "parking_lot",
  "rand 0.8.5",
@@ -5348,10 +5348,10 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "enum-iterator",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "paste",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -5367,7 +5367,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "bincode",
  "serde_json",
@@ -5380,7 +5380,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5403,7 +5403,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.3.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=fbd99608f#fbd99608feb8acc991eb74298e791e2de4b92bc3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Frestore-pending-blocks#24467a208bbb64af1af01909ac855e6c8a18284a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
@@ -5932,7 +5932,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
 dependencies = [
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -6805,18 +6805,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "43fa6694ed34d6e57407afbccdeecfa268c470a7d2a5b0cf49ce9fcc345afb90"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "c640b22cd9817fae95be82f0d2f90b11f7605f6c319d16705c459b27ac2cbc26"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
@@ -6908,7 +6908,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.12.0",
+ "indexmap 2.12.1",
  "memchr",
  "thiserror 2.0.17",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,9 @@ version = "=0.3.19"
 [workspace.dependencies.test-strategy]
 version = "0.4"
 
+[workspace.dependencies.test-log]
+version = "0.2"
+
 [workspace.dependencies.snarkos-account]
 path = "account"
 version = "=4.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,9 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "fbd99608f"
+#rev = "fbd99608f"
 #version = "=4.3.0"
+branch="fix/restore-pending-blocks"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/build.rs
+++ b/build.rs
@@ -98,22 +98,22 @@ fn check_locktick_imports<P: AsRef<Path>>(path: P) {
 
             // Modify the lock balance based on the type of the relevant import.
             if [ImportOfInterest::ParkingLot, ImportOfInterest::Tokio].contains(&ioi) {
-                if line.contains("Mutex") {
-                    lock_balance += 1;
+                // Counts `Mutex` and `MutexGuard`.
+                lock_balance += line.matches("Mutex").count() as i8;
+                // Counts `RwLock` and its guards.
+                lock_balance += line.matches("RwLock").count() as i8;
+                // A correction in case we counted mutex guards.
+                if line.contains("MutexGuard") {
+                    lock_balance -= 1;
                 }
-                if line.contains("RwLock") {
-                    lock_balance += 1;
-                }
+                // Corrections for `use tokio::Mutex as TMutex` and `MutexGuard as TMutexGuard`.
+                lock_balance -= line.matches("TMutex").count() as i8;
             } else if ioi == ImportOfInterest::Locktick {
                 // Use `matches` instead of just `contains` here, as more than a single
                 // lock type entry is possible in a locktick import.
-                for _hit in line.matches("Mutex") {
-                    lock_balance -= 1;
-                }
-                for _hit in line.matches("RwLock") {
-                    lock_balance -= 1;
-                }
-                // A correction in case of the `use tokio::Mutex as TMutex` convention.
+                lock_balance -= line.matches("Mutex").count() as i8;
+                lock_balance -= line.matches("RwLock").count() as i8;
+                // A correction in case of the `use tokio::Mutex as TMutex`.
                 if line.contains("TMutex") {
                     lock_balance += 1;
                 }

--- a/cli/src/helpers/logger.rs
+++ b/cli/src/helpers/logger.rs
@@ -107,7 +107,9 @@ fn parse_log_filter(filter_str: &str) -> Result<EnvFilter> {
 }
 
 /// Sets the log filter based on the given verbosity level.
+/// Initializes the logger with the specified verbosity level, where 0 is the lowest verbosity and 6 the highest.
 ///
+/// The following shows what messages are enabled at each level.
 /// ```ignore
 /// 0 => info
 /// 1 => info, debug

--- a/node/bft/Cargo.toml
+++ b/node/bft/Cargo.toml
@@ -190,6 +190,9 @@ features = [ "test" ]
 [dev-dependencies.test-strategy]
 workspace = true
 
+[dev-dependencies.test-log]
+workspace = true
+
 [dev-dependencies.tower-http]
 version = "0.6"
 features = [ "fs", "trace" ]

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -16,8 +16,10 @@
 use crate::{LedgerService, fmt_id, spawn_blocking};
 use snarkvm::{
     ledger::{
+        Block,
         Ledger,
-        block::{Block, Transaction},
+        PendingBlock,
+        Transaction,
         committee::Committee,
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
@@ -339,6 +341,14 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
         // Check the transaction is well-formed.
         let ledger = self.ledger.clone();
         spawn_blocking!(ledger.check_transaction_basic(&transaction, None, &mut rand::thread_rng()))
+    }
+
+    fn check_block_subdag(&self, block: Block<N>, prefix: &[PendingBlock<N>]) -> Result<PendingBlock<N>> {
+        self.ledger.check_block_subdag(block, prefix)
+    }
+
+    fn check_block_content(&self, block: PendingBlock<N>) -> Result<Block<N>> {
+        self.ledger.check_block_content(block, &mut rand::thread_rng())
     }
 
     /// Checks the given block is valid next block.

--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -16,7 +16,9 @@
 use crate::{LedgerService, fmt_id};
 use snarkvm::{
     ledger::{
-        block::{Block, Transaction},
+        Block,
+        PendingBlock,
+        Transaction,
         committee::Committee,
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
@@ -209,6 +211,14 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
     ) -> Result<()> {
         trace!("[MockLedgerService] Check transaction basic {:?} - Ok", fmt_id(transaction_id));
         Ok(())
+    }
+
+    fn check_block_subdag(&self, _block: Block<N>, _prefix: &[PendingBlock<N>]) -> Result<PendingBlock<N>> {
+        unimplemented!();
+    }
+
+    fn check_block_content(&self, _block: PendingBlock<N>) -> Result<Block<N>> {
+        unimplemented!();
     }
 
     /// Checks the given block is valid next block.

--- a/node/bft/ledger-service/src/prover.rs
+++ b/node/bft/ledger-service/src/prover.rs
@@ -16,7 +16,9 @@
 use crate::LedgerService;
 use snarkvm::{
     ledger::{
-        block::{Block, Transaction},
+        Block,
+        PendingBlock,
+        Transaction,
         committee::Committee,
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
@@ -164,6 +166,14 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
         _transaction: Transaction<N>,
     ) -> Result<()> {
         Ok(())
+    }
+
+    fn check_block_subdag(&self, _block: Block<N>, _prefix: &[PendingBlock<N>]) -> Result<PendingBlock<N>> {
+        bail!("Cannot check block subDAG in prover")
+    }
+
+    fn check_block_content(&self, _pending_block: PendingBlock<N>) -> Result<Block<N>> {
+        bail!("Cannot check block content in prover")
     }
 
     /// Checks the given block is valid next block.

--- a/node/bft/ledger-service/src/traits.rs
+++ b/node/bft/ledger-service/src/traits.rs
@@ -15,7 +15,9 @@
 
 use snarkvm::{
     ledger::{
-        block::{Block, Transaction},
+        Block,
+        PendingBlock,
+        Transaction,
         committee::Committee,
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
@@ -105,6 +107,12 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
         transaction_id: N::TransactionID,
         transaction: Transaction<N>,
     ) -> Result<()>;
+
+    /// Checks that the subDAG in a given block is valid, but does not fully verify the block.
+    fn check_block_subdag(&self, block: Block<N>, prefix: &[PendingBlock<N>]) -> Result<PendingBlock<N>>;
+
+    /// Takes a pending block and performs the remaining checks to full verify it.
+    fn check_block_content(&self, _block: PendingBlock<N>) -> Result<Block<N>>;
 
     /// Checks the given block is valid next block.
     fn check_next_block(&self, block: &Block<N>) -> Result<()>;

--- a/node/bft/ledger-service/src/translucent.rs
+++ b/node/bft/ledger-service/src/translucent.rs
@@ -18,8 +18,10 @@ use async_trait::async_trait;
 use indexmap::IndexMap;
 use snarkvm::{
     ledger::{
+        Block,
         Ledger,
-        block::{Block, Transaction},
+        PendingBlock,
+        Transaction,
         committee::Committee,
         narwhal::{Data, Subdag, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
@@ -175,6 +177,14 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for TranslucentLedgerS
         _transaction: Transaction<N>,
     ) -> Result<()> {
         Ok(())
+    }
+
+    fn check_block_subdag(&self, _block: Block<N>, _prefix: &[PendingBlock<N>]) -> Result<PendingBlock<N>> {
+        unimplemented!();
+    }
+
+    fn check_block_content(&self, _block: PendingBlock<N>) -> Result<Block<N>> {
+        unimplemented!();
     }
 
     /// Always succeeds.

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -521,7 +521,11 @@ impl<N: Network> BFT<N> {
         }
 
         /* Proceeding to check if the leader is ready to be committed. */
-        trace!("Checking if the leader is ready to be committed for round {commit_round}...");
+        if IS_SYNCING {
+            trace!("Checking if the leader is ready to be committed for round {commit_round} (from sync)...");
+        } else {
+            trace!("Checking if the leader is ready to be committed for round {commit_round}...");
+        }
 
         // Retrieve the committee lookback for the commit round.
         let committee_lookback = self.ledger().get_committee_lookback_for_round(commit_round).with_context(|| {
@@ -591,9 +595,6 @@ impl<N: Network> BFT<N> {
         &self,
         leader_certificate: BatchCertificate<N>,
     ) -> Result<()> {
-        // Ensure sync is not advancing while this commit is in progress.
-        let _pause_hdl = if !IS_SYNCING { Some(self.primary.block_sync().pause().await) } else { None };
-
         #[cfg(debug_assertions)]
         trace!("Attempting to commit leader certificate for round {}...", leader_certificate.round());
 

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -499,18 +499,20 @@ impl<N: Network> BFT<N> {
         // Acquire the BFT lock.
         let _lock = self.lock.lock().await;
 
+        // ### First, insert the certificate into the DAG. ###
         // Retrieve the round of the new certificate to add to the DAG.
         let certificate_round = certificate.round();
 
         // Insert the certificate into the DAG.
         self.dag.write().insert(certificate);
 
-        // Get the previous round number.
+        // ### Second, determine if a new leader certificate can be committed. ###
         let commit_round = certificate_round.saturating_sub(1);
 
         // Leaders are elected in even rounds.
         // If the previous round is odd, the current round cannot commit any leader certs.
-        if commit_round % 2 != 0 || commit_round < 2 {
+        // Similarly, no leader certificate can be committed for round zero.
+        if !commit_round.is_multiple_of(2) || commit_round < 2 {
             return Ok(());
         }
         // If the commit round is at or below the last committed round, return early.
@@ -592,6 +594,9 @@ impl<N: Network> BFT<N> {
         // Ensure sync is not advancing while this commit is in progress.
         let _pause_hdl = if !IS_SYNCING { Some(self.primary.block_sync().pause().await) } else { None };
 
+        #[cfg(debug_assertions)]
+        trace!("Attempting to commit leader certificate for round {}...", leader_certificate.round());
+
         // Fetch the leader round.
         let latest_leader_round = leader_certificate.round();
         // Determine the list of all previous leader certificates since the last committed round.
@@ -636,6 +641,11 @@ impl<N: Network> BFT<N> {
                     leader_certificates.push(previous_certificate.clone());
                     // Update the current certificate to the previous leader certificate.
                     current_certificate = previous_certificate;
+                } else {
+                    #[cfg(debug_assertions)]
+                    trace!(
+                        "Skipping anchor for round {round} as it is not linked to the most recent committed leader certificate"
+                    );
                 }
             }
         }
@@ -977,16 +987,31 @@ impl<N: Network> BFT<N> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{BFT, MAX_LEADER_CERTIFICATE_DELAY_IN_SECS, helpers::Storage};
+    use crate::{
+        BFT,
+        MAX_LEADER_CERTIFICATE_DELAY_IN_SECS,
+        helpers::{Storage, dag::test_helpers::mock_dag_with_modified_last_committed_round},
+    };
+
     use snarkos_account::Account;
-    use snarkos_node_bft_ledger_service::MockLedgerService;
+    use snarkos_node_bft_ledger_service::{LedgerService, MockLedgerService};
     use snarkos_node_bft_storage_service::BFTMemoryService;
     use snarkos_node_sync::BlockSync;
     use snarkvm::{
         console::account::{Address, PrivateKey},
         ledger::{
-            committee::Committee,
-            narwhal::batch_certificate::test_helpers::{sample_batch_certificate, sample_batch_certificate_for_round},
+            committee::{
+                Committee,
+                test_helpers::{sample_committee, sample_committee_for_round, sample_committee_for_round_and_members},
+            },
+            narwhal::{
+                BatchCertificate,
+                batch_certificate::test_helpers::{
+                    sample_batch_certificate,
+                    sample_batch_certificate_for_round,
+                    sample_batch_certificate_for_round_with_committee,
+                },
+            },
         },
         utilities::TestRng,
     };
@@ -1010,8 +1035,8 @@ mod tests {
         Storage<CurrentNetwork>,
     ) {
         let committee = match committee_round {
-            Some(round) => snarkvm::ledger::committee::test_helpers::sample_committee_for_round(round, rng),
-            None => snarkvm::ledger::committee::test_helpers::sample_committee(rng),
+            Some(round) => sample_committee_for_round(round, rng),
+            None => sample_committee(rng),
         };
         let account = Account::new(rng).unwrap();
         let ledger = Arc::new(MockLedgerService::new(committee.clone()));
@@ -1430,7 +1455,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[tracing_test::traced_test]
     async fn test_bft_gc_on_commit() -> Result<()> {
         let rng = &mut TestRng::default();
 
@@ -1477,7 +1501,8 @@ mod tests {
         let account = Account::new(rng)?;
         let bft = initialize_bft(account.clone(), storage.clone(), ledger.clone())?;
 
-        *bft.dag.write() = crate::helpers::dag::test_helpers::mock_dag_with_modified_last_committed_round(commit_round);
+        // Create an empty mock DAG with last committed round set to `commit_round`.
+        *bft.dag.write() = mock_dag_with_modified_last_committed_round(commit_round);
 
         // Ensure that the `gc_round` has not been updated yet.
         assert_eq!(bft.storage().gc_round(), committee_round.saturating_sub(max_gc_rounds));
@@ -1951,5 +1976,310 @@ mod tests {
             }
         }
         Ok(())
+    }
+
+    /// Tests that a leader certificate can be committed by sufficient endorsements in a succeeding leader certificate.
+    #[test_log::test(tokio::test)]
+    async fn test_commit_via_is_linked() {
+        let rng = &mut TestRng::default();
+
+        let committee_round = 0;
+        let leader_round_1 = 2;
+        let leader_round_2 = 4; // subsequent even round
+        let max_gc_rounds = 50;
+
+        // Create a committee with four members.
+        let num_authors = 4;
+        let private_keys: Vec<_> = (0..num_authors).map(|_| PrivateKey::new(rng).unwrap()).collect();
+        let addresses: Vec<_> = private_keys.iter().map(|pkey| Address::try_from(pkey).unwrap()).collect();
+
+        let committee = sample_committee_for_round_and_members(committee_round, addresses.clone(), rng);
+        let ledger = Arc::new(MockLedgerService::new(committee.clone()));
+        let storage = Storage::new(ledger.clone(), Arc::new(BFTMemoryService::new()), max_gc_rounds);
+        let bft = initialize_bft(Account::new(rng).unwrap(), storage.clone(), ledger.clone()).unwrap();
+
+        let mut certificates_by_round: IndexMap<u64, IndexSet<BatchCertificate<CurrentNetwork>>> = IndexMap::new();
+
+        // Round 1
+        let round1_certs: IndexSet<_> = (0..num_authors)
+            .map(|idx| {
+                let author = &private_keys[idx];
+                let endorsements: Vec<_> = private_keys
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(other_idx, pkey)| if idx == other_idx { None } else { Some(*pkey) })
+                    .collect();
+
+                sample_batch_certificate_for_round_with_committee(1, IndexSet::new(), author, &endorsements[..], rng)
+            })
+            .collect();
+        certificates_by_round.insert(1, round1_certs.clone());
+
+        let leader1 = ledger.get_committee_for_round(leader_round_1 + 1).unwrap().get_leader(leader_round_1).unwrap();
+        let mut leader1_certificate = None;
+
+        let round2_certs: IndexSet<_> = (0..num_authors)
+            .map(|idx| {
+                let author = &private_keys[idx];
+                let endorsements: Vec<_> = private_keys
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(other_idx, pkey)| if idx == other_idx { None } else { Some(*pkey) })
+                    .collect();
+                let cert = sample_batch_certificate_for_round_with_committee(
+                    leader_round_1,
+                    round1_certs.iter().map(|c| c.id()).collect(),
+                    author,
+                    &endorsements[..],
+                    rng,
+                );
+
+                if cert.author() == leader1 {
+                    leader1_certificate = Some(cert.clone());
+                }
+                cert
+            })
+            .collect();
+        certificates_by_round.insert(leader_round_1, round2_certs.clone());
+
+        let round3_certs: IndexSet<_> = (0..num_authors)
+            .map(|idx| {
+                let author = &private_keys[idx];
+                let endorsements: Vec<_> = private_keys
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(other_idx, pkey)| if idx == other_idx { None } else { Some(*pkey) })
+                    .collect();
+
+                let previous_certificate_ids: IndexSet<_> = round2_certs
+                    .iter()
+                    .filter_map(|cert| {
+                        // Only have the leader endorse the previous round's leader certificate.
+                        if cert.author() == leader1 && cert.author() != addresses[idx] { None } else { Some(cert.id()) }
+                    })
+                    .collect();
+
+                sample_batch_certificate_for_round_with_committee(
+                    leader_round_1 + 1,
+                    previous_certificate_ids,
+                    author,
+                    &endorsements[..],
+                    rng,
+                )
+            })
+            .collect();
+        certificates_by_round.insert(leader_round_1 + 1, round3_certs.clone());
+
+        // Ensure the first leader's certificate is not committed yet.
+        let leader_certificate_1 = leader1_certificate.unwrap();
+        assert!(
+            !bft.dag.read().is_recently_committed(leader_round_1, leader_certificate_1.id()),
+            "Leader certificate 1 should not be committed yet"
+        );
+        assert_eq!(bft.dag.read().last_committed_round(), 0);
+
+        let leader2 = ledger.get_committee_for_round(leader_round_2 + 1).unwrap().get_leader(leader_round_2).unwrap();
+        let round4_certs: IndexSet<_> = (0..num_authors)
+            .map(|idx| {
+                let endorsements: Vec<_> = private_keys
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(other_idx, pkey)| if idx == other_idx { None } else { Some(*pkey) })
+                    .collect();
+
+                sample_batch_certificate_for_round_with_committee(
+                    leader_round_2,
+                    round3_certs.iter().map(|c| c.id()).collect(),
+                    &private_keys[idx],
+                    &endorsements[..],
+                    rng,
+                )
+            })
+            .collect();
+        certificates_by_round.insert(leader_round_2, round4_certs.clone());
+
+        // Insert all certificates into the storage and DAG.
+        for certificate in certificates_by_round.into_iter().flat_map(|(_, certs)| certs) {
+            storage.testing_only_insert_certificate_testing_only(certificate.clone());
+            bft.update_dag::<false, false>(certificate).await.unwrap();
+        }
+
+        let leader_certificate_2 = storage.get_certificate_for_round_with_author(leader_round_2, leader2).unwrap();
+
+        assert!(
+            bft.is_linked(leader_certificate_1.clone(), leader_certificate_2.clone()).unwrap(),
+            "Leader certificate 1 should be linked to leader certificate 2"
+        );
+
+        // Explicitely commit leader certificate 2.
+        bft.commit_leader_certificate::<false, false>(leader_certificate_2.clone()).await.unwrap();
+
+        // Leader certificate 1 should be committed transitively when committing the leader certificate 2.
+        assert!(
+            bft.dag.read().is_recently_committed(leader_round_1, leader_certificate_1.id()),
+            "Leader certificate for round 2 should be committed when committing at round 4"
+        );
+
+        // Leader certificate 2 should be committed as the above call was successful.
+        assert!(
+            bft.dag.read().is_recently_committed(leader_round_2, leader_certificate_2.id()),
+            "Leader certificate for round 4 should be committed"
+        );
+
+        assert_eq!(bft.dag.read().last_committed_round(), 4);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_commit_via_is_linked_with_skipped_anchor() {
+        let rng = &mut TestRng::default();
+
+        let committee_round = 0;
+        let leader_round_1 = 2;
+        let leader_round_2 = 4;
+        let max_gc_rounds = 50;
+
+        let num_authors = 4;
+        let private_keys: Vec<_> = (0..num_authors).map(|_| PrivateKey::new(rng).unwrap()).collect();
+        let addresses: Vec<_> = private_keys.iter().map(|pkey| Address::try_from(pkey).unwrap()).collect();
+
+        let committee = sample_committee_for_round_and_members(committee_round, addresses.clone(), rng);
+        let ledger = Arc::new(MockLedgerService::new(committee.clone()));
+        let storage = Storage::new(ledger.clone(), Arc::new(BFTMemoryService::new()), max_gc_rounds);
+        let bft = initialize_bft(Account::new(rng).unwrap(), storage.clone(), ledger.clone()).unwrap();
+
+        let mut certificates_by_round: IndexMap<u64, IndexSet<BatchCertificate<CurrentNetwork>>> = IndexMap::new();
+
+        // Round 1
+        let round1_certs: IndexSet<_> = (0..num_authors)
+            .map(|idx| {
+                let author = &private_keys[idx];
+                let endorsements: Vec<_> = private_keys
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(other_idx, pkey)| if idx == other_idx { None } else { Some(*pkey) })
+                    .collect();
+
+                sample_batch_certificate_for_round_with_committee(1, IndexSet::new(), author, &endorsements[..], rng)
+            })
+            .collect();
+        certificates_by_round.insert(1, round1_certs.clone());
+
+        let leader1 = ledger.get_committee_for_round(leader_round_1 + 1).unwrap().get_leader(leader_round_1).unwrap();
+        let mut leader1_certificate = None;
+
+        let round2_certs: IndexSet<_> = (0..num_authors)
+            .map(|idx| {
+                let author = &private_keys[idx];
+                let endorsements: Vec<_> = private_keys
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(other_idx, pkey)| if idx == other_idx { None } else { Some(*pkey) })
+                    .collect();
+                let cert = sample_batch_certificate_for_round_with_committee(
+                    leader_round_1,
+                    round1_certs.iter().map(|c| c.id()).collect(),
+                    author,
+                    &endorsements[..],
+                    rng,
+                );
+
+                if cert.author() == leader1 {
+                    leader1_certificate = Some(cert.clone());
+                }
+                cert
+            })
+            .collect();
+        certificates_by_round.insert(leader_round_1, round2_certs.clone());
+
+        let round3_certs: IndexSet<_> = (0..num_authors)
+            .map(|idx| {
+                let author = &private_keys[idx];
+                let endorsements: Vec<_> = private_keys
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(other_idx, pkey)| if idx == other_idx { None } else { Some(*pkey) })
+                    .collect();
+
+                let previous_certificate_ids: IndexSet<_> = round2_certs
+                    .iter()
+                    .filter_map(|cert| {
+                        // Only have the leader endorse the previous round's leader certificate.
+                        if cert.author() == leader1 && cert.author() != addresses[idx] { None } else { Some(cert.id()) }
+                    })
+                    .collect();
+
+                sample_batch_certificate_for_round_with_committee(
+                    leader_round_1 + 1,
+                    previous_certificate_ids,
+                    author,
+                    &endorsements[..],
+                    rng,
+                )
+            })
+            .collect();
+        certificates_by_round.insert(leader_round_1 + 1, round3_certs.clone());
+
+        // Ensure the first leader's certificate is not committed yet.
+        let leader_certificate_1 = leader1_certificate.unwrap();
+        assert!(
+            !bft.dag.read().is_recently_committed(leader_round_1, leader_certificate_1.id()),
+            "Leader certificate 1 should not be committed yet"
+        );
+
+        let leader2 = ledger.get_committee_for_round(leader_round_2 + 1).unwrap().get_leader(leader_round_2).unwrap();
+        let round4_certs: IndexSet<_> = (0..num_authors)
+            .map(|idx| {
+                let endorsements: Vec<_> = private_keys
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(other_idx, pkey)| if idx == other_idx { None } else { Some(*pkey) })
+                    .collect();
+
+                // Do not create a path to the previous leader certificate.
+                let previous_certificate_ids: IndexSet<_> = round3_certs
+                    .iter()
+                    .filter_map(|cert| if cert.author() == leader1 { None } else { Some(cert.id()) })
+                    .collect();
+
+                sample_batch_certificate_for_round_with_committee(
+                    leader_round_2,
+                    previous_certificate_ids,
+                    &private_keys[idx],
+                    &endorsements[..],
+                    rng,
+                )
+            })
+            .collect();
+        certificates_by_round.insert(leader_round_2, round4_certs.clone());
+
+        // Insert all certificates into the storage and DAG.
+        for certificate in certificates_by_round.into_iter().flat_map(|(_, certs)| certs) {
+            storage.testing_only_insert_certificate_testing_only(certificate.clone());
+            bft.update_dag::<false, false>(certificate).await.unwrap();
+        }
+
+        let leader_certificate_2 = storage.get_certificate_for_round_with_author(leader_round_2, leader2).unwrap();
+
+        assert!(
+            !bft.is_linked(leader_certificate_1.clone(), leader_certificate_2.clone()).unwrap(),
+            "Leader certificate 1 should not be linked to leader certificate 2"
+        );
+        assert_eq!(bft.dag.read().last_committed_round(), 0);
+
+        // Explicitely commit leader certificate 2.
+        bft.commit_leader_certificate::<false, false>(leader_certificate_2.clone()).await.unwrap();
+
+        // Leader certificate 1 should be committed transitively when committing the leader certificate 2.
+        assert!(
+            !bft.dag.read().is_recently_committed(leader_round_1, leader_certificate_1.id()),
+            "Leader certificate for round 2 should not be committed when committing at round 4"
+        );
+
+        // Leader certificate 2 should be committed as the above call was successful.
+        assert!(
+            bft.dag.read().is_recently_committed(leader_round_2, leader_certificate_2.id()),
+            "Leader certificate for round 4 should be committed"
+        );
+        assert_eq!(bft.dag.read().last_committed_round(), 4);
     }
 }

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -522,18 +522,18 @@ impl<N: Network> BFT<N> {
         trace!("Checking if the leader is ready to be committed for round {commit_round}...");
 
         // Retrieve the committee lookback for the commit round.
-        let Ok(committee_lookback) = self.ledger().get_committee_lookback_for_round(commit_round) else {
-            bail!("BFT failed to retrieve the committee with lag for commit round {commit_round}");
-        };
+        let committee_lookback = self.ledger().get_committee_lookback_for_round(commit_round).with_context(|| {
+            format!("BFT failed to retrieve the committee with lag for commit round {commit_round}")
+        })?;
 
         // Either retrieve the cached leader or compute it.
         let leader = match self.ledger().latest_leader() {
             Some((cached_round, cached_leader)) if cached_round == commit_round => cached_leader,
             _ => {
                 // Compute the leader for the commit round.
-                let Ok(computed_leader) = committee_lookback.get_leader(commit_round) else {
-                    bail!("BFT failed to compute the leader for commit round {commit_round}");
-                };
+                let computed_leader = committee_lookback
+                    .get_leader(commit_round)
+                    .with_context(|| format!("BFT failed to compute the leader for commit round {commit_round}"))?;
 
                 // Cache the computed leader.
                 self.ledger().update_latest_leader(commit_round, computed_leader);
@@ -549,15 +549,16 @@ impl<N: Network> BFT<N> {
             return Ok(());
         };
         // Retrieve all of the certificates for the **certificate** round.
-        let Some(certificates) = self.dag.read().get_certificates_for_round(certificate_round) else {
-            // TODO (howardwu): Investigate how many certificates we should have at this point.
-            bail!("BFT failed to retrieve the certificates for certificate round {certificate_round}");
-        };
+        let certificates = self.dag.read().get_certificates_for_round(certificate_round).with_context(|| {
+            format!("BFT failed to retrieve the certificates for certificate round {certificate_round}")
+        })?;
+
         // Retrieve the committee lookback for the certificate round (i.e. the round just after the commit round).
-        let Ok(certificate_committee_lookback) = self.ledger().get_committee_lookback_for_round(certificate_round)
-        else {
-            bail!("BFT failed to retrieve the committee lookback for certificate round {certificate_round}");
-        };
+        let certificate_committee_lookback =
+            self.ledger().get_committee_lookback_for_round(certificate_round).with_context(|| {
+                format!("BFT failed to retrieve the committee lookback for certificate round {certificate_round}")
+            })?;
+
         // Construct a set over the authors who included the leader's certificate in the certificate round.
         let authors = certificates
             .values()
@@ -569,12 +570,15 @@ impl<N: Network> BFT<N> {
         // Check if the leader is ready to be committed.
         if !certificate_committee_lookback.is_availability_threshold_reached(&authors) {
             // If the leader is not ready to be committed, return early.
-            trace!("BFT is not ready to commit {commit_round}");
+            trace!("BFT is not ready to commit {commit_round}. Availability threshold has not been reached yet.");
             return Ok(());
         }
 
-        /* Proceeding to commit the leader. */
-        info!("Proceeding to commit round {commit_round} with leader '{}'", fmt_id(leader));
+        if IS_SYNCING {
+            info!("Proceeding to commit round {commit_round} with leader '{}' from block sync", fmt_id(leader));
+        } else {
+            info!("Proceeding to commit round {commit_round} with leader '{}'", fmt_id(leader));
+        }
 
         // Commit the leader certificate, and all previous leader certificates since the last committed round.
         self.commit_leader_certificate::<ALLOW_LEDGER_ACCESS, IS_SYNCING>(leader_certificate).await
@@ -641,10 +645,9 @@ impl<N: Network> BFT<N> {
             // Retrieve the leader certificate round.
             let leader_round = leader_certificate.round();
             // Compute the commit subdag.
-            let commit_subdag = match self.order_dag_with_dfs::<ALLOW_LEDGER_ACCESS>(leader_certificate) {
-                Ok(subdag) => subdag,
-                Err(e) => bail!("BFT failed to order the DAG with DFS - {e}"),
-            };
+            let commit_subdag = self
+                .order_dag_with_dfs::<ALLOW_LEDGER_ACCESS>(leader_certificate)
+                .with_context(|| "BFT failed to order the DAG with DFS")?;
             // If the node is not syncing, trigger consensus, as this will build a new block for the ledger.
             if !IS_SYNCING {
                 // Initialize a map for the deduped transmissions.
@@ -687,14 +690,14 @@ impl<N: Network> BFT<N> {
                             continue;
                         }
                         // Retrieve the transmission.
-                        let Some(transmission) = self.storage().get_transmission(*transmission_id) else {
-                            bail!(
+                        let transmission = self.storage().get_transmission(*transmission_id).with_context(|| {
+                            format!(
                                 "BFT failed to retrieve transmission '{}.{}' from round {}",
                                 fmt_id(transmission_id),
                                 fmt_id(transmission_id.checksum().unwrap_or_default()).dimmed(),
                                 certificate.round()
-                            );
-                        };
+                            )
+                        })?;
                         // Insert the transaction ID or solution ID into the map.
                         match transmission_id {
                             TransmissionID::Solution(id, _) => {
@@ -755,9 +758,15 @@ impl<N: Network> BFT<N> {
             }
 
             // Update the DAG, as the subdag was successfully included into a block.
-            let mut dag_write = self.dag.write();
-            for certificate in commit_subdag.values().flatten() {
-                dag_write.commit(certificate, self.storage().max_gc_rounds());
+            {
+                let mut dag_write = self.dag.write();
+                let mut count = 0;
+                for certificate in commit_subdag.values().flatten() {
+                    dag_write.commit(certificate, self.storage().max_gc_rounds());
+                    count += 1;
+                }
+
+                trace!("Committed {count} certificates to the DAG");
             }
 
             // Update the validator telemetry.

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -585,6 +585,9 @@ impl<N: Network> BFT<N> {
         &self,
         leader_certificate: BatchCertificate<N>,
     ) -> Result<()> {
+        // Ensure sync is not advancing while this commit is in progress.
+        let _pause_hdl = if !IS_SYNCING { Some(self.primary.block_sync().pause().await) } else { None };
+
         // Fetch the leader round.
         let latest_leader_round = leader_certificate.round();
         // Determine the list of all previous leader certificates since the last committed round.

--- a/node/bft/src/helpers/dag.rs
+++ b/node/bft/src/helpers/dag.rs
@@ -40,7 +40,8 @@ pub struct DAG<N: Network> {
     /// where each entry has a round number as its key and a set of certificate IDs as its value.
     recent_committed_ids: BTreeMap<u64, IndexSet<Field<N>>>,
 
-    /// The last round that was committed.
+    /// The latest round a certificate was committed too.
+    /// This corresponds to the latest leader certificate's round, because the leader certificate always has the greatest round number of its subDAG.
     last_committed_round: u64,
 }
 
@@ -62,7 +63,7 @@ impl<N: Network> DAG<N> {
         &self.graph
     }
 
-    /// Returns the last committed round.
+    /// Returns the latest round a certificate was committed to.
     pub const fn last_committed_round(&self) -> u64 {
         self.last_committed_round
     }
@@ -135,6 +136,10 @@ impl<N: Network> DAG<N> {
 
         // Update the last committed round.
         if self.last_committed_round < certificate_round {
+            trace!(
+                "Last committed round updated from {last_committed_round} to {certificate_round}",
+                last_committed_round = self.last_committed_round
+            );
             self.last_committed_round = certificate_round;
         } else {
             // TODO(kaimast); only remove old certificates for specific author here?

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -241,7 +241,9 @@ impl<N: Network> Storage<N> {
             for gc_round in current_gc_round..=next_gc_round {
                 // Iterate over the certificates for the GC round.
                 for id in self.get_certificate_ids_for_round(gc_round).into_iter() {
-                    trace!("Garbage collecting certificate {id}");
+                    trace!(
+                        "Garbage collecting certificate {id} at round {gc_round} (cut-off is round {next_gc_round})"
+                    );
                     self.remove_certificate(id);
                 }
             }

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -124,7 +124,7 @@ impl<N: Network> Storage<N> {
         let storage = Self(Arc::new(StorageInner {
             ledger,
             current_height: Default::default(),
-            current_round: Default::default(),
+            current_round: AtomicU64::new(current_round),
             gc_round: Default::default(),
             max_gc_rounds,
             rounds: Default::default(),
@@ -133,8 +133,6 @@ impl<N: Network> Storage<N> {
             batch_ids: Default::default(),
             transmissions,
         }));
-        // Update the storage to the current round.
-        storage.update_current_round(current_round);
         // Perform GC on the current round.
         // Since there are no certificates yet, this only sets `gc_round`.
         storage.garbage_collect_certificates(current_round);
@@ -183,6 +181,8 @@ impl<N: Network> Storage<N> {
             if next_round < storage_round {
                 return Ok(storage_round);
             }
+
+            trace!("Incrementing storage from round {storage_round} to {next_round}");
         }
 
         // Retrieve the current committee.
@@ -768,7 +768,7 @@ impl<N: Network> Storage<N> {
 
     /// Syncs the current round with the block.
     pub(crate) fn sync_round_with_block(&self, next_round: u64) {
-        // Retrieve the current round in the block.
+        // Ensure we sync to at least round 1.
         let next_round = next_round.max(1);
         // If the round in the block is greater than the current round in storage, sync the round.
         if next_round > self.current_round() {
@@ -776,6 +776,11 @@ impl<N: Network> Storage<N> {
             self.update_current_round(next_round);
             // Log the updated round.
             info!("Synced to round {next_round}...");
+        } else {
+            trace!(
+                "Skipping sync to round {next_round} as it is less than the current round ({})",
+                self.current_round()
+            );
         }
     }
 

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -241,7 +241,7 @@ impl<N: Network> Storage<N> {
             for gc_round in current_gc_round..=next_gc_round {
                 // Iterate over the certificates for the GC round.
                 for id in self.get_certificate_ids_for_round(gc_round).into_iter() {
-                    // Remove the certificate from storage.
+                    trace!("Garbage collecting certificate {id}");
                     self.remove_certificate(id);
                 }
             }
@@ -414,6 +414,12 @@ impl<N: Network> Storage<N> {
 
     /// Checks the given `batch_header` for validity, returning the missing transmissions from storage.
     ///
+    /// # Arguments
+    /// - `batch_header`: The batch header to check.
+    /// - `transmissions`: All transmissions referenced by the certificate.
+    /// - `aborted_transmissions`: The set of aborted transmissions in this certificate.
+    ///
+    /// # Invariants
     /// This method ensures the following invariants:
     /// - The batch ID does not already exist in storage.
     /// - The author is a member of the committee for the batch round.
@@ -558,6 +564,12 @@ impl<N: Network> Storage<N> {
 
     /// Checks the given `certificate` for validity, returning the missing transmissions from storage.
     ///
+    /// # Arguments
+    /// - `certificate`: The certificate to check.
+    /// - `transmissions`: The transmissions contained in the certificate.
+    /// - `aborted_transmissions`: The aborted transmission contained in the certificate.
+    ///
+    /// # Invariants
     /// This method ensures the following invariants:
     /// - The certificate ID does not already exist in storage.
     /// - The batch ID does not already exist in storage.
@@ -638,6 +650,12 @@ impl<N: Network> Storage<N> {
     ///
     /// This method triggers updates to the `rounds`, `certificates`, `batch_ids`, and `transmissions` maps.
     ///
+    /// # Arguments
+    /// - `certificate`: The certificate to insert.
+    /// - `transmissions`: The transmissions contained in the certificate, or the subset of the transmissions that in the certificate that do not yet exist in storage.
+    /// - `aborted_transmissions`: The aborted transmission contained in the certificate.
+    ///
+    /// # Invariants
     /// This method ensures the following invariants:
     /// - The certificate ID does not already exist in storage.
     /// - The batch ID does not already exist in storage.
@@ -710,7 +728,7 @@ impl<N: Network> Storage<N> {
         Ok(())
     }
 
-    /// Removes the given `certificate ID` from storage.
+    /// Removes the given `certificate ID` from storage. This method is used to garbage collect individual certificates once blocks are committed.
     ///
     /// This method triggers updates to the `rounds`, `certificates`, `batch_ids`, and `transmissions` maps.
     ///

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -287,6 +287,11 @@ impl<N: Network> Primary<N> {
         &self.storage
     }
 
+    /// Returns the block sync logic.
+    pub const fn block_sync(&self) -> &Sync<N> {
+        &self.sync
+    }
+
     /// Returns the ledger.
     pub const fn ledger(&self) -> &Arc<dyn LedgerService<N>> {
         &self.ledger
@@ -1384,8 +1389,12 @@ impl<N: Network> Primary<N> {
                 tokio::spawn(async move {
                     // Process the batch proposal.
                     let round = batch_propose.round;
-                    if let Err(e) = self_.process_batch_propose_from_peer(peer_ip, batch_propose).await {
-                        warn!("Cannot sign a batch at round {round} from '{peer_ip}' - {e}");
+                    if let Err(err) = self_
+                        .process_batch_propose_from_peer(peer_ip, batch_propose)
+                        .await
+                        .with_context(|| format!("Cannot sign a batch at round {round} from '{peer_ip}'"))
+                    {
+                        warn!("{}", flatten_error(err));
                     }
                 });
             }

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -1836,9 +1836,7 @@ impl<N: Network> Primary<N> {
         let (missing_transmissions, missing_previous_certificates) = tokio::try_join!(
             missing_transmissions_handle,
             missing_previous_certificates_handle,
-        ).map_err(|e| {
-            anyhow!("Failed to fetch missing transmissions and previous certificates for round {batch_round} from '{peer_ip}' - {e}")
-        })?;
+        ).with_context(|| format!("Failed to fetch missing transmissions and previous certificates for round {batch_round} from '{peer_ip}"))?;
 
         // Iterate through the missing previous certificates.
         for batch_certificate in missing_previous_certificates {

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -842,11 +842,21 @@ impl<N: Network> Sync<N> {
                 break;
             }
 
+            trace!(
+                "Pending block {hash} at height {height} became obsolete",
+                hash = pending_block.hash(),
+                height = pending_block.height()
+            );
             pending_blocks.pop_front();
         }
 
         // Check the block against the chain of pending blocks and append it on success.
         let new_block = self.ledger.check_block_subdag(new_block, pending_blocks.make_contiguous())?;
+        trace!(
+            "Adding new pending block {hash} at height {height}",
+            hash = new_block.hash(),
+            height = new_block.height()
+        );
         pending_blocks.push_back(new_block);
 
         // Now, figure out if and which pending block we can commit.
@@ -883,21 +893,22 @@ impl<N: Network> Sync<N> {
                 let height = pending_block.height();
 
                 spawn_blocking!({
-                    match ledger.check_block_content(pending_block) {
-                        Ok(block) => {
-                            trace!("Adding pending block {hash} at height {height} to the ledger");
-                            ledger.advance_to_next_block(&block)?;
-                            // Sync the height with the block.
-                            storage.sync_height_with_block(block.height());
-                            // Sync the round with the block.
-                            storage.sync_round_with_block(block.round());
-                        }
-                        Err(err) => bail!("Failed to check contents of pending block {hash} at height {height}: {err}"),
-                    }
+                    let block = ledger.check_block_content(pending_block).with_context(|| {
+                        format!("Failed to check contents of pending block {hash} at height {height}")
+                    })?;
+
+                    trace!("Adding pending block {hash} at height {height} to the ledger");
+                    ledger.advance_to_next_block(&block)?;
+                    // Sync the height with the block.
+                    storage.sync_height_with_block(block.height());
+                    // Sync the round with the block.
+                    storage.sync_round_with_block(block.round());
 
                     Ok(())
                 })?
             }
+        } else {
+            trace!("No pending block are ready to be committed ({} block(s) are pending)", pending_blocks.len());
         }
 
         Ok(())
@@ -955,7 +966,7 @@ impl<N: Network> Sync<N> {
         if should_send_request {
             // Send the certificate request to the peer.
             if self.gateway.send(peer_ip, Event::CertificateRequest(certificate_id.into())).await.is_none() {
-                bail!("Unable to fetch batch certificate {certificate_id} - failed to send request")
+                bail!("Unable to fetch batch certificate {certificate_id} (failed to send request)")
             }
         } else {
             debug!(
@@ -965,12 +976,10 @@ impl<N: Network> Sync<N> {
         }
         // Wait for the certificate to be fetched.
         // TODO (raychu86): Consider making the timeout dynamic based on network traffic and/or the number of validators.
-        match tokio::time::timeout(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS), callback_receiver).await {
-            // If the certificate was fetched, return it.
-            Ok(result) => Ok(result?),
-            // If the certificate was not fetched, return an error.
-            Err(e) => bail!("Unable to fetch certificate {} - (timeout) {e}", fmt_id(certificate_id)),
-        }
+        tokio::time::timeout(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS), callback_receiver)
+            .await
+            .with_context(|| format!("Unable to fetch batch certificate {} (timeout)", fmt_id(certificate_id)))?
+            .with_context(|| format!("Unable to fetch batch certificate {}", fmt_id(certificate_id)))
     }
 
     /// Handles the incoming certificate request.

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -1192,12 +1192,15 @@ mod tests {
                 subdag_map.insert(leader_round - 2, previous_commit_cert_map);
             }
 
-            let subdag = Subdag::from(subdag_map.clone())?;
-            let block = core_ledger.prepare_advance_to_next_quorum_block(subdag, Default::default())?;
-
             previous_leader_cert = Some(leader_certificate);
 
-            core_ledger.advance_to_next_block(&block)?;
+            let core_ledger = core_ledger.clone();
+            let block = spawn_blocking!({
+                let subdag = Subdag::from(subdag_map.clone())?;
+                let block = core_ledger.prepare_advance_to_next_quorum_block(subdag, Default::default())?;
+                core_ledger.advance_to_next_block(&block)?;
+                Ok(block)
+            })?;
             blocks.push(block);
         }
 

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -143,7 +143,9 @@ impl<N: Network> Sync<N> {
         info!("Syncing storage with the ledger...");
 
         // Sync the storage with the ledger.
-        self.sync_storage_with_ledger_at_bootup().await?;
+        self.sync_storage_with_ledger_at_bootup()
+            .await
+            .with_context(|| "Syncing storage with the ledger at bootup failed")?;
 
         debug!("Finished initial block synchronization at startup");
         Ok(())
@@ -667,9 +669,9 @@ impl<N: Network> Sync<N> {
             let within_gc = (current_height + 1) > max_gc_height;
             if within_gc {
                 info!("Finished catching up with the network. Switching back to BFT sync.");
-                if let Err(err) = self.sync_storage_with_ledger_at_bootup().await {
-                    error!("BFT sync (with bootup routine) failed - {err}");
-                }
+                self.sync_storage_with_ledger_at_bootup()
+                    .await
+                    .with_context(|| "BFT sync (with bootup routine) failed")?;
             }
 
             cleanup(start_height, current_height, None)

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -515,10 +515,14 @@ impl<N: Network> Sync<N> {
     /// BFT-version of [`snarkos_node_client::Client::try_advancing_block_synchronization`].
     async fn try_advancing_block_synchronization(&self, ping: &Option<Arc<Ping<N>>>) {
         // Process block responses and advance the ledger.
-        let new_blocks = match self.try_advancing_block_synchronization_inner().await {
+        let new_blocks = match self
+            .try_advancing_block_synchronization_inner()
+            .await
+            .with_context(|| "Failed to advance block synchronization")
+        {
             Ok(new_blocks) => new_blocks,
             Err(err) => {
-                error!("Block synchronization failed - {err}");
+                error!("{}", flatten_error(err));
                 false
             }
         };
@@ -701,7 +705,7 @@ impl<N: Network> Sync<N> {
     /// It syncs the batch certificates with the BFT, if the block's authority is a sub-DAG.
     ///
     /// Note that the block authority is always a sub-DAG in production; beacon signatures are only used for testing,
-    /// and as placeholder (irrelevant) block authority in the genesis block.i
+    /// and as placeholder (irrelevant) block authority in the genesis block.
     async fn add_block_subdag_to_bft(&self, block: &Block<N>) -> Result<()> {
         // Nothing to do if this is a beacon block
         let Authority::Quorum(subdag) = block.authority() else {
@@ -872,6 +876,7 @@ impl<N: Network> Sync<N> {
 
             for pending_block in pending_blocks.drain(0..num_blocks) {
                 let ledger = self.ledger.clone();
+                let storage = self.storage.clone();
                 let hash = pending_block.hash();
                 let height = pending_block.height();
 
@@ -880,6 +885,10 @@ impl<N: Network> Sync<N> {
                         Ok(block) => {
                             trace!("Adding pending block {hash} at height {height} to the ledger");
                             ledger.advance_to_next_block(&block)?;
+                            // Sync the height with the block.
+                            storage.sync_height_with_block(block.height());
+                            // Sync the round with the block.
+                            storage.sync_round_with_block(block.round());
                         }
                         Err(err) => bail!("Failed to check contents of pending block {hash} at height {height}: {err}"),
                     }
@@ -1212,7 +1221,7 @@ mod tests {
         }
 
         // ### Test that sync works as expected ###
-        let storage_mode = StorageMode::Test(None);
+        let storage_mode = StorageMode::new_test(None);
 
         // Create a new ledger to test with, but use the existing storage
         // so that the certificates exist.

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -38,7 +38,7 @@ use snarkvm::{
 use anyhow::{Context, Result, anyhow, bail, ensure};
 use indexmap::IndexMap;
 #[cfg(feature = "locktick")]
-use locktick::{LockGuard, parking_lot::Mutex, tokio::Mutex as TMutex};
+use locktick::{parking_lot::Mutex, tokio::Mutex as TMutex};
 #[cfg(not(feature = "locktick"))]
 use parking_lot::Mutex;
 #[cfg(not(feature = "serial"))]
@@ -53,7 +53,7 @@ use std::{
 #[cfg(not(feature = "locktick"))]
 use tokio::sync::Mutex as TMutex;
 use tokio::{
-    sync::{MutexGuard as TMutexGuard, OnceCell, oneshot},
+    sync::{OnceCell, oneshot},
     task::JoinHandle,
 };
 
@@ -95,16 +95,6 @@ pub struct Sync<N: Network> {
     ///
     /// Whenever a new block is added to this map, BlockSync::set_sync_height needs to be called.
     pending_blocks: Arc<TMutex<VecDeque<PendingBlock<N>>>>,
-}
-
-/// Pauses sync from advancing until the object is dropped.
-pub struct PausedSyncHandle<'a> {
-    #[cfg(feature = "locktick")]
-    #[allow(dead_code)]
-    inner: LockGuard<TMutexGuard<'a, ()>>,
-    #[cfg(not(feature = "locktick"))]
-    #[allow(dead_code)]
-    inner: TMutexGuard<'a, ()>,
 }
 
 impl<N: Network> Sync<N> {
@@ -149,11 +139,6 @@ impl<N: Network> Sync<N> {
 
         debug!("Finished initial block synchronization at startup");
         Ok(())
-    }
-
-    /// Pause synchronization until the returned handle is dropped.
-    pub(crate) async fn pause<'a>(&'a self) -> PausedSyncHandle<'a> {
-        PausedSyncHandle { inner: self.sync_lock.lock().await }
     }
 
     /// Sends the given batch of block requests to peers.

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -14,7 +14,9 @@
 // limitations under the License.
 
 use crate::{
-    Gateway, MAX_FETCH_TIMEOUT_IN_MS, Transport,
+    Gateway,
+    MAX_FETCH_TIMEOUT_IN_MS,
+    Transport,
     events::{CertificateRequest, CertificateResponse, DataBlocks, Event},
     helpers::{BFTSender, Pending, Storage, SyncReceiver, fmt_id, max_redundant_requests},
     ledger_service::LedgerService,
@@ -860,15 +862,21 @@ impl<N: Network> Sync<N> {
             }
 
             for pending_block in pending_blocks.drain(0..num_blocks) {
+                let ledger = self.ledger.clone();
                 let hash = pending_block.hash();
                 let height = pending_block.height();
-                match self.ledger.check_block_content(pending_block) {
-                    Ok(block) => {
-                        trace!("Adding pending block {hash} at height {height} to the ledger");
-                        self.ledger.advance_to_next_block(&block)?;
+
+                spawn_blocking!({
+                    match ledger.check_block_content(pending_block) {
+                        Ok(block) => {
+                            trace!("Adding pending block {hash} at height {height} to the ledger");
+                            ledger.advance_to_next_block(&block)?;
+                        }
+                        Err(err) => bail!("Failed to check contents of pending block {hash} at height {height}: {err}"),
                     }
-                    Err(err) => bail!("Failed to check contents of pending block {hash} at height {height}: {err}"),
-                }
+
+                    Ok(())
+                })?
             }
         }
 

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -38,7 +38,7 @@ use snarkvm::{
 use anyhow::{Context, Result, anyhow, bail, ensure};
 use indexmap::IndexMap;
 #[cfg(feature = "locktick")]
-use locktick::{parking_lot::Mutex, tokio::Mutex as TMutex};
+use locktick::{LockGuard, parking_lot::Mutex, tokio::Mutex as TMutex};
 #[cfg(not(feature = "locktick"))]
 use parking_lot::Mutex;
 #[cfg(not(feature = "serial"))]
@@ -53,7 +53,7 @@ use std::{
 #[cfg(not(feature = "locktick"))]
 use tokio::sync::Mutex as TMutex;
 use tokio::{
-    sync::{OnceCell, oneshot},
+    sync::{MutexGuard as TMutexGuard, OnceCell, oneshot},
     task::JoinHandle,
 };
 
@@ -85,8 +85,6 @@ pub struct Sync<N: Network> {
     bft_sender: Arc<OnceCell<BFTSender<N>>>,
     /// Handles to the spawned background tasks.
     handles: Arc<Mutex<Vec<JoinHandle<()>>>>,
-    /// The response lock.
-    response_lock: Arc<TMutex<()>>,
     /// The sync lock. Ensures that only one task syncs the ledger at a time.
     sync_lock: Arc<TMutex<()>>,
     /// The latest block responses.
@@ -97,6 +95,16 @@ pub struct Sync<N: Network> {
     ///
     /// Whenever a new block is added to this map, BlockSync::set_sync_height needs to be called.
     pending_blocks: Arc<TMutex<VecDeque<PendingBlock<N>>>>,
+}
+
+/// Pauses sync from advancing until the object is dropped.
+pub struct PausedSyncHandle<'a> {
+    #[cfg(feature = "locktick")]
+    #[allow(dead_code)]
+    inner: LockGuard<TMutexGuard<'a, ()>>,
+    #[cfg(not(feature = "locktick"))]
+    #[allow(dead_code)]
+    inner: TMutexGuard<'a, ()>,
 }
 
 impl<N: Network> Sync<N> {
@@ -120,7 +128,6 @@ impl<N: Network> Sync<N> {
             pending: Default::default(),
             bft_sender: Default::default(),
             handles: Default::default(),
-            response_lock: Default::default(),
             sync_lock: Default::default(),
             pending_blocks: Default::default(),
         }
@@ -140,6 +147,11 @@ impl<N: Network> Sync<N> {
 
         debug!("Finished initial block synchronization at startup");
         Ok(())
+    }
+
+    /// Pause synchronization until the returned handle is dropped.
+    pub(crate) async fn pause<'a>(&'a self) -> PausedSyncHandle<'a> {
+        PausedSyncHandle { inner: self.sync_lock.lock().await }
     }
 
     /// Sends the given batch of block requests to peers.
@@ -536,9 +548,6 @@ impl<N: Network> Sync<N> {
     /// If the node falls behind more than GC rounds, this function calls [`Self::sync_storage_without_bft`] instead,
     /// which syncs without updating the BFT state.
     async fn try_advancing_block_synchronization_inner(&self) -> Result<bool> {
-        // Acquire the response lock.
-        let _lock = self.response_lock.lock().await;
-
         // For sanity, set the sync height again.
         // (if the sync height is already larger or equal, this is a noop)
         let ledger_height = self.ledger.latest_block_height();
@@ -989,8 +998,6 @@ impl<N: Network> Sync<N> {
     /// Shuts down the primary.
     pub async fn shut_down(&self) {
         info!("Shutting down the sync module...");
-        // Acquire the response lock.
-        let _lock = self.response_lock.lock().await;
         // Acquire the sync lock.
         let _lock = self.sync_lock.lock().await;
         // Abort the tasks.

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -14,15 +14,12 @@
 // limitations under the License.
 
 use crate::{
-    Gateway,
-    MAX_FETCH_TIMEOUT_IN_MS,
-    Transport,
-    events::DataBlocks,
+    Gateway, MAX_FETCH_TIMEOUT_IN_MS, Transport,
+    events::{CertificateRequest, CertificateResponse, DataBlocks, Event},
     helpers::{BFTSender, Pending, Storage, SyncReceiver, fmt_id, max_redundant_requests},
+    ledger_service::LedgerService,
     spawn_blocking,
 };
-use snarkos_node_bft_events::{CertificateRequest, CertificateResponse, Event};
-use snarkos_node_bft_ledger_service::LedgerService;
 use snarkos_node_network::PeerPoolHandling;
 use snarkos_node_sync::{BLOCK_REQUEST_BATCH_DELAY, BlockSync, Ping, PrepareSyncRequest, locators::BlockLocators};
 
@@ -31,12 +28,12 @@ use snarkvm::{
         network::{ConsensusVersion, Network},
         types::Field,
     },
-    ledger::{authority::Authority, block::Block, narwhal::BatchCertificate},
+    ledger::{PendingBlock, authority::Authority, block::Block, narwhal::BatchCertificate},
     prelude::{cfg_into_iter, cfg_iter},
-    utilities::flatten_error,
+    utilities::{ensure_equals, flatten_error},
 };
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow, bail, ensure};
 use indexmap::IndexMap;
 #[cfg(feature = "locktick")]
 use locktick::{parking_lot::Mutex, tokio::Mutex as TMutex};
@@ -45,7 +42,7 @@ use parking_lot::Mutex;
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{HashMap, VecDeque},
     future::Future,
     net::SocketAddr,
     sync::Arc,
@@ -92,12 +89,12 @@ pub struct Sync<N: Network> {
     sync_lock: Arc<TMutex<()>>,
     /// The latest block responses.
     ///
-    /// This is used in [`Sync::sync_storage_with_block()`] to accumulate blocks  whose addition to the ledger is
-    /// deferred until certain checks pass.
+    /// This is used in [`Sync::sync_storage_with_block()`] to accumulate blocks
+    /// whose addition to the ledger is deferred until certain checks pass.
     /// Blocks need to be processed in order, hence a BTree map.
     ///
     /// Whenever a new block is added to this map, BlockSync::set_sync_height needs to be called.
-    latest_block_responses: Arc<TMutex<BTreeMap<u32, Block<N>>>>,
+    pending_blocks: Arc<TMutex<VecDeque<PendingBlock<N>>>>,
 }
 
 impl<N: Network> Sync<N> {
@@ -123,7 +120,7 @@ impl<N: Network> Sync<N> {
             handles: Default::default(),
             response_lock: Default::default(),
             sync_lock: Default::default(),
-            latest_block_responses: Default::default(),
+            pending_blocks: Default::default(),
         }
     }
 
@@ -488,13 +485,17 @@ impl<N: Network> Sync<N> {
     /// If there are queued block responses, this might be higher than the latest block in the ledger.
     async fn compute_sync_height(&self) -> u32 {
         let ledger_height = self.ledger.latest_block_height();
-        let mut responses = self.latest_block_responses.lock().await;
+        let mut pending_blocks = self.pending_blocks.lock().await;
 
         // Remove any old responses.
-        responses.retain(|height, _| *height > ledger_height);
+        while let Some(b) = pending_blocks.front()
+            && b.height() <= ledger_height
+        {
+            pending_blocks.pop_front();
+        }
 
         // Ensure the returned value is always greater or equal than ledger height.
-        responses.last_key_value().map(|(height, _)| *height).unwrap_or(0).max(ledger_height)
+        pending_blocks.back().map(|b| b.height()).unwrap_or(0).max(ledger_height)
     }
 
     /// BFT-version of [`snarkos_node_client::Client::try_advancing_block_synchronization`].
@@ -526,7 +527,7 @@ impl<N: Network> Sync<N> {
     /// This returns Ok(true) if we successfully advanced the ledger by at least one new block.
     ///
     /// A key difference to `BlockSync`'s versions is that it will only add blocks to the ledger once they have been confirmed by the network.
-    /// If blocks are not confirmed yet, they will be kept in [`Self::latest_block_responses`].
+    /// If blocks are not confirmed yet, they will be kept in [`Self::pending_blocks`].
     /// It will also pass certificates from synced blocks to the BFT module so that consensus can progress as expected
     /// (see [`Self::sync_storage_with_block`] for more details).
     ///
@@ -668,7 +669,7 @@ impl<N: Network> Sync<N> {
         let _lock = self.sync_lock.lock().await;
 
         let self_ = self.clone();
-        tokio::task::spawn_blocking(move || {
+        spawn_blocking!({
             // Check the next block.
             self_.ledger.check_next_block(&block)?;
             // Attempt to advance to the next block.
@@ -683,7 +684,88 @@ impl<N: Network> Sync<N> {
 
             Ok(())
         })
-        .await?
+    }
+
+    /// Helper function for [`Self::sync_storage_with_block`].
+    /// It syncs the batch certificates with the BFT, if the block's authority is a sub-DAG.
+    ///
+    /// Note that the block authority is always a sub-DAG in production; beacon signatures are only used for testing,
+    /// and as placeholder (irrelevant) block authority in the genesis block.i
+    async fn add_block_subdag_to_bft(&self, block: &Block<N>) -> Result<()> {
+        // Nothing to do if this is a beacon block
+        let Authority::Quorum(subdag) = block.authority() else {
+            return Ok(());
+        };
+
+        // Reconstruct the unconfirmed transactions.
+        let unconfirmed_transactions = cfg_iter!(block.transactions())
+            .filter_map(|tx| tx.to_unconfirmed_transaction().map(|unconfirmed| (unconfirmed.id(), unconfirmed)).ok())
+            .collect::<HashMap<_, _>>();
+
+        // Iterate over the certificates.
+        for certificates in subdag.values().cloned() {
+            cfg_into_iter!(certificates.clone()).for_each(|certificate| {
+                // Sync the batch certificate with the block.
+                self.storage.sync_certificate_with_block(block, certificate.clone(), &unconfirmed_transactions);
+            });
+
+            // Sync the BFT DAG with the certificates.
+            for certificate in certificates {
+                // If a BFT sender was provided, send the certificate to the BFT.
+                // For validators, BFT spawns a receiver task in `BFT::start_handlers`.
+                if let Some(bft_sender) = self.bft_sender.get() {
+                    let (callback_tx, callback_rx) = oneshot::channel();
+                    bft_sender
+                        .tx_sync_bft
+                        .send((certificate, callback_tx))
+                        .await
+                        .with_context(|| "Failed to sync certificate")?;
+                    callback_rx.await?.with_context(|| "Failed to sync certificate")?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Helper function for [`Self::sync_storage_with_block`].
+    ///
+    /// It checks that successor of a given block contains enough votes to commit it.
+    /// This can only return `Ok(true)` if the certificates of the block's successor were added to the storage.
+    fn is_block_availability_threshold_reached(&self, block: &PendingBlock<N>) -> Result<bool> {
+        // Fetch the leader certificate and the relevant rounds.
+        let leader_certificate = match block.authority() {
+            Authority::Quorum(subdag) => subdag.leader_certificate().clone(),
+            _ => bail!("Received a block with an unexpected authority type."),
+        };
+        let commit_round = leader_certificate.round();
+        let certificate_round =
+            commit_round.checked_add(1).ok_or_else(|| anyhow!("Integer overflow on round number"))?;
+
+        // Get the committee lookback for the round just after the leader.
+        let certificate_committee_lookback = self.ledger.get_committee_lookback_for_round(certificate_round)?;
+        // Retrieve all of the certificates for the round just after the leader.
+        let certificates = self.storage.get_certificates_for_round(certificate_round);
+        // Construct a set over the authors, at the round just after the leader,
+        // who included the leader's certificate in their previous certificate IDs.
+        let authors = certificates
+            .iter()
+            .filter_map(|c| match c.previous_certificate_ids().contains(&leader_certificate.id()) {
+                true => Some(c.author()),
+                false => None,
+            })
+            .collect();
+
+        // Check if the leader is ready to be committed.
+        if certificate_committee_lookback.is_availability_threshold_reached(&authors) {
+            trace!(
+                "Block {hash} at height {height} has reached availability threshold",
+                hash = block.hash(),
+                height = block.height()
+            );
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
     /// Advances the ledger by the given block and updates the storage accordingly.
@@ -692,209 +774,105 @@ impl<N: Network> Sync<N> {
     /// meets the voter availability threshold (i.e. > f voting stake)
     /// or is reachable via a DAG path from a later leader certificate that does.
     /// Since performing this check requires DAG certificates from later blocks,
-    /// the block is stored in `Sync::latest_block_responses`,
+    /// the block is stored in `Sync::pending_blocks`,
     /// and its addition to the ledger is deferred until the check passes.
-    /// Several blocks may be stored in `Sync::latest_block_responses`
+    /// Several blocks may be stored in `Sync::pending_blocks`
     /// before they can be all checked and added to the ledger.
-    async fn sync_storage_with_block(&self, block: Block<N>) -> Result<()> {
+    ///
+    /// # Usage
+    /// This function assumes that blocks are passed in order, i.e.,
+    /// that the given block is a direct successor of the block that was last passed to this function.
+    async fn sync_storage_with_block(&self, new_block: Block<N>) -> Result<()> {
         // Acquire the sync lock.
         let _lock = self.sync_lock.lock().await;
 
         // If this block has already been processed, return early.
         // TODO(kaimast): Should we remove the response here?
-        if self.ledger.contains_block_height(block.height()) {
-            debug!("Ledger is already synced with block at height {}. Will not sync.", block.height());
+        if self.ledger.contains_block_height(new_block.height()) {
+            debug!(
+                "Ledger is already synced with block at height {height}. Will not sync.",
+                height = new_block.height()
+            );
             return Ok(());
         }
 
-        // Acquire the latest block responses lock.
-        let mut latest_block_responses = self.latest_block_responses.lock().await;
+        // Append the certificates to the storage.
+        self.add_block_subdag_to_bft(&new_block).await?;
 
-        if latest_block_responses.contains_key(&block.height()) {
-            debug!("An unconfirmed block is queued already for height {}. Will not sync.", block.height());
-            return Ok(());
-        }
+        // Acquire the pending blocks lock.
+        let mut pending_blocks = self.pending_blocks.lock().await;
 
-        // If the block authority is a sub-DAG, then sync the batch certificates with the block.
-        // Note that the block authority is always a sub-DAG in production;
-        // beacon signatures are only used for testing,
-        // and as placeholder (irrelevant) block authority in the genesis block.
-        if let Authority::Quorum(subdag) = block.authority() {
-            // Reconstruct the unconfirmed transactions.
-            let unconfirmed_transactions = cfg_iter!(block.transactions())
-                .filter_map(|tx| {
-                    tx.to_unconfirmed_transaction().map(|unconfirmed| (unconfirmed.id(), unconfirmed)).ok()
-                })
-                .collect::<HashMap<_, _>>();
-
-            // Iterate over the certificates.
-            for certificates in subdag.values().cloned() {
-                cfg_into_iter!(certificates.clone()).for_each(|certificate| {
-                    // Sync the batch certificate with the block.
-                    self.storage.sync_certificate_with_block(&block, certificate.clone(), &unconfirmed_transactions);
-                });
-
-                // Sync the BFT DAG with the certificates.
-                for certificate in certificates {
-                    // If a BFT sender was provided, send the certificate to the BFT.
-                    // For validators, BFT spawns a receiver task in `BFT::start_handlers`.
-                    if let Some(bft_sender) = self.bft_sender.get() {
-                        // Await the callback to continue.
-                        if let Err(err) = bft_sender.send_sync_bft(certificate).await {
-                            bail!("Failed to sync certificate - {err}");
-                        };
-                    }
-                }
+        if let Some(tail) = pending_blocks.back() {
+            if tail.height() >= new_block.height() {
+                debug!(
+                    "A unconfirmed block is queued already for height {height}. \
+                    Will not sync.",
+                    height = new_block.height()
+                );
+                return Ok(());
             }
+
+            ensure_equals!(tail.height() + 1, new_block.height(), "Got an out-of-order block");
         }
 
         // Fetch the latest block height.
         let ledger_block_height = self.ledger.latest_block_height();
 
-        // Insert the latest block response.
-        latest_block_responses.insert(block.height(), block);
-        // Clear the latest block responses of older blocks.
-        latest_block_responses.retain(|height, _| *height > ledger_block_height);
+        // Clear any older pending blocks.
+        // TODO(kaimast): ensure there are no dangling block requests
+        while let Some(pending_block) = pending_blocks.front() {
+            if pending_block.height() > ledger_block_height {
+                break;
+            }
 
-        // Get a list of contiguous blocks from the latest block responses.
-        let contiguous_blocks: Vec<Block<N>> = (ledger_block_height.saturating_add(1)..)
-            .take_while(|&k| latest_block_responses.contains_key(&k))
-            .filter_map(|k| latest_block_responses.get(&k).cloned())
-            .collect();
+            pending_blocks.pop_front();
+        }
 
-        // Check if each block response, from the contiguous sequence just constructed,
-        // is ready to be added to the ledger.
-        // Ensure that the block's leader certificate meets the availability threshold
-        // based on the certificates in the DAG just after the block's round.
-        // If the availability threshold is not met,
-        // process the next block and check if it is linked to the current block,
-        // in the sense that there is a path in the DAG
-        // from the next block's leader certificate
-        // to the current block's leader certificate.
-        // Note: We do not advance to the most recent block response because we would be unable to
-        // validate if the leader certificate in the block has been certified properly.
-        for next_block in contiguous_blocks.into_iter() {
-            // Retrieve the height of the next block.
-            let next_block_height = next_block.height();
+        // Check the block against the chain of pending blocks and append it on success.
+        let new_block = self.ledger.check_block_subdag(new_block, pending_blocks.make_contiguous())?;
+        pending_blocks.push_back(new_block);
 
-            // Fetch the leader certificate and the relevant rounds.
-            let leader_certificate = match next_block.authority() {
-                Authority::Quorum(subdag) => subdag.leader_certificate().clone(),
-                _ => bail!("Received a block with an unexpected authority type."),
-            };
-            let commit_round = leader_certificate.round();
-            let certificate_round =
-                commit_round.checked_add(1).ok_or_else(|| anyhow!("Integer overflow on round number"))?;
+        // Now, figure out if and which pending block we can commit.
+        // To do this effectively and because commits are transitive,
+        // we iterate in reverse so that we can stop at the first successful check.
+        //
+        // Note, that if the storage already contains certificates for the round after new block,
+        // the availability threshold for the new block could also be reached.
+        let mut commit_height = None;
+        for block in pending_blocks.iter().rev() {
+            if self.is_block_availability_threshold_reached(block)? {
+                commit_height = Some(block.height());
+                break;
+            }
+        }
 
-            // Get the committee lookback for the round just after the leader.
-            let certificate_committee_lookback = self.ledger.get_committee_lookback_for_round(certificate_round)?;
-            // Retrieve all of the certificates for the round just after the leader.
-            let certificates = self.storage.get_certificates_for_round(certificate_round);
-            // Construct a set over the authors, at the round just after the leader,
-            // who included the leader's certificate in their previous certificate IDs.
-            let authors = certificates
-                .iter()
-                .filter_map(|c| match c.previous_certificate_ids().contains(&leader_certificate.id()) {
-                    true => Some(c.author()),
-                    false => None,
-                })
-                .collect();
+        if let Some(commit_height) = commit_height {
+            let start_height = ledger_block_height + 1;
+            ensure!(commit_height >= start_height, "Invalid commit height");
+            let num_blocks = (commit_height - start_height + 1) as usize;
 
-            debug!("Validating sync block {next_block_height} at round {commit_round}...");
-            // Check if the leader is ready to be committed.
-            if certificate_committee_lookback.is_availability_threshold_reached(&authors) {
-                // Initialize the current certificate.
-                let mut current_certificate = leader_certificate;
-                // Check if there are any linked blocks that need to be added.
-                let mut blocks_to_add = vec![next_block];
-
-                // Check if there are other blocks to process based on `is_linked`.
-                for height in (self.ledger.latest_block_height().saturating_add(1)..next_block_height).rev() {
-                    // Retrieve the previous block.
-                    let Some(previous_block) = latest_block_responses.get(&height) else {
-                        bail!("Block {height} is missing from the latest block responses.");
-                    };
-                    // Retrieve the previous block's leader certificate.
-                    let previous_certificate = match previous_block.authority() {
-                        Authority::Quorum(subdag) => subdag.leader_certificate().clone(),
-                        _ => bail!("Received a block with an unexpected authority type."),
-                    };
-                    // Determine if there is a path between the previous certificate and the current certificate.
-                    if self.is_linked(previous_certificate.clone(), current_certificate.clone())? {
-                        debug!("Previous sync block {height} is linked to the current block {next_block_height}");
-                        // Add the previous leader certificate to the list of certificates to commit.
-                        blocks_to_add.insert(0, previous_block.clone());
-                        // Update the current certificate to the previous leader certificate.
-                        current_certificate = previous_certificate;
-                    }
-                }
-
-                // Add the blocks to the ledger.
-                for block in blocks_to_add {
-                    // Check that the blocks are sequential and can be added to the ledger.
-                    let block_height = block.height();
-                    if block_height != self.ledger.latest_block_height().saturating_add(1) {
-                        warn!("Skipping block {block_height} from the latest block responses - not sequential.");
-                        continue;
-                    }
-                    #[cfg(feature = "telemetry")]
-                    let block_authority = block.authority().clone();
-
-                    let self_ = self.clone();
-                    tokio::task::spawn_blocking(move || {
-                        // Check the next block.
-                        self_.ledger.check_next_block(&block)?;
-                        // Attempt to advance to the next block.
-                        self_.ledger.advance_to_next_block(&block)?;
-
-                        // Sync the height with the block.
-                        self_.storage.sync_height_with_block(block.height());
-                        // Sync the round with the block.
-                        self_.storage.sync_round_with_block(block.round());
-
-                        Ok::<(), anyhow::Error>(())
-                    })
-                    .await??;
-                    // Remove the block height from the latest block responses.
-                    latest_block_responses.remove(&block_height);
-
-                    // Update the validator telemetry.
-                    #[cfg(feature = "telemetry")]
-                    if let Authority::Quorum(subdag) = block_authority {
-                        self_.gateway.validator_telemetry().insert_subdag(&subdag);
-                    }
-                }
-            } else {
-                debug!(
-                    "Availability threshold was not reached for block {next_block_height} at round {commit_round}. Checking next block..."
+            // Create a more detailed log message if we are committing more than one block at a time.
+            if num_blocks > 1 {
+                trace!(
+                    "Attempting to commit {chain_length} pending block(s) starting at height {start_height}.",
+                    chain_length = pending_blocks.len(),
                 );
             }
 
-            // Don't remove the response from BlockSync yet as we might fall back to non-BFT sync.
+            for pending_block in pending_blocks.drain(0..num_blocks) {
+                let hash = pending_block.hash();
+                let height = pending_block.height();
+                match self.ledger.check_block_content(pending_block) {
+                    Ok(block) => {
+                        trace!("Adding pending block {hash} at height {height} to the ledger");
+                        self.ledger.advance_to_next_block(&block)?;
+                    }
+                    Err(err) => bail!("Failed to check contents of pending block {hash} at height {height}: {err}"),
+                }
+            }
         }
 
         Ok(())
-    }
-
-    /// Returns `true` if there is a path from the previous certificate to the current certificate.
-    fn is_linked(
-        &self,
-        previous_certificate: BatchCertificate<N>,
-        current_certificate: BatchCertificate<N>,
-    ) -> Result<bool> {
-        // Initialize the list containing the traversal.
-        let mut traversal = vec![current_certificate.clone()];
-        // Iterate over the rounds from the current certificate to the previous certificate.
-        for round in (previous_certificate.round()..current_certificate.round()).rev() {
-            // Retrieve all of the certificates for this past round.
-            let certificates = self.storage.get_certificates_for_round(round);
-            // Filter the certificates to only include those that are in the traversal.
-            traversal = certificates
-                .into_iter()
-                .filter(|p| traversal.iter().any(|c| c.previous_certificate_ids().contains(&p.id())))
-                .collect();
-        }
-        Ok(traversal.contains(&previous_certificate))
     }
 }
 
@@ -1042,12 +1020,23 @@ mod tests {
     type CurrentLedger = Ledger<CurrentNetwork, ConsensusMemory<CurrentNetwork>>;
     type CurrentConsensusStore = ConsensusStore<CurrentNetwork, ConsensusMemory<CurrentNetwork>>;
 
+    /// Tests that commits work as expected when some anchors are not committed immediately.
     #[tokio::test]
-    async fn test_commit_via_is_linked() -> anyhow::Result<()> {
+    async fn test_commit_chain() -> anyhow::Result<()> {
         let rng = &mut TestRng::default();
         // Initialize the round parameters.
         let max_gc_rounds = BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS as u64;
-        let commit_round = 2;
+
+        // The first round of the first block.
+        let first_round = 1;
+        // The total number of blocks we test
+        let num_blocks = 3;
+        // The number of certificate rounds needed.
+        // There is one additional round to provide availability for the inal block.
+        let num_rounds = first_round + num_blocks * 2 + 1;
+        // The first round that has at least N-f certificates referencing the anchor from the previous round.
+        // This is also the last round we use in the test.
+        let first_committed_round = num_rounds - 1;
 
         // Initialize the store.
         let store = CurrentConsensusStore::open(StorageMode::new_test(None)).unwrap();
@@ -1090,77 +1079,70 @@ mod tests {
                 HashMap::new();
             let mut previous_certificates: IndexSet<BatchCertificate<CurrentNetwork>> = IndexSet::with_capacity(4);
 
-            for round in 0..=commit_round + 8 {
+            for round in first_round..=first_committed_round {
                 let mut current_certificates = IndexSet::new();
                 let previous_certificate_ids: IndexSet<_> = if round == 0 || round == 1 {
                     IndexSet::new()
                 } else {
                     previous_certificates.iter().map(|c| c.id()).collect()
                 };
+
                 let committee_id = committee.id();
+                let prev_leader = committee.get_leader(round - 1).unwrap();
 
-                // Create a certificate for the leader.
-                if round <= 5 {
-                    let leader = committee.get_leader(round).unwrap();
-                    let leader_index = addresses.iter().position(|&address| address == leader).unwrap();
-                    let non_leader_index = addresses.iter().position(|&address| address != leader).unwrap();
-                    for i in [leader_index, non_leader_index].into_iter() {
-                        let batch_header = BatchHeader::new(
-                            &private_keys[i],
-                            round,
-                            now(),
-                            committee_id,
-                            Default::default(),
-                            previous_certificate_ids.clone(),
-                            rng,
-                        )
-                        .unwrap();
-                        // Sign the batch header.
-                        let mut signatures = IndexSet::with_capacity(4);
-                        for (j, private_key_2) in private_keys.iter().enumerate() {
-                            if i != j {
-                                signatures.insert(private_key_2.sign(&[batch_header.batch_id()], rng).unwrap());
-                            }
+                // For the first two blocks non-leaders will not reference the leader certificate.
+                // This means, while there is an anchor, it is isn't committed
+                // until later.
+                for (i, private_key) in private_keys.iter().enumerate() {
+                    let leader_index = addresses.iter().position(|&address| address == prev_leader).unwrap();
+                    let is_certificate_round = round % 2 == 1;
+                    let is_leader = i == leader_index;
+
+                    let previous_certs = if round < first_committed_round && is_certificate_round && !is_leader {
+                        previous_certificate_ids
+                            .iter()
+                            .cloned()
+                            .enumerate()
+                            .filter(|(idx, _)| *idx != leader_index)
+                            .map(|(_, id)| id)
+                            .collect()
+                    } else {
+                        previous_certificate_ids.clone()
+                    };
+
+                    let batch_header = BatchHeader::new(
+                        private_key,
+                        round,
+                        now(),
+                        committee_id,
+                        Default::default(),
+                        previous_certs,
+                        rng,
+                    )
+                    .unwrap();
+
+                    // Sign the batch header.
+                    let mut signatures = IndexSet::with_capacity(4);
+                    for (j, private_key_2) in private_keys.iter().enumerate() {
+                        if i != j {
+                            signatures.insert(private_key_2.sign(&[batch_header.batch_id()], rng).unwrap());
                         }
-                        current_certificates.insert(BatchCertificate::from(batch_header, signatures).unwrap());
                     }
+                    current_certificates.insert(BatchCertificate::from(batch_header, signatures).unwrap());
                 }
 
-                // Create a certificate for each validator.
-                if round > 5 {
-                    for (i, private_key_1) in private_keys.iter().enumerate() {
-                        let batch_header = BatchHeader::new(
-                            private_key_1,
-                            round,
-                            now(),
-                            committee_id,
-                            Default::default(),
-                            previous_certificate_ids.clone(),
-                            rng,
-                        )
-                        .unwrap();
-                        // Sign the batch header.
-                        let mut signatures = IndexSet::with_capacity(4);
-                        for (j, private_key_2) in private_keys.iter().enumerate() {
-                            if i != j {
-                                signatures.insert(private_key_2.sign(&[batch_header.batch_id()], rng).unwrap());
-                            }
-                        }
-                        current_certificates.insert(BatchCertificate::from(batch_header, signatures).unwrap());
-                    }
-                }
                 // Update the map of certificates.
                 round_to_certificates_map.insert(round, current_certificates.clone());
-                previous_certificates = current_certificates.clone();
+                previous_certificates = current_certificates;
             }
             (round_to_certificates_map, committee)
         };
 
         // Initialize the storage.
         let storage = Storage::new(core_ledger.clone(), Arc::new(BFTMemoryService::new()), max_gc_rounds);
-        // Insert certificates into storage.
+        // Insert all certificates into storage.
         let mut certificates: Vec<BatchCertificate<CurrentNetwork>> = Vec::new();
-        for i in 1..=commit_round + 8 {
+        for i in first_round..=first_committed_round {
             let c = (*round_to_certificates_map.get(&i).unwrap()).clone();
             certificates.extend(c);
         }
@@ -1168,94 +1150,61 @@ mod tests {
             storage.testing_only_insert_certificate_testing_only(certificate.clone());
         }
 
-        // Create block 1.
-        let leader_round_1 = commit_round;
-        let leader_1 = committee.get_leader(leader_round_1).unwrap();
-        let leader_certificate = storage.get_certificate_for_round_with_author(commit_round, leader_1).unwrap();
-        let block_1 = {
+        // Create the blocks
+        let mut previous_leader_cert = None;
+        let mut blocks = vec![];
+
+        for block_height in 1..=num_blocks {
+            let leader_round = block_height * 2;
+
+            let leader = committee.get_leader(leader_round).unwrap();
+            let leader_certificate = storage.get_certificate_for_round_with_author(leader_round, leader).unwrap();
+
             let mut subdag_map: BTreeMap<u64, IndexSet<BatchCertificate<CurrentNetwork>>> = BTreeMap::new();
             let mut leader_cert_map = IndexSet::new();
             leader_cert_map.insert(leader_certificate.clone());
-            let mut previous_cert_map = IndexSet::new();
-            for cert in storage.get_certificates_for_round(commit_round - 1) {
-                previous_cert_map.insert(cert);
+
+            let previous_cert_map = storage.get_certificates_for_round(leader_round - 1);
+
+            subdag_map.insert(leader_round, leader_cert_map.clone());
+            subdag_map.insert(leader_round - 1, previous_cert_map.clone());
+
+            if leader_round > 2 {
+                let previous_commit_cert_map: IndexSet<_> = storage
+                    .get_certificates_for_round(leader_round - 2)
+                    .into_iter()
+                    .filter(|cert| {
+                        if let Some(previous_leader_cert) = &previous_leader_cert {
+                            cert != previous_leader_cert
+                        } else {
+                            true
+                        }
+                    })
+                    .collect();
+                subdag_map.insert(leader_round - 2, previous_commit_cert_map);
             }
-            subdag_map.insert(commit_round, leader_cert_map.clone());
-            subdag_map.insert(commit_round - 1, previous_cert_map.clone());
+
             let subdag = Subdag::from(subdag_map.clone())?;
-            let ledger = core_ledger.clone();
-            spawn_blocking!(ledger.prepare_advance_to_next_quorum_block(subdag, Default::default()))?
-        };
-        // Insert block 1.
-        let ledger = core_ledger.clone();
-        let block = block_1.clone();
-        spawn_blocking!(ledger.advance_to_next_block(&block))?;
+            let block = core_ledger.prepare_advance_to_next_quorum_block(subdag, Default::default())?;
 
-        // Create block 2.
-        let leader_round_2 = commit_round + 2;
-        let leader_2 = committee.get_leader(leader_round_2).unwrap();
-        let leader_certificate_2 = storage.get_certificate_for_round_with_author(leader_round_2, leader_2).unwrap();
-        let block_2 = {
-            let mut subdag_map_2: BTreeMap<u64, IndexSet<BatchCertificate<CurrentNetwork>>> = BTreeMap::new();
-            let mut leader_cert_map_2 = IndexSet::new();
-            leader_cert_map_2.insert(leader_certificate_2.clone());
-            let mut previous_cert_map_2 = IndexSet::new();
-            for cert in storage.get_certificates_for_round(leader_round_2 - 1) {
-                previous_cert_map_2.insert(cert);
-            }
-            let mut prev_commit_cert_map_2 = IndexSet::new();
-            for cert in storage.get_certificates_for_round(leader_round_2 - 2) {
-                if cert != leader_certificate {
-                    prev_commit_cert_map_2.insert(cert);
-                }
-            }
-            subdag_map_2.insert(leader_round_2, leader_cert_map_2.clone());
-            subdag_map_2.insert(leader_round_2 - 1, previous_cert_map_2.clone());
-            subdag_map_2.insert(leader_round_2 - 2, prev_commit_cert_map_2.clone());
-            let subdag_2 = Subdag::from(subdag_map_2.clone())?;
-            let ledger = core_ledger.clone();
-            spawn_blocking!(ledger.prepare_advance_to_next_quorum_block(subdag_2, Default::default()))?
-        };
-        // Insert block 2.
-        let ledger = core_ledger.clone();
-        let block = block_2.clone();
-        spawn_blocking!(ledger.advance_to_next_block(&block))?;
+            previous_leader_cert = Some(leader_certificate);
 
-        // Create block 3
-        let leader_round_3 = commit_round + 4;
-        let leader_3 = committee.get_leader(leader_round_3).unwrap();
-        let leader_certificate_3 = storage.get_certificate_for_round_with_author(leader_round_3, leader_3).unwrap();
-        let block_3 = {
-            let mut subdag_map_3: BTreeMap<u64, IndexSet<BatchCertificate<CurrentNetwork>>> = BTreeMap::new();
-            let mut leader_cert_map_3 = IndexSet::new();
-            leader_cert_map_3.insert(leader_certificate_3.clone());
-            let mut previous_cert_map_3 = IndexSet::new();
-            for cert in storage.get_certificates_for_round(leader_round_3 - 1) {
-                previous_cert_map_3.insert(cert);
-            }
-            let mut prev_commit_cert_map_3 = IndexSet::new();
-            for cert in storage.get_certificates_for_round(leader_round_3 - 2) {
-                if cert != leader_certificate_2 {
-                    prev_commit_cert_map_3.insert(cert);
-                }
-            }
-            subdag_map_3.insert(leader_round_3, leader_cert_map_3.clone());
-            subdag_map_3.insert(leader_round_3 - 1, previous_cert_map_3.clone());
-            subdag_map_3.insert(leader_round_3 - 2, prev_commit_cert_map_3.clone());
-            let subdag_3 = Subdag::from(subdag_map_3.clone())?;
-            let ledger = core_ledger.clone();
-            spawn_blocking!(ledger.prepare_advance_to_next_quorum_block(subdag_3, Default::default()))?
-        };
-        // Insert block 3.
-        let ledger = core_ledger.clone();
-        let block = block_3.clone();
-        spawn_blocking!(ledger.advance_to_next_block(&block))?;
+            core_ledger.advance_to_next_block(&block)?;
+            blocks.push(block);
+        }
 
-        // Initialize the syncing ledger.
-        let syncing_ledger = spawn_blocking!(CurrentLedger::load(genesis, StorageMode::new_test(None))).unwrap();
-        let syncing_ledger = Arc::new(CoreLedgerService::new(syncing_ledger, Default::default()));
-        // Initialize the gateway.
-        let storage_mode = StorageMode::new_test(None);
+        // ### Test that sync works as expected ###
+        let storage_mode = StorageMode::Test(None);
+
+        // Create a new ledger to test with, but use the existing storage
+        // so that the certificates exist.
+        let syncing_ledger = {
+            let storage_mode = storage_mode.clone();
+            let syncing_ledger = spawn_blocking!(CurrentLedger::load(genesis, storage_mode)).unwrap();
+            Arc::new(CoreLedgerService::new(syncing_ledger, Default::default()))
+        };
+
+        // Set up sync and its dependencies.
         let gateway = Gateway::new(
             account.clone(),
             storage.clone(),
@@ -1266,19 +1215,25 @@ mod tests {
             storage_mode,
             None,
         )?;
-        // Initialize the block synchronization logic.
         let block_sync = Arc::new(BlockSync::new(syncing_ledger.clone()));
-        // Initialize the sync module.
-        let sync = Sync::new(gateway, storage, syncing_ledger.clone(), block_sync);
-        // Try to sync block 1.
-        sync.sync_storage_with_block(block_1).await?;
-        assert_eq!(syncing_ledger.latest_block_height(), 1);
-        // Try to sync block 2.
-        sync.sync_storage_with_block(block_2).await?;
-        assert_eq!(syncing_ledger.latest_block_height(), 2);
-        // Try to sync block 3.
-        sync.sync_storage_with_block(block_3).await?;
+        let sync = Sync::new(gateway.clone(), storage.clone(), syncing_ledger.clone(), block_sync);
+
+        let mut block_iter = blocks.into_iter();
+
+        // Insert the blocks into the new sync module
+        for _ in 0..num_blocks - 1 {
+            let block = block_iter.next().unwrap();
+            sync.sync_storage_with_block(block).await?;
+
+            // Availability threshold is not met, so we should not advance yet.
+            assert_eq!(syncing_ledger.latest_block_height(), 0);
+        }
+
+        // Only for the final block, the availability threshold is met,
+        // because certificates for the subsequent round are already in storage.
+        sync.sync_storage_with_block(block_iter.next().unwrap()).await?;
         assert_eq!(syncing_ledger.latest_block_height(), 3);
+
         // Ensure blocks 1 and 2 were added to the ledger.
         assert!(syncing_ledger.contains_block_height(1));
         assert!(syncing_ledger.contains_block_height(2));
@@ -1287,7 +1242,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[tracing_test::traced_test]
     async fn test_pending_certificates() -> anyhow::Result<()> {
         let rng = &mut TestRng::default();
         // Initialize the round parameters.

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -26,7 +26,7 @@ use snarkos_node_bft_ledger_service::LedgerService;
 use snarkvm::{
     console::prelude::*,
     ledger::{
-        block::Transaction,
+        Transaction,
         narwhal::{BatchHeader, Data, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
     },
@@ -560,7 +560,8 @@ mod tests {
     use snarkvm::{
         console::{network::Network, types::Field},
         ledger::{
-            block::Block,
+            Block,
+            PendingBlock,
             committee::Committee,
             narwhal::{BatchCertificate, Subdag, Transmission, TransmissionID},
             test_helpers::sample_execution_transaction_with_fee,
@@ -626,6 +627,8 @@ mod tests {
                 transaction_id: N::TransactionID,
                 transaction: Transaction<N>,
             ) -> Result<()>;
+            fn check_block_subdag(&self, _block: Block<N>, _prefix: &[PendingBlock<N>]) -> Result<PendingBlock<N>>;
+            fn check_block_content(&self, _block: PendingBlock<N>) -> Result<Block<N>>;
             fn check_next_block(&self, block: &Block<N>) -> Result<()>;
             fn prepare_advance_to_next_quorum_block(
                 &self,

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -32,6 +32,7 @@ use snarkvm::{
     },
 };
 
+use anyhow::Context;
 use colored::Colorize;
 use indexmap::{IndexMap, IndexSet};
 #[cfg(feature = "locktick")]
@@ -508,12 +509,25 @@ impl<N: Network> Worker<N> {
             );
         }
         // Wait for the transmission to be fetched.
-        match timeout(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS), callback_receiver).await {
-            // If the transmission was fetched, return it.
-            Ok(result) => Ok((transmission_id, result?)),
-            // If the transmission was not fetched, return an error.
-            Err(e) => bail!("Unable to fetch transmission - (timeout) {e}"),
-        }
+
+        let transmission = timeout(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS), callback_receiver)
+            .await
+            .with_context(|| {
+                format!(
+                    "Unable to fetch transmission {}.{} (timeout)",
+                    fmt_id(transmission_id),
+                    fmt_id(transmission_id.checksum().unwrap_or_default())
+                )
+            })?
+            .with_context(|| {
+                format!(
+                    "Unable to fetch transmission {}.{}",
+                    fmt_id(transmission_id),
+                    fmt_id(transmission_id.checksum().unwrap_or_default())
+                )
+            })?;
+
+        Ok((transmission_id, transmission))
     }
 
     /// Handles the incoming transmission response.

--- a/node/bft/storage-service/src/persistent.rs
+++ b/node/bft/storage-service/src/persistent.rs
@@ -118,7 +118,8 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
         }
     }
 
-    /// Returns the missing transmissions in storage from the given transmissions.
+    /// Takes a certificate and its transmissions, and returns the subset of transmissions that
+    /// did not yet exists in the storage.
     fn find_missing_transmissions(
         &self,
         batch_header: &BatchHeader<N>,

--- a/node/bft/storage-service/src/traits.rs
+++ b/node/bft/storage-service/src/traits.rs
@@ -32,7 +32,8 @@ pub trait StorageService<N: Network>: Debug + Send + Sync {
     /// If the transmission ID does not exist in storage, `None` is returned.
     fn get_transmission(&self, transmission_id: TransmissionID<N>) -> Option<Transmission<N>>;
 
-    /// Returns the missing transmissions in storage from the given transmissions.
+    /// Takes a certificate and its transmissions, and returns the subset of transmissions that
+    /// did not yet exists in the storage.
     fn find_missing_transmissions(
         &self,
         batch_header: &BatchHeader<N>,

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -355,13 +355,16 @@ impl<N: Network> Consensus<N> {
                     fmt_id(solution_id)
                 ),
                 Err(err) => {
-                    // If the node is synced and the occurs after the first 10 blocks of an epoch, log it as a warning, otherwise ignore.
+                    let err = err.context(format!(
+                        "Unable to add unconfirmed solution '{}' to the memory pool",
+                        fmt_id(solution_id)
+                    ));
+
+                    // If the node is synced and the occurs after the first 10 blocks of an epoch, log it as a warning, otherwise trace it.
                     if self.bft.is_synced() && self.ledger.latest_block_height() % N::NUM_BLOCKS_PER_EPOCH > 10 {
-                        let err = err.context(format!(
-                            "Unable to add unconfirmed solution '{}' to the memory pool",
-                            fmt_id(solution_id)
-                        ));
                         warn!("{}", flatten_error(err));
+                    } else {
+                        trace!("{}", flatten_error(err));
                     }
                 }
             }

--- a/node/network/src/peering.rs
+++ b/node/network/src/peering.rs
@@ -169,23 +169,33 @@ pub trait PeerPoolHandling<N: Network>: P2P {
     }
 
     /// Downgrades a connected peer to candidate status.
-    fn downgrade_peer_to_candidate(&self, listener_addr: SocketAddr) {
-        if let Some(peer) = self.peer_pool().write().get_mut(&listener_addr) {
-            if let Peer::Connected(peer) = peer {
-                // Exception: the BootstrapClient only has a single Resolver,
-                // so it may only map a validator's Aleo address once, for its
-                // Gateway-mode connection. This also means that the Router-mode
-                // connection may not remove that mapping.
-                let aleo_addr = if self.node_type() == NodeType::BootstrapClient
-                    && peer.connection_mode == ConnectionMode::Router
-                {
-                    None
-                } else {
-                    Some(peer.aleo_addr)
-                };
-                self.resolver().write().remove_peer(peer.connected_addr, aleo_addr);
-            }
+    ///
+    /// Returns true if the peer was fully connected.
+    fn downgrade_peer_to_candidate(&self, listener_addr: SocketAddr) -> bool {
+        let mut peer_pool = self.peer_pool().write();
+        let Some(peer) = peer_pool.get_mut(&listener_addr) else {
+            trace!("{} Downgrade peer to candidate failed - peer not found", Self::OWNER);
+            return false;
+        };
+
+        if let Peer::Connected(conn_peer) = peer {
+            // Exception: the BootstrapClient only has a single Resolver,
+            // so it may only map a validator's Aleo address once, for its
+            // Gateway-mode connection. This also means that the Router-mode
+            // connection may not remove that mapping.
+            let aleo_addr = if self.node_type() == NodeType::BootstrapClient
+                && conn_peer.connection_mode == ConnectionMode::Router
+            {
+                None
+            } else {
+                Some(conn_peer.aleo_addr)
+            };
+            self.resolver().write().remove_peer(conn_peer.connected_addr, aleo_addr);
             peer.downgrade_to_candidate(listener_addr);
+            true
+        } else {
+            peer.downgrade_to_candidate(listener_addr);
+            false
         }
     }
 

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -146,7 +146,7 @@ impl<N: Network> Router<N> {
     /// The minimum permitted interval between connection attempts for an IP; anything shorter is considered malicious.
     #[cfg(not(feature = "test"))]
     const CONNECTION_ATTEMPTS_SINCE_SECS: i64 = 10;
-    /// The maximum amount of connection attempts within a 10 second threshold
+    /// The maximum amount of connection attempts within a 10 second threshold.
     #[cfg(not(feature = "test"))]
     const MAX_CONNECTION_ATTEMPTS: usize = 10;
     /// The duration after which a connected peer is considered inactive or

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -86,7 +86,9 @@ impl<N: Network, C: ConsensusStorage<N>> Disconnect for Client<N, C> {
     async fn handle_disconnect(&self, peer_addr: SocketAddr) {
         if let Some(peer_ip) = self.router.resolve_to_listener(peer_addr) {
             self.sync.remove_peer(&peer_ip);
+
             self.router.downgrade_peer_to_candidate(peer_ip);
+
             // Clear cached entries applicable to the peer.
             self.router.cache().clear_peer_entries(peer_ip);
             #[cfg(feature = "metrics")]

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -81,8 +81,14 @@ impl<N: Network, C: ConsensusStorage<N>> Disconnect for Validator<N, C> {
     /// Any extra operations to be performed during a disconnect.
     async fn handle_disconnect(&self, peer_addr: SocketAddr) {
         if let Some(peer_ip) = self.router.resolve_to_listener(peer_addr) {
-            self.sync.remove_peer(&peer_ip);
-            self.router.downgrade_peer_to_candidate(peer_ip);
+            let was_connected = self.router.downgrade_peer_to_candidate(peer_ip);
+
+            // Only remove the peer from sync if the handshake was successful.
+            // This handles the cases where a validator unsuccessfully tries to connect to another validator using the router.
+            if was_connected {
+                self.sync.remove_peer(&peer_ip);
+            }
+
             // Clear cached entries applicable to the peer.
             self.router.cache().clear_peer_entries(peer_ip);
             #[cfg(feature = "metrics")]

--- a/node/sync/src/block_sync/helpers.rs
+++ b/node/sync/src/block_sync/helpers.rs
@@ -17,38 +17,36 @@
 ///
 /// The function expects the input to already be sorted.
 pub fn rangify_heights(heights: &[u32]) -> String {
-    // This impl assumes that the heights are sorted and non-empty.
     let mut iter = heights.iter().copied().peekable();
-    let Some(mut curr_height) = iter.next() else {
-        return String::from("[]");
-    };
-
     let mut ret = String::from("[");
+    let mut first = true;
 
     while let Some(next_height) = iter.next() {
-        if next_height == curr_height + 1 {
-            ret.push_str(&format!("{curr_height}-"));
-            curr_height = next_height;
-            while let Some(next_height) = iter.peek().copied() {
-                if next_height == curr_height + 1 {
-                    curr_height += 1;
-                    let _ = iter.next();
-                } else {
-                    break;
-                }
-            }
-            ret.push_str(&format!("{curr_height}, "));
-            let Some(next_height) = iter.next() else {
+        let start = next_height;
+        let mut curr_height = start;
+
+        while let Some(next_height) = iter.peek().copied() {
+            if next_height == curr_height + 1 {
+                curr_height += 1;
+                let _ = iter.next();
+            } else {
                 break;
-            };
-            curr_height = next_height;
+            }
+        }
+
+        if first {
+            first = false;
         } else {
-            ret.push_str(&format!("{curr_height}, "));
-            curr_height = next_height;
+            ret.push_str(", ");
+        }
+
+        if curr_height == start {
+            ret.push_str(&format!("{curr_height}"));
+        } else {
+            ret.push_str(&format!("{start}-{curr_height}"));
         }
     }
 
-    let mut ret = ret.trim_end_matches(", ").to_owned();
     ret.push(']');
     ret
 }
@@ -63,6 +61,14 @@ mod tests {
 
         let rangified = rangify_heights(heights);
         assert_eq!(rangified, "[]");
+    }
+
+    #[test]
+    fn test_rangify_heights_single_value() {
+        let heights = &[52425];
+
+        let rangified = rangify_heights(heights);
+        assert_eq!(rangified, "[52425]");
     }
 
     #[test]


### PR DESCRIPTION
This PR aims to fix #3911. It does so by pausing block sync when the BFT commits a new leader certificate. This "pausing" is achieved through an existing `sync_lock`.

Other minor changes in this PR:
* Adjusted`build.rs` to work correctly with MutexGuards.
* Removed the `response_lock` in block sync, as the changes in #3810 already ensure that there is always exactly one task processing responses.
* Error logging improvements in `primary.rs`.