### PR TITLE
Fix prover solution submissions for tests

### DIFF
--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -419,12 +419,9 @@ impl Start {
                 dev < num_validators,
                 "Development validator index is too high (dev={dev}, dev_num_validators={num_validators})",
             );
-        } else {
-            ensure!(
-                dev >= self.dev_num_validators,
-                "Development prover/client index is too low (dev={dev}, dev_num_validators={num_validators})",
-            );
         }
+        // A dev client or prover is allowed to have an index lower than
+        // `dev_num_validators` in order to have a balance at startup.
 
         // Add the dev nodes to the trusted validators.
         if trusted_validators.is_empty() && is_validator {


### PR DESCRIPTION
## Motivation

Our test environment with a prover can't easily land solutions if it doesn't have a staked balance, which is instantly the case if they re-use a validator index. 
