### PR TITLE
[Fix] Use correct edition when recursively fetching programs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.47"
+version = "1.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
+checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -795,9 +795,9 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
-version = "0.7.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1165,22 +1165,23 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "10b768e943bed7bf2cab53df09f4bc34bfd217cdb57d971e769874c9a6710618"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "6d286bfdaf75e988b4a78e013ecd79c581e06399ab53fbacd2d916c2f904f30b"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote 1.0.42",
+ "rustc_version",
  "syn 2.0.111",
 ]
 
@@ -2048,9 +2049,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2252,9 +2253,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
+checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
 dependencies = [
  "darling 0.20.11",
  "indoc",
@@ -2340,9 +2341,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2389,9 +2390,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libgit2-sys"
@@ -2511,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
@@ -2654,9 +2655,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
@@ -3651,9 +3652,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3912,9 +3913,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.0"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10574371d41b0d9b2cff89418eda27da52bcaff2cc8741db26382a77c29131f1"
+checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3931,9 +3932,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.0"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a72d8216842fdd57820dc78d840bef99248e35fb2554ff923319e60f2d686b"
+checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -4263,7 +4264,6 @@ dependencies = [
  "indexmap 2.12.1",
  "proptest",
  "serde",
- "snarkos-node-network",
  "snarkos-node-sync-locators",
  "snarkvm",
  "test-strategy 0.4.3",
@@ -5697,9 +5697,9 @@ dependencies = [
 
 [[package]]
 name = "test-log-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451b374529930d7601b1eef8d32bc79ae870b6079b069401709c2a8bf9e75f36"
+checksum = "be35209fd0781c5401458ab66e4f98accf63553e8fae7425503e92fdd319783b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",
@@ -6132,9 +6132,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -6425,9 +6425,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6438,9 +6438,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6451,9 +6451,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote 1.0.42",
  "wasm-bindgen-macro-support",
@@ -6461,9 +6461,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6474,18 +6474,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6848,18 +6848,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.42",

--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -105,6 +105,9 @@ pub struct Execute {
     /// Timeout in seconds when waiting for transaction confirmation. Default is 60 seconds.
     #[clap(long, default_value_t = 60, requires = "wait")]
     timeout: u64,
+    /// Send the transaction without checking if sufficient funds are available (intended for testing purposes only).
+    #[clap(long, hide = true)]
+    skip_funds_check: bool,
 }
 
 impl Drop for Execute {
@@ -184,7 +187,7 @@ impl Execute {
         };
 
         // Check if the public balance is sufficient.
-        if self.record.is_none() && !is_static_query {
+        if self.record.is_none() && !is_static_query && !self.skip_funds_check {
             // Fetch the public balance.
             let address = Address::try_from(&private_key)?;
             let public_balance = Developer::get_public_balance::<N>(&endpoint, &address)

--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -155,11 +155,9 @@ impl Execute {
                 let height = query.current_block_height().with_context(|| "Failed to retrieve current block height")?;
                 let version = N::CONSENSUS_VERSION(height)?;
                 debug!("At block height {height} and consensus {version:?}");
-                let edition = Developer::get_latest_edition(&endpoint, &program_id)
-                    .with_context(|| format!("Failed to get latest edition for program {program_id}"))?;
 
                 // Load the program and it's imports into the process.
-                load_program(&query, &mut vm.process().write(), &program_id, edition)?;
+                load_program(&query, &mut vm.process().write(), &program_id, &endpoint)?;
             }
 
             // Prepare the fee.
@@ -239,10 +237,13 @@ fn load_program<N: Network>(
     query: &Query<N, BlockMemory<N>>,
     process: &mut Process<N>,
     program_id: &ProgramID<N>,
-    edition: u16,
+    endpoint: &Uri,
 ) -> Result<()> {
     // Fetch the program.
     let program = query.get_program(program_id).with_context(|| "Failed to fetch program")?;
+    // Fetch the latest edition of the program.
+    let edition = Developer::get_latest_edition(endpoint, program_id)
+        .with_context(|| format!("Failed to get latest edition for program {program_id}"))?;
 
     // Return early if the program is already loaded.
     if process.contains_program(program.id()) {
@@ -254,13 +255,14 @@ fn load_program<N: Network>(
         // Add the imports to the process if does not exist yet.
         if !process.contains_program(import_program_id) {
             // Recursively load the program and its imports.
-            load_program(query, process, import_program_id, edition)
+            load_program(query, process, import_program_id, endpoint)
                 .with_context(|| format!("Failed to load imported program {import_program_id}"))?;
         }
     }
 
     // Add the program to the process if it does not already exist.
     if !process.contains_program(program.id()) {
+        debug!("Adding program {program_id} with edition {edition}");
         process
             .add_programs_with_editions(&[(program, edition)])
             .with_context(|| format!("Failed to add program {program_id}"))?;

--- a/cli/src/commands/developer/execute.rs
+++ b/cli/src/commands/developer/execute.rs
@@ -74,6 +74,8 @@ pub struct Execute {
     /// to fit the network type and query.
     /// For example, the base URL may extend to "http://mynode.com/testnet/transaction/unconfirmed/ID" to retrieve
     /// an unconfirmed transaction on the test network.
+    ///
+    /// The given value may also be a JSON serialized `StaticQuery` struct.
     #[clap(short, long, alias="query", default_value=DEFAULT_ENDPOINT, verbatim_doc_comment)]
     endpoint: Uri,
     /// The priority fee in microcredits.
@@ -122,7 +124,7 @@ impl Execute {
         // Specify the query
         let query = Query::<N, BlockMemory<N>>::from(endpoint.clone());
 
-        // TODO (kaimast): can this ever be true?
+        // Check if the query is a static query.
         let is_static_query = matches!(query, Query::STATIC(_));
 
         // Retrieve the private key.

--- a/cli/src/commands/developer/mod.rs
+++ b/cli/src/commands/developer/mod.rs
@@ -76,7 +76,8 @@ pub enum DeveloperCommand {
 }
 
 /// Use the Provable explorer's API by default.
-const DEFAULT_ENDPOINT: &str = "https://api.explorer.provable.com";
+/// Note, `v2` here refers to the explorer version, not the snarkOS API version.
+const DEFAULT_ENDPOINT: &str = "https://api.explorer.provable.com/v2";
 
 #[derive(Debug, Parser)]
 pub struct Developer {


### PR DESCRIPTION
This PR replaces #4002 and fixes #3758.

### Changes
* [83757e8](https://github.com/ProvableHQ/snarkOS/pull/4037/commits/83757e887b8bf2f9cef5fb91fea3b030e0082e27) ensure the correct edition for each import is fetched. The current behavior only fetches the latest edition for the top-level program and then incorrectly reuses that value.
*  [c74b12d](https://github.com/ProvableHQ/snarkOS/pull/4037/commits/c74b12d9e240d242a08c56c5e6c4b10314b49d4e) improves a doc comment.
* [7ba6481](https://github.com/ProvableHQ/snarkOS/pull/4037/commits/7ba6481aee92e2764c1fba54748c0df92e2aa576) changes the default endpoint/base_url to `https://api.explorer.provable.com/v2/`. The `v2` component is needed (otherwise the explorer returns a 404 error) and refers to the explorer version, not the snarkOS API version.
* [2db8047](https://github.com/ProvableHQ/snarkOS/pull/4037/commits/2db8047e32ca9b93728a1039d55f0ad12100d0b0) adds a new flag `--skip-funds-check`, so you can test these changes without requiring actual funds in your account. This flag is only intended for testing purposes and marked as hidden.

### Testing
Ensure the following works to verify the correctness of these changes:
```
~> snarkos developer execute --private-key APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH \
    token_registry.aleo transfer_public 1field \
    aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px 1000u128 \
    --broadcast https://api.explorer.provable.com/v1/mainnet/transaction/broadcast --skip-funds-check

📦 Creating execution transaction for 'token_registry.aleo/transfer_public'...
✅ Created execution transaction for 'token_registry.aleo/transfer_public'
⌛ Execution at1n73ffv5eewcnkfkfd7acyyaslnwvrjnewygu9wxudufev4veeqyq2juge7 ('token_registry.aleo/transfer_public') has been broadcast to https://api.explorer.provable.com/v1/mainnet/transaction/broadcast.
at1n73ffv5eewcnkfkfd7acyyaslnwvrjnewygu9wxudufev4veeqyq2juge7```