### PR TITLE
[Feat] Add 2 new REST routes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "b176b1409"
+git = "https://github.com/ljedrz/snarkVM.git"
+branch = "feat/record_queries"
 #version = "=4.4.0"
 default-features = false
 

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -177,6 +177,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route("/block/height/latest", get(Self::get_block_height_latest))
             .route("/block/hash/latest", get(Self::get_block_hash_latest))
             .route("/block/latest", get(Self::get_block_latest))
+            .route("/block/{height}/record_count", get(Self::get_number_of_block_records))
             .route("/block/{height_or_hash}", get(Self::get_block))
             // The path param here is actually only the height, but the name must match the route
             // above, otherwise there'll be a conflict at runtime.
@@ -223,6 +224,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             // GET misc endpoints.
             .route("/version", get(Self::get_version))
             .route("/blocks", get(Self::get_blocks))
+            .route("/record_count", get(Self::get_number_of_records))
             .route("/height/{hash}", get(Self::get_height))
             .route("/memoryPool/transmissions", get(Self::get_memory_pool_transmissions))
             .route("/memoryPool/solutions", get(Self::get_memory_pool_solutions))

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -936,4 +936,21 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             None => Err(RestError::service_unavailable(anyhow!("Route isn't available for this node type"))),
         }
     }
+
+    /// GET /{network}/record_count
+    pub(crate) async fn get_number_of_records(State(rest): State<Self>) -> ErasedJson {
+        let (input, output) = rest.ledger.get_record_count();
+        ErasedJson::pretty(format!("input: {input}, output: {output}"))
+    }
+
+    /// GET /{network}/{block}/record_count
+    pub(crate) async fn get_number_of_block_records(
+        State(rest): State<Self>,
+        Path(height): Path<u32>,
+    ) -> Result<ErasedJson, RestError> {
+        match rest.ledger.get_num_block_records(height) {
+            Ok((input, output)) => Ok(ErasedJson::pretty(format!("input: {input}, output: {output}"))),
+            Err(_) => Err(RestError::not_found(anyhow!("Records for block {height} couldn't be found"))),
+        }
+    }
 }

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -939,8 +939,8 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
 
     /// GET /{network}/record_count
     pub(crate) async fn get_number_of_records(State(rest): State<Self>) -> ErasedJson {
-        let (input, output) = rest.ledger.get_record_count();
-        ErasedJson::pretty(format!("input: {input}, output: {output}"))
+        let record_counts = rest.ledger.get_record_count();
+        ErasedJson::pretty(record_counts)
     }
 
     /// GET /{network}/{block}/record_count
@@ -949,7 +949,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Path(height): Path<u32>,
     ) -> Result<ErasedJson, RestError> {
         match rest.ledger.get_num_block_records(height) {
-            Ok((input, output)) => Ok(ErasedJson::pretty(format!("input: {input}, output: {output}"))),
+            Ok(record_counts) => Ok(ErasedJson::pretty(record_counts)),
             Err(_) => Err(RestError::not_found(anyhow!("Records for block {height} couldn't be found"))),
         }
     }


### PR DESCRIPTION
The snarkOS counterpart to https://github.com/ProvableHQ/snarkVM/pull/3047.

Filing as a draft due to the corresponding snarkVM branch not having been merged yet.