### PR TITLE
[Build] Add `cargo audit` exception for unmaintained `number_prefix` crate

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -7,4 +7,6 @@ ignore = [
   "RUSTSEC-2025-0057",
   # TODO remove once newer versions of tracing-sbuscriber support colored logs again.
   "RUSTSEC-2025-0055",
+  # TODO remove once `self_update` updates its dependency for `indicatif`.
+  "RUSTSEC-2025-0119",
 ]


### PR DESCRIPTION
## Motivation

`cargo audit` started throwing a warning for the `number_prefix` crate.

```
~> cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 873 security advisories (from /Users/kaimast/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (636 crate dependencies)
Crate:     number_prefix
Version:   0.4.0
Warning:   unmaintained
Title:     number_prefix crate is unmaintained
Date:      2025-11-17
ID:        RUSTSEC-2025-0119
URL:       https://rustsec.org/advisories/RUSTSEC-2025-0119
Dependency tree:
number_prefix 0.4.0
└── indicatif 0.17.11
    └── self_update 0.42.0
        └── snarkos-cli 4.3.0
            └── snarkos 4.3.0
```

I already filed [an issue](https://github.com/jaemk/self_update/issues/162) with `self_update` to update to `indicatif` 0.18, which does not use the unmaintained crate anymore. Until then, we should ignore this warning.


## Test Plan

This should be fine to merge without any further testing, assuming CI passes.