### PR TITLE
Add metric for total connected stake

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -917,6 +917,10 @@ impl<N: Network> Gateway<N> {
         // Log the validators that are not connected.
         let num_not_connected = validators_total.saturating_sub(connected_validators.len());
         if num_not_connected > 0 {
+            // Cache the total stake for computing percentages.
+            let total_stake = committee.total_stake();
+            let total_stake_f64 = total_stake as f64;
+
             // Collect the committee members.
             let committee_members: HashSet<_> =
                 self.ledger.current_committee().map(|c| c.members().keys().copied().collect()).unwrap_or_default();
@@ -925,7 +929,8 @@ impl<N: Network> Gateway<N> {
                 .difference(&connected_validator_addresses)
                 .map(|address| {
                     let address_stake = committee.get_stake(*address);
-                    let address_stake_as_percentage = address_stake as f64 / committee.total_stake() as f64 * 100.0;
+                    let address_stake_as_percentage =
+                        if total_stake == 0 { 0.0 } else { address_stake as f64 / total_stake_f64 * 100.0 };
                     debug!(
                         "{}",
                         format!("  Not connected to {address} ({address_stake_as_percentage:.2}% of total stake)")
@@ -935,11 +940,20 @@ impl<N: Network> Gateway<N> {
                 })
                 .sum();
 
-            let not_connected_stake_as_percentage = not_connected_stake as f64 / committee.total_stake() as f64 * 100.0;
+            let not_connected_stake_as_percentage =
+                if total_stake == 0 { 0.0 } else { not_connected_stake as f64 / total_stake_f64 * 100.0 };
             warn!(
                 "Not connected to {num_not_connected} validators {total_validators} ({not_connected_stake_as_percentage:.2}% of total stake not connected)"
             );
-        }
+            #[cfg(feature = "metrics")]
+            {
+                let connected_stake_as_percentage = 100.0 - not_connected_stake_as_percentage;
+                metrics::gauge(metrics::bft::CONNECTED_STAKE, connected_stake_as_percentage);
+            }
+        } else {
+            #[cfg(feature = "metrics")]
+            metrics::gauge(metrics::bft::CONNECTED_STAKE, 100.0);
+        };
 
         if !committee.is_quorum_threshold_reached(&connected_validator_addresses) {
             // Not being connected to a quorum of validators is begning during startup.

--- a/node/metrics/src/names.rs
+++ b/node/metrics/src/names.rs
@@ -16,8 +16,9 @@
 pub(super) const COUNTER_NAMES: [&str; 3] =
     [bft::LEADERS_ELECTED, consensus::STALE_UNCONFIRMED_TRANSACTIONS, consensus::STALE_UNCONFIRMED_SOLUTIONS];
 
-pub(super) const GAUGE_NAMES: [&str; 26] = [
+pub(super) const GAUGE_NAMES: [&str; 27] = [
     bft::CONNECTED,
+    bft::CONNECTED_STAKE,
     bft::CONNECTING,
     bft::LAST_STORED_ROUND,
     bft::PROPOSAL_ROUND,
@@ -51,6 +52,7 @@ pub(super) const HISTOGRAM_NAMES: [&str; 4] =
 pub mod bft {
     pub const COMMIT_ROUNDS_LATENCY: &str = "snarkos_bft_commit_rounds_latency_secs"; // <-- This one doesn't even make sense.
     pub const CONNECTED: &str = "snarkos_bft_connected_total";
+    pub const CONNECTED_STAKE: &str = "snarkos_bft_connected_stake_as_percentage";
     pub const CONNECTING: &str = "snarkos_bft_connecting_total";
     pub const LAST_STORED_ROUND: &str = "snarkos_bft_last_stored_round";
     pub const LEADERS_ELECTED: &str = "snarkos_bft_leaders_elected_total";


### PR DESCRIPTION
## Motivation

Adding a metric for total stake of validators a node is connected to, so we can alert on it if it's goes too low (below 66% the network will halt).

A stylistic comment: it's a bit wonky to compute unconnected stake and then convert back to connected stake, but it's not too complex and it's likely the most efficient because there will be fewer non-connected than connected validators.

CC @mike2194
