### PR TITLE
[CI] Ensure devnet does not generate errors

### DIFF
--- a/.ci/utils.sh
+++ b/.ci/utils.sh
@@ -75,7 +75,7 @@ function check_heights() {
   fi
 }
 
-# Function checking that nodes created logs on disk.
+# Function checking that nodes created logs on disk and they contain no errors.
 function check_logs() {
   echo "Checking logs exist for all nodes..."
   local log_dir=$1
@@ -90,6 +90,11 @@ function check_logs() {
       echo "❌ Test failed! Validator #${validator_index} did not create any logs in \"$log_dir\"."
       return 1
     fi
+
+    if grep -q "ERROR" "$log_dir/validator-${validator_index}.log"; then
+      echo "❌ Test failed! Validator #${validator_index} logs contain errors."
+      return 1
+    fi
   done
 
   for ((client_index = 0; client_index < total_clients; client_index++)); do
@@ -97,6 +102,12 @@ function check_logs() {
       echo "❌ Test failed! Client #${client_index} did not create any logs in \"$log_dir\"."
       return 1
     fi
+
+    if grep -q "ERROR" "$log_dir/client-${client_index}.log"; then
+      echo "❌ Test failed! Client #${client_index} logs contain errors."
+      return 1
+    fi
+ 
   done
 
   return 0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4263,7 +4263,6 @@ dependencies = [
  "indexmap 2.12.1",
  "proptest",
  "serde",
- "snarkos-node-network",
  "snarkos-node-sync-locators",
  "snarkvm",
  "test-strategy 0.4.3",

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -87,7 +87,7 @@ use std::{
     io,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 use tokio::{
     net::TcpStream,
@@ -821,12 +821,14 @@ impl<N: Network> Gateway<N> {
     fn initialize_heartbeat(&self) {
         let self_clone = self.clone();
         self.spawn(async move {
+            let start = Instant::now();
             // Sleep briefly to ensure the other nodes are ready to connect.
             tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
             info!("Starting the heartbeat of the gateway...");
             loop {
                 // Process a heartbeat in the gateway.
-                self_clone.heartbeat().await;
+                let uptime = start.elapsed();
+                self_clone.heartbeat(uptime).await;
                 // Sleep for the heartbeat interval.
                 tokio::time::sleep(Duration::from_secs(15)).await;
             }
@@ -854,10 +856,13 @@ impl<N: Network> Gateway<N> {
 }
 
 impl<N: Network> Gateway<N> {
+    /// The uptime after which nodes log a warning about missing validator connections.
+    const MISSING_VALIDATOR_CONNECTIONS_GRACE_PERIOD: Duration = Duration::from_secs(60);
+
     /// Handles the heartbeat request.
-    async fn heartbeat(&self) {
+    async fn heartbeat(&self, uptime: Duration) {
         // Log the connected validators.
-        self.log_connected_validators();
+        self.log_connected_validators(uptime);
         // Log the validator participation scores.
         #[cfg(feature = "telemetry")]
         self.log_participation_scores();
@@ -874,7 +879,7 @@ impl<N: Network> Gateway<N> {
     }
 
     /// Logs the connected validators.
-    fn log_connected_validators(&self) {
+    fn log_connected_validators(&self, uptime: Duration) {
         // Retrieve the connected validators and current committee.
         let connected_validators = self.connected_peers();
         let committee = match self.ledger.current_committee() {
@@ -937,7 +942,12 @@ impl<N: Network> Gateway<N> {
         }
 
         if !committee.is_quorum_threshold_reached(&connected_validator_addresses) {
-            error!("Not connected to a quorum of validators");
+            // Not being connected to a quorum of validators is begning during startup.
+            if uptime > Self::MISSING_VALIDATOR_CONNECTIONS_GRACE_PERIOD {
+                error!("Not connected to a quorum of validators");
+            } else {
+                debug!("Not connected to a quorum of validators");
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #4030.

This PR makes two changes:
* [c9267f9](https://github.com/ProvableHQ/snarkOS/pull/4035/commits/c9267f96b84522fe08926b49f2510dcfcbd7d2ac) avoids errors about lacking sufficient validator connections within the first minute of a node's uptime. As of now, validators will virtually always print this error at startup, potentially confusing users.
* [a3606d1](https://github.com/ProvableHQ/snarkOS/pull/4035/commits/a3606d122d77b11d508682caa814c086953a3a32) adds a simple check (using `grep`) that no errors were generated when running the devnet tests. 