### PR TITLE
[Feat] Introduce a dynamic validator whitelist

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -70,7 +70,6 @@ use snarkvm::{
     prelude::{Address, Field},
 };
 
-use aleo_std::aleo_ledger_dir;
 use colored::Colorize;
 use futures::SinkExt;
 use indexmap::IndexMap;
@@ -84,7 +83,6 @@ use rand::{
 };
 use std::{
     collections::{HashMap, HashSet},
-    fs,
     future::Future,
     io,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
@@ -850,7 +848,7 @@ impl<N: Network> Gateway<N> {
     pub async fn shut_down(&self) {
         info!("Shutting down the gateway...");
         // Save the best peers for future use.
-        if let Err(e) = self.save_best_peers(&self.storage_mode, VALIDATOR_CACHE_FILENAME, None) {
+        if let Err(e) = self.save_best_peers(&self.storage_mode, VALIDATOR_CACHE_FILENAME, None, true) {
             warn!("Failed to persist best validators to disk: {e}");
         }
         // Abort the tasks.
@@ -1129,25 +1127,10 @@ impl<N: Network> Gateway<N> {
 
     // Update the dynamic validator whitelist.
     fn update_validator_whitelist(&self) {
-        // Collect the addresses of all the connected validators.
-        let connected_validator_addrs = self.connected_peers();
-
-        // Create or truncate the existing whitelist file.
-        let mut path = aleo_ledger_dir(N::ID, &self.storage_mode);
-        path.push(VALIDATOR_WHITELIST_FILENAME);
-        let mut whitelist = match fs::File::create(path) {
-            Ok(file) => file,
-            Err(e) => {
-                warn!("Couldn't create the validator whitelist file at {VALIDATOR_WHITELIST_FILENAME}: {e}");
-                return;
-            }
-        };
-
-        // Save all the addresses in a space-delimited format for trivial script extraction.
-        for addr in connected_validator_addrs {
-            if let Err(e) = writeln!(whitelist, "{} {}", addr.ip(), addr.port()) {
-                warn!("Couldn't save {addr} to the validator whitelist: {e}");
-            }
+        if let Err(e) =
+            self.save_best_peers(&self.storage_mode, VALIDATOR_WHITELIST_FILENAME, Some(MAX_VALIDATORS_TO_SEND), false)
+        {
+            warn!("Couldn't update the validator whitelist: {e}");
         }
     }
 }

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -70,6 +70,7 @@ use snarkvm::{
     prelude::{Address, Field},
 };
 
+use aleo_std::aleo_ledger_dir;
 use colored::Colorize;
 use futures::SinkExt;
 use indexmap::IndexMap;
@@ -83,6 +84,7 @@ use rand::{
 };
 use std::{
     collections::{HashMap, HashSet},
+    fs,
     future::Future,
     io,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
@@ -118,6 +120,9 @@ const IP_BAN_TIME_IN_SECS: u64 = 300;
 
 /// The name of the file containing cached validators.
 const VALIDATOR_CACHE_FILENAME: &str = "cached_gateway_peers";
+
+/// The name of the file containing the dynamic validator whitelist.
+const VALIDATOR_WHITELIST_FILENAME: &str = "dynamic_validator_whitelist";
 
 /// Part of the Gateway API that deals with networking.
 /// This is a separate trait to allow for easier testing/mocking.
@@ -876,6 +881,8 @@ impl<N: Network> Gateway<N> {
         self.handle_min_connected_validators();
         // Unban any addresses whose ban time has expired.
         self.handle_banned_ips();
+        // Update the dynamic validator whitelist.
+        self.update_validator_whitelist();
     }
 
     /// Logs the connected validators.
@@ -1118,6 +1125,30 @@ impl<N: Network> Gateway<N> {
     // Remove addresses whose ban time has expired.
     fn handle_banned_ips(&self) {
         self.tcp.banned_peers().remove_old_bans(IP_BAN_TIME_IN_SECS);
+    }
+
+    // Update the dynamic validator whitelist.
+    fn update_validator_whitelist(&self) {
+        // Collect the addresses of all the connected validators.
+        let connected_validator_addrs = self.connected_peers();
+
+        // Create or truncate the existing whitelist file.
+        let mut path = aleo_ledger_dir(N::ID, &self.storage_mode);
+        path.push(VALIDATOR_WHITELIST_FILENAME);
+        let mut whitelist = match fs::File::create(path) {
+            Ok(file) => file,
+            Err(e) => {
+                warn!("Couldn't create the validator whitelist file at {VALIDATOR_WHITELIST_FILENAME}: {e}");
+                return;
+            }
+        };
+
+        // Save all the addresses in a space-delimited format for trivial script extraction.
+        for addr in connected_validator_addrs {
+            if let Err(e) = writeln!(whitelist, "{} {}", addr.ip(), addr.port()) {
+                warn!("Couldn't save {addr} to the validator whitelist: {e}");
+            }
+        }
     }
 }
 

--- a/node/network/src/peering.rs
+++ b/node/network/src/peering.rs
@@ -491,7 +491,13 @@ pub trait PeerPoolHandling<N: Network>: P2P {
 
     /// Preserve the peers who have the greatest known block heights, and the lowest
     /// number of registered network failures.
-    fn save_best_peers(&self, storage_mode: &StorageMode, filename: &str, max_entries: Option<usize>) -> Result<()> {
+    fn save_best_peers(
+        &self,
+        storage_mode: &StorageMode,
+        filename: &str,
+        max_entries: Option<usize>,
+        store_ports: bool,
+    ) -> Result<()> {
         // Collect all prospect peers.
         let mut peers = self.get_peers();
 
@@ -517,7 +523,11 @@ pub trait PeerPoolHandling<N: Network>: P2P {
         path.push(filename);
         let mut file = fs::File::create(path)?;
         for peer in peers {
-            writeln!(file, "{}", peer.listener_addr())?;
+            writeln!(
+                file,
+                "{}",
+                if store_ports { peer.listener_addr().to_string() } else { peer.listener_addr().ip().to_string() }
+            )?;
         }
 
         Ok(())

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -279,7 +279,7 @@ impl<N: Network> Router<N> {
     pub async fn shut_down(&self) {
         info!("Shutting down the router...");
         // Save the best peers for future use.
-        if let Err(e) = self.save_best_peers(&self.storage_mode, PEER_CACHE_FILENAME, Some(MAX_PEERS_TO_SEND)) {
+        if let Err(e) = self.save_best_peers(&self.storage_mode, PEER_CACHE_FILENAME, Some(MAX_PEERS_TO_SEND), true) {
             warn!("Failed to persist best peers to disk: {e}");
         }
         // Abort the tasks.


### PR DESCRIPTION
This PR introduces a new ledger-adjacent file containing the list of all the currently connected validators, and updated with every validator heartbeat. The format is a space-delimited list of IP-port pairs for trivial script processing for potential use in commands like `ipset`.

Closes https://github.com/ProvableHQ/snarkOS/issues/4053.