### PR TITLE
Add Nix flake for reproducible builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -627,6 +627,46 @@ jobs:
       - check_windows:
           workspace_member: << parameters.workspace_member >>
 
+  check-nix:
+    docker:
+      - image: nixos/nix:latest
+    resource_class: << pipeline.parameters.medium >>
+    steps:
+      - checkout
+      - run:
+          name: Enable Nix Flakes
+          command: |
+            mkdir -p ~/.config/nix
+            echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
+            echo "sandbox = false" >> ~/.config/nix/nix.conf
+      - restore_cache:
+          keys:
+            - nix-v1-{{ checksum "flake.lock" }}
+            - nix-v1-{{ checksum "flake.nix" }}
+            - nix-v1-
+      - run:
+          name: Nix Build (snarkos)
+          command: |
+            nix build --print-build-logs --no-update-lock-file .#snarkos
+      - run:
+          name: Nix Develop (snarkos-dev)
+          command: |
+            nix develop --no-update-lock-file .#snarkos-dev --command echo "Dev shell OK"
+      - run:
+          name: Nix Flake Check
+          no_output_timeout: 30m
+          command: |
+            nix flake check --all-systems --no-update-lock-file
+      - run:
+          name: Nix Format Check
+          no_output_timeout: 10m
+          command: |
+            nix fmt -- --ci
+      - save_cache:
+          key: nix-v1-{{ checksum "flake.lock" }}
+          paths:
+            - /nix
+            - ~/.cache/nix
 workflows:
   version: 2
 
@@ -676,3 +716,7 @@ workflows:
                 display,
                 node
               ]
+
+  nix-workflow:
+    jobs:
+      - check-nix

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ Lastly, install `snarkOS`:
 cargo install --locked --path .
 ```
 
+**[For Nix users]** If you have Nix with flakes enabled, you can build and run snarkOS directly:
+```
+nix run github:ProvableHQ/snarkOS -- --help
+```
+
 #### Optional: CUDA Acceleration for Provers
 
 > This CUDA build is optional. The current snarkOS puzzle does not leverage CUDA acceleration—it is a leftover from a previous event, although CUDA may become relevant again with ARC-43.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1764950072,
+        "narHash": "sha256-BmPWzogsG2GsXZtlT+MTcAWeDK5hkbGRZTeZNW42fwA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f61125a668a320878494449750330ca58b78c557",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "systems": "systems"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1765248027,
+        "narHash": "sha256-ngar+yP06x3+2k2Iey29uU0DWx5ur06h3iPBQXlU+yI=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "7b50ad68415ae5be7ee4cc68fa570c420741b644",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,137 @@
+{
+  description = "snarkOS - A decentralized operating system";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    systems.url = "github:nix-systems/default";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      rust-overlay,
+      systems,
+    }:
+    let
+      eachSystem = f: nixpkgs.lib.genAttrs (import systems) (system: f system);
+
+      # Common configuration factory that takes pkgs as input
+      mkCommonConfig = pkgs: rec {
+        # Rust toolchain matching rust-toolchain.toml
+        rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+        # Native build inputs for the project
+        nativeBuildInputs = with pkgs; [
+          rustToolchain
+          curl
+          openssl
+          zlib
+          pkg-config
+          clang
+          gcc
+          lld
+          libclang
+          git # Required for build.rs (built crate with git2 feature)
+        ];
+
+        # Runtime dependencies
+        buildInputs = with pkgs; [
+          openssl
+        ];
+
+        # Environment variables
+        LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+        GIT = "${pkgs.git}/bin/git";
+        LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+          pkgs.zlib
+          pkgs.openssl
+          pkgs.libclang.lib
+        ];
+      };
+    in
+    {
+      devShells = eachSystem (
+        system:
+        let
+          overlays = [ (import rust-overlay) ];
+          pkgs = import nixpkgs {
+            inherit system overlays;
+          };
+
+          common = mkCommonConfig pkgs;
+        in
+        {
+          default = self.devShells.${system}.snarkos-dev;
+          snarkos-dev = pkgs.mkShell (
+            common
+            // {
+
+              shellHook = ''
+                echo "snarkOS development environment"
+                echo "Rust version: $(rustc --version)"
+                echo "Cargo version: $(cargo --version)"
+              '';
+            }
+          );
+        }
+      );
+
+      packages = eachSystem (
+        system:
+        let
+          overlays = [ (import rust-overlay) ];
+          pkgs = import nixpkgs {
+            inherit system overlays;
+          };
+
+          common = mkCommonConfig pkgs;
+
+          # Read version from Cargo.toml
+          cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+        in
+        {
+          default = self.packages.${system}.snarkos;
+          snarkos-testnet = self.packages.${system}.snarkos.overrideAttrs (old: {
+            buildFeatures = [ "test_network" ];
+          });
+          snarkos = pkgs.rustPlatform.buildRustPackage (
+            common
+            // {
+              pname = cargoToml.package.name;
+              version = cargoToml.package.version;
+
+              # cleanup source tree
+              src = nixpkgs.lib.cleanSourceWith {
+                src = ./.;
+                filter =
+                  path: type:
+                  # Exclude common build/cache directories
+                  (!nixpkgs.lib.hasInfix "/target" path)
+                  && (!nixpkgs.lib.hasInfix "/.git" path)
+                  && (
+                    # Include directories
+                    (type == "directory")
+                    ||
+                      # Include .resources folder
+                      (nixpkgs.lib.hasInfix "/.resources" path)
+                    ||
+                      # Include specific files
+                      (nixpkgs.lib.hasSuffix ".lock" path)
+                    || (nixpkgs.lib.hasSuffix ".rs" path)
+                    || (nixpkgs.lib.hasSuffix ".toml" path)
+                  );
+              };
+              cargoLock = {
+                lockFile = ./Cargo.lock;
+                outputHashes = {
+                  "snarkvm-4.4.0" = "sha256-5NbGhCunhjxQA334wuM7WUqytIY1bP6OALIDwqVNuH8=";
+                };
+              };
+            }
+          );
+        }
+      );
+    };
+}


### PR DESCRIPTION
Add a flake.nix to enable Nix users to build and develop snarkOS in a reproducible environment. This provides:

- Development shell with all necessary dependencies
- Reproducible builds across different systems
- Easy integration with NixOS, nix-darwin and other Nix-based systems
- Consistent toolchain versions for all contributors

This change does not affect non-Nix users and maintains backward compatibility with existing build processes.

Nix flakes provide a standardized way to define inputs and outputs for Nix projects, making it easier for users of NixOS, nix-darwin, and other Nix-based systems to work with snarkOS.
