### PR TITLE
[Fix] TCP edge cases

### DIFF
--- a/node/tcp/src/helpers/connections.rs
+++ b/node/tcp/src/helpers/connections.rs
@@ -15,7 +15,7 @@
 
 //! Objects associated with connection handling.
 
-use std::{collections::HashMap, net::SocketAddr, ops::Not};
+use std::{collections::HashMap, net::SocketAddr, ops::Not, sync::atomic::AtomicBool};
 
 #[cfg(feature = "locktick")]
 use locktick::parking_lot::RwLock;
@@ -33,7 +33,7 @@ use crate::protocols::{Handshake, Reading, Writing};
 
 /// A map of all currently connected addresses to their associated connection.
 #[derive(Default)]
-pub(crate) struct Connections(RwLock<HashMap<SocketAddr, Connection>>);
+pub(crate) struct Connections(pub(crate) RwLock<HashMap<SocketAddr, Connection>>);
 
 impl Connections {
     /// Adds the given connection to the list of active connections.
@@ -85,6 +85,8 @@ pub struct Connection {
     pub(crate) writer: Option<Box<dyn AW>>,
     /// Used to notify the [`Reading`] protocol that the connection is fully ready.
     pub(crate) readiness_notifier: Option<oneshot::Sender<()>>,
+    /// Prevents the OnDisconnect hook from being triggered multiple times.
+    pub(crate) disconnecting: AtomicBool,
     /// Handles to tasks spawned for the connection.
     pub(crate) tasks: Vec<JoinHandle<()>>,
 }
@@ -98,6 +100,7 @@ impl Connection {
             reader: None,
             writer: None,
             readiness_notifier: None,
+            disconnecting: Default::default(),
             side,
             tasks: Default::default(),
         }

--- a/node/tcp/src/protocols/reading.rs
+++ b/node/tcp/src/protocols/reading.rs
@@ -175,6 +175,9 @@ impl<R: Reading> ReadingInternal for R {
                         if let Err(e) = inbound_message_sender.try_send(msg) {
                             error!(parent: node.span(), "can't process a message from {addr}: {e}");
                             node.stats().register_failure();
+                            if matches!(e, mpsc::error::TrySendError::Closed(_)) {
+                                break;
+                            }
                         }
                         #[cfg(feature = "metrics")]
                         metrics::increment_gauge(metrics::tcp::TCP_TASKS, 1f64);

--- a/node/tcp/src/tcp.rs
+++ b/node/tcp/src/tcp.rs
@@ -302,12 +302,21 @@ impl Tcp {
     ///
     /// Returns true if the we were connected to the given address.
     pub async fn disconnect(&self, addr: SocketAddr) -> bool {
-        if let Some(handler) = self.protocols.disconnect.get() {
-            if self.is_connected(addr) {
-                let (sender, receiver) = oneshot::channel();
-                handler.trigger((addr, sender));
-                let _ = receiver.await; // can't really fail
+        // claim the disconnect to avoid duplicate executions, or return early if already claimed
+        if let Some(conn) = self.connections.0.read().get(&addr) {
+            if conn.disconnecting.swap(true, Relaxed) {
+                // valid connection, but someone else is already disconnecting it
+                return false;
             }
+        } else {
+            // not connected
+            return false;
+        };
+
+        if let Some(handler) = self.protocols.disconnect.get() {
+            let (sender, receiver) = oneshot::channel();
+            handler.trigger((addr, sender));
+            let _ = receiver.await; // can't really fail
         }
 
         let conn = self.connections.remove(addr);


### PR DESCRIPTION
This PR handles 2 edge cases:
- https://github.com/ProvableHQ/snarkOS/commit/dc6ab50d2e30ccc75b9c7e4565cc83faa539946f - use an atomic to ensure that duplicate concurrent calls to `Tcp::disconnect` won't trigger the behavior defined in `Disconnect`
- https://github.com/ProvableHQ/snarkOS/commit/7d89f298bd73c792681a988c2f8682000fc63ec5 - drop the stream reading task in case the message processing task (to be more specific, `Reading::process_message`) panics, in order to avoid a connection/memory leak