### PR TITLE
[Logs] Do not show debug logs on lowest verbosity level

### DIFF
--- a/cli/src/helpers/logger.rs
+++ b/cli/src/helpers/logger.rs
@@ -45,21 +45,29 @@ fn parse_log_verbosity(verbosity: u8) -> Result<EnvFilter> {
     // Now, set rules for specific crates.
     let filter = if verbosity >= 2 {
         filter.add_directive("snarkos_node_sync=trace".parse().unwrap())
-    } else {
+    } else if verbosity >= 1 {
         filter.add_directive("snarkos_node_sync=debug".parse().unwrap())
+    } else {
+        filter
     };
 
     let filter = if verbosity >= 3 {
-        filter
-            .add_directive("snarkos_node_bft=trace".parse().unwrap())
-            .add_directive("snarkos_node_bft::gateway=debug".parse().unwrap())
-    } else {
+        filter.add_directive("snarkos_node_bft=trace".parse().unwrap())
+    } else if verbosity >= 1 {
         filter.add_directive("snarkos_node_bft=debug".parse().unwrap())
+    } else {
+        filter
     };
 
     let filter = if verbosity >= 4 {
-        let filter = filter.add_directive("snarkos_node_bft::gateway=trace".parse().unwrap());
+        filter.add_directive("snarkos_node_bft::gateway=trace".parse().unwrap())
+    } else if verbosity >= 1 {
+        filter.add_directive("snarkos_node_bft::gateway=debug".parse().unwrap())
+    } else {
+        filter
+    };
 
+    let filter = if verbosity >= 4 {
         // At high log levels, also show warnings of third-party crates.
         filter
             .add_directive("mio=warn".parse().unwrap())
@@ -73,8 +81,6 @@ fn parse_log_verbosity(verbosity: u8) -> Result<EnvFilter> {
             .add_directive("ureq=warn".parse().unwrap())
             .add_directive("rustls=warn".parse().unwrap())
     } else {
-        let filter = filter.add_directive("snarkos_node_bft::gateway=debug".parse().unwrap());
-
         // Disable logs from third-party crates by default.
         filter
             .add_directive("mio=off".parse().unwrap())
@@ -91,8 +97,10 @@ fn parse_log_verbosity(verbosity: u8) -> Result<EnvFilter> {
 
     let filter = if verbosity >= 5 {
         filter.add_directive("snarkos_node_router=trace".parse().unwrap())
-    } else {
+    } else if verbosity >= 1 {
         filter.add_directive("snarkos_node_router=debug".parse().unwrap())
+    } else {
+        filter
     };
 
     let filter = if verbosity >= 6 {


### PR DESCRIPTION
I noticed that even on the lowest verbosity setting (i.e., `snarkos start --verbosity=0`), nodes will print some debug logs. This can be too verbose when running a devnet with many validators, and it should be possible to disable all debug messages.

This PR changes the logging behavior so that debug logs for `gateway`, `bft`, and `sync` are only show with verbosity set to 1 or greater.