### PR TITLE
[Feature] REST endpoint to query connected validators

### DIFF
--- a/.ci/bench_bft_sync.sh
+++ b/.ci/bench_bft_sync.sh
@@ -66,7 +66,7 @@ PIDS[0]=$!
 # Stores the list of all validators.
 validators="127.0.0.1:5000"
 
-# Spawn the clients that will sync the ledger
+# Spawn the validator that will sync the ledger
 for node_index in $(seq 1 "$num_nodes"); do
   name="validator-$node_index"
 
@@ -125,6 +125,6 @@ while (( SECONDS < max_wait )); do
 done
 
 log "❌ Benchmark failed! Validators did not sync within 30 minutes."
-print_client_logs "$log_dir" "$num_validators" "$num_nodes"
+print_validator_logs "$log_dir" "$num_validators" "$num_nodes"
 
 exit 1

--- a/.ci/bench_bft_sync.sh
+++ b/.ci/bench_bft_sync.sh
@@ -91,12 +91,12 @@ wait_for_nodes $((num_nodes+1)) 0 "$network_name"
 
 SECONDS=0
 
-# TODO add API call for number of connected validators.
-#for ((node_index = 0; node_index < num_nodes+1; node_index++)); do
-#  if ! (wait_for_peers "$node_index" $num_nodes); then
-#    exit 1
-#  fi
-#done
+# Wait for all validators to be connected to each other via the gateway.
+for ((node_index = 0; node_index < num_nodes+1; node_index++)); do
+  if ! (wait_for_bft_connections "$node_index" $num_nodes "$network_name"); then
+    exit 1
+  fi
+done
 
 connect_time=$SECONDS
 echo "ℹ️ Nodes are fully connected (took $connect_time secs). Starting block sync measurement."

--- a/.ci/bench_bft_sync.sh
+++ b/.ci/bench_bft_sync.sh
@@ -25,17 +25,17 @@ poll_interval=1 # Check block heights every second
 #shellcheck source=SCRIPTDIR/utils.sh
 . .ci/utils.sh
 
-branch_name=$(git rev-parse --abbrev-ref HEAD)
-echo "On branch: ${branch_name}"
-
-network_name=$(get_network_name $network_id)
-echo "Using network: $network_name (ID: $network_id)"
-
-snapshot_info=$(<info.txt)
-echo "Snapshot_info: ${snapshot_info}"
-
 # Create log directory
 init_log_dir
+
+branch_name=$(git rev-parse --abbrev-ref HEAD)
+log "On branch: ${branch_name}"
+
+network_name=$(get_network_name $network_id)
+log "Using network: $network_name (ID: $network_id)"
+
+snapshot_info=$(<info.txt)
+log "Snapshot_info: ${snapshot_info}"
 
 # Define a trap handler that cleans up all processes on exit.
 # shellcheck disable=SC2329
@@ -45,7 +45,7 @@ function exit_handler() {
 trap exit_handler EXIT
 
 # Define a trap handler that prints a message when an error occurs 
-trap 'echo "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
+trap 'log "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
 
 # Shared flags betwen all nodes
 common_flags=(
@@ -99,7 +99,7 @@ for ((node_index = 0; node_index < num_nodes+1; node_index++)); do
 done
 
 connect_time=$SECONDS
-echo "ℹ️ Nodes are fully connected (took $connect_time secs). Starting block sync measurement."
+log "ℹ️ Nodes are fully connected (took $connect_time secs). Starting block sync measurement."
 
 # Check heights periodically with a timeout
 SECONDS=0
@@ -112,7 +112,7 @@ while (( SECONDS < max_wait )); do
     total_wait=$SECONDS
     throughput=$(compute_throughput "$min_height" "$total_wait")
 
-    echo "🎉 BFT sync benchmark done! Waited $total_wait seconds for $min_height blocks. Throughput was $throughput blocks/s."
+    log "🎉 BFT sync benchmark done! Waited $total_wait seconds for $min_height blocks. Throughput was $throughput blocks/s."
 
     # Append data to results file.
     printf "{ \"name\": \"bft-sync\", \"unit\": \"blocks/s\", \"value\": %.3f, \"extra\": \"total_wait=%is, target_height=%i, connect_time=%i, branch=%s, %s\" },\n" \
@@ -124,7 +124,7 @@ while (( SECONDS < max_wait )); do
   sleep $poll_interval
 done
 
-echo "❌ Benchmark failed! Validators did not sync within 30 minutes."
+log "❌ Benchmark failed! Validators did not sync within 30 minutes."
 print_client_logs "$log_dir" "$num_validators" "$num_nodes"
 
 exit 1

--- a/.ci/bench_bft_sync.sh
+++ b/.ci/bench_bft_sync.sh
@@ -66,7 +66,7 @@ PIDS[0]=$!
 # Stores the list of all validators.
 validators="127.0.0.1:5000"
 
-# Spawn the validator that will sync the ledger
+# Spawn the validators that will sync the ledger
 for node_index in $(seq 1 "$num_nodes"); do
   name="validator-$node_index"
 

--- a/.ci/bench_cdn_sync.sh
+++ b/.ci/bench_cdn_sync.sh
@@ -22,7 +22,7 @@ poll_interval=1 # Check block heights every second
 init_log_dir
 
 network_name=$(get_network_name $network_id)
-echo "Using network: $network_name (ID: $network_id)"
+log "Using network: $network_name (ID: $network_id)"
 
 # Define a trap handler that cleans up all processes on exit.
 # shellcheck disable=SC2329
@@ -32,7 +32,7 @@ function exit_handler() {
 trap exit_handler EXIT
 
 # Define a trap handler that prints a message when an error occurs.
-trap 'echo "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
+trap 'log "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
 
 # Ensure there are no old ledger files and the node syncs from scratch
 snarkos clean "--network=$network_id" || true
@@ -50,7 +50,7 @@ args=(
 $TASKSET2 snarkos start --client "${args[@]}" &
 PIDS[0]=$!
 
-wait_for_nodes 0 1
+wait_for_nodes 0 1 "$network_name"
 
 # Check heights periodically with a timeout
 SECONDS=0
@@ -59,7 +59,7 @@ while (( SECONDS < max_wait )); do
     total_wait=$SECONDS
     throughput=$(compute_throughput "$min_height" "$total_wait")
 
-    echo "🎉 Benchmark done! Waited ${total_wait}s for $min_height blocks. Throughput was $throughput blocks/s."
+    log "🎉 Benchmark done! Waited ${total_wait}s for $min_height blocks. Throughput was $throughput blocks/s."
 
     # Append data to results file.
     printf "{ \"name\": \"cdn-sync\", \"unit\": \"blocks/s\", \"value\": %.3f, \"extra\": \"total_wait=%is, target_height=${min_height}\" }\n" \
@@ -71,6 +71,6 @@ while (( SECONDS < max_wait )); do
   sleep $poll_interval
 done
 
-echo "❌ Benchmark failed! Client did not sync within 30 minutes."
+log "❌ Benchmark failed! Client did not sync within 30 minutes."
 
 exit 1

--- a/.ci/bench_p2p_sync.sh
+++ b/.ci/bench_p2p_sync.sh
@@ -51,13 +51,13 @@ function sample_sync_speeds() {
 
     # Skip null or empty
     if [[ -z "$speed" ]] || [[ "$speed" == "null" ]]; then
-      echo "Invalid speed value $speed"
+      log "Invalid speed value $speed"
       continue
     fi
 
     # Validate numeric (allow exponent)
     if ! (is_float "$speed"); then
-        echo "Invalid speed value $speed"
+        log "Invalid speed value $speed"
        continue
     fi
 
@@ -79,19 +79,19 @@ function sample_sync_speeds() {
 }
 
 branch_name=$(git rev-parse --abbrev-ref HEAD)
-echo "On branch: ${branch_name}"
+log "On branch: ${branch_name}"
 
 network_name=$(get_network_name $network_id)
-echo "Using network: $network_name (ID: $network_id)"
+log "Using network: $network_name (ID: $network_id)"
 
 snapshot_info=$(<info.txt)
-echo "Snapshot_info: ${snapshot_info}"
+log "Snapshot_info: ${snapshot_info}"
 
 # Define a trap handler that cleans up all processes on exit.
 trap stop_nodes EXIT
 
 # Define a trap handler that prints a message when an error occurs.
-trap 'echo "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
+trap 'log "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
 
 # Shared flags between all nodes
 common_flags=(
@@ -143,7 +143,7 @@ for node_index in $(seq 0 "$num_clients"); do
 done
 
 connect_time=$SECONDS
-echo "ℹ️ Nodes are fully connected (took $connect_time secs). Starting block sync measurement."
+log "ℹ️ Nodes are fully connected (took $connect_time secs). Starting block sync measurement."
 
 # Ensure the first node actually has the ledger snapshot.
 # This should succeed instantly in most cases
@@ -159,7 +159,7 @@ while (( SECONDS < 30 )); do
 done
 
 if ! $has_blocks; then
-  echo "Node #0 has not reached the expected height. Maybe the ledger snapshot is corrupted or outdated?"
+  log "Node #0 has not reached the expected height. Maybe the ledger snapshot is corrupted or outdated?"
   exit 1
 fi
 
@@ -185,7 +185,7 @@ while (( SECONDS < max_wait )); do
       variance=$(echo "scale=8; 0" | bc -l)
     fi
 
-    echo "🎉 P2P sync benchmark done! Waited $total_wait seconds for $min_height blocks. Throughput was $throughput blocks/s."
+    log "🎉 P2P sync benchmark done! Waited $total_wait seconds for $min_height blocks. Throughput was $throughput blocks/s."
 
     # Append data to results file.
     printf "{ \"name\": \"p2p-sync\", \"unit\": \"blocks/s\", \"value\": %.3f, \"extra\": \"total_wait=%is, target_height=%i, connect_time=%is, %s\" },\n" \
@@ -200,7 +200,7 @@ while (( SECONDS < max_wait )); do
   sleep $poll_interval
 done
 
-echo "❌ Benchmark failed! Clients did not sync within 40 minutes."
+log "❌ Benchmark failed! Clients did not sync within 40 minutes."
 
 # Print logs for debugging
 print_client_logs "$log_dir" "$num_validators" "$num_clients"

--- a/.ci/bench_rest_api.sh
+++ b/.ci/bench_rest_api.sh
@@ -21,19 +21,19 @@ log_filter="info,snarkos_node_sync=debug,snarkos_node_tcp=warn,snarkos_node_rest
 init_log_dir
 
 branch_name=$(git rev-parse --abbrev-ref HEAD)
-echo "On branch: ${branch_name}"
+log "On branch: ${branch_name}"
 
 network_name=$(get_network_name $network_id)
-echo "Using network: $network_name (ID: $network_id)"
+log "Using network: $network_name (ID: $network_id)"
 
 snapshot_info=$(<info.txt)
-echo "Snapshot_info: ${snapshot_info}"
+log "Snapshot_info: ${snapshot_info}"
 
 # Define a trap handler that cleans up all processes on exit.
 trap stop_nodes EXIT
 
 # Define a trap handler that prints a message when an error occurs.
-trap 'echo "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
+trap 'log "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
 
 # Shared flags between all nodes
 common_flags=(
@@ -42,21 +42,20 @@ common_flags=(
   "--network=$network_id"
   --nocdn # don't sync from CDN, so we only benchmark p2p sync
   "--dev-num-validators=$num_validators"
-  "--dev-num-clients=0" # no clients, so no need to populate the validators list
   "--no-dev-txs" # disable developemnt transaction generation
   --rest-rps=1000000 # ensure benchmarks don't fail due to rate limiting
 )
 
 # The node that has the ledger (runs on the first two cores)
-$TASKSET1 snarkos start --dev 0 --validator "${common_flags[@]}" \
-  --logfile="$log_dir/validator-0.log" --validators="127.0.0.1:5001"& # the node will populate the validators list, if not at least one is set.
+$TASKSET1 snarkos start --dev 0 --client "${common_flags[@]}" --logfile="$log_dir/client-0.log" &
 PIDS[0]=$!
 
 # Block until node is running.
-wait_for_nodes 0 1
+wait_for_nodes 0 1 "$network_name"
 
 python ./.ci/rest_api_helper.py "get-block" "$CORES_PER_NODE" 60
 python ./.ci/rest_api_helper.py "block-height" "$CORES_PER_NODE" 10000
 python ./.ci/rest_api_helper.py "get-latest-block" "$CORES_PER_NODE" 100
 
+log "🎉 Rest API benchmark done!"
 exit 0

--- a/.ci/devnet_ci.sh
+++ b/.ci/devnet_ci.sh
@@ -17,7 +17,7 @@ min_height=$4
 max_warnings=$5
 
 # The verobsity of snarkos nodes.
-NODE_VERBOSITY=3
+NODE_VERBOSITY=0
 
 # Default values if not provided
 : "${total_validators:=4}"
@@ -101,13 +101,19 @@ done
 # Ensure all nodes are up and running.
 wait_for_nodes "$total_validators" "$total_clients" "$network_name"
 
-# Wait for all clients to be connected to another client or a validator.
-# TODO(kaimast): also check that validators are connected to each other.
+# Wait for validators to be fully connected.
 log "ℹ️ Waiting for all nodes to have at least one peer..."
 SECONDS=0
-for node_index in $(seq 0 $((total_clients))); do
-  client_index=$node_index+total_validators
-  if ! (wait_for_peers "$client_index" 1 "$network_name"); then
+for validator_index in $(seq 0 $((total_validators-1))); do
+  if ! (wait_for_bft_connections "$validator_index" $((total_validators-1)) "$network_name"); then
+    exit 1
+  fi
+done
+
+# Wait for all clients to be connected to another client or a validator.
+for client_index in $(seq 0 $((total_clients-1))); do
+  node_index=$((client_index + total_validators))
+  if ! (wait_for_peers "$node_index" 1 "$network_name"); then
     exit 1
   fi
 done

--- a/.ci/devnet_ci.sh
+++ b/.ci/devnet_ci.sh
@@ -17,7 +17,7 @@ min_height=$4
 max_warnings=$5
 
 # The verobsity of snarkos nodes.
-NODE_VERBOSITY=0
+NODE_VERBOSITY=3
 
 # Default values if not provided
 : "${total_validators:=4}"
@@ -102,22 +102,26 @@ done
 wait_for_nodes "$total_validators" "$total_clients" "$network_name"
 
 # Wait for validators to be fully connected.
-log "ℹ️ Waiting for all nodes to have at least one peer..."
+log "ℹ️ Waiting for validators to be fully connected..." 
 SECONDS=0
 for validator_index in $(seq 0 $((total_validators-1))); do
   if ! (wait_for_bft_connections "$validator_index" $((total_validators-1)) "$network_name"); then
     exit 1
   fi
 done
+log "✅ All validators are fully connected"
 
-# Wait for all clients to be connected to another client or a validator.
-for client_index in $(seq 0 $((total_clients-1))); do
-  node_index=$((client_index + total_validators))
-  if ! (wait_for_peers "$node_index" 1 "$network_name"); then
-    exit 1
-  fi
-done
-log "✅ All nodes have at least one peer"
+if (( total_clients > 0 )); then
+  log "ℹ️ Waiting for clients to have at least one peer..."
+  # Wait for all clients to be connected to another client or a validator.
+  for client_index in $(seq 0 $((total_clients-1))); do
+    node_index=$((client_index + total_validators))
+    if ! (wait_for_peers "$node_index" 1 "$network_name"); then
+      exit 1
+    fi
+  done
+  log "✅ All clients have at least one peer"
+fi
 
 last_seen_consensus_version=0
 last_seen_height=0

--- a/.ci/utils.sh
+++ b/.ci/utils.sh
@@ -272,6 +272,37 @@ function wait_for_peers() {
   return 1
 }
 
+# Succeeds if the node with the given index has the specified number of BFT connections (or greater)
+function wait_for_bft_connections() {
+  local node_index=$1
+  local min_peers=$2
+  local network_name=$3
+
+  local total_wait=0
+  local max_wait=300
+  local poll_interval=1
+  local port=$((3030 + node_index))
+  
+  while (( total_wait < max_wait )); do
+    result=$(curl -s "http://localhost:$port/v2/$network_name/connections/bft/count")
+
+    if ! (is_integer "$result"); then
+      log "Failed to get number of BFT connections for node #${node_index} (port=$port). Will retry..."
+    elif (( result < min_peers )); then
+      log "Node #${node_index} (port=$port) has $result BFT connections, expected at least $min_peers. Will wait and retry..."
+    else
+      return 0
+    fi
+
+    # Continue waiting
+    sleep $poll_interval
+    total_wait=$((total_wait+poll_interval))
+  done
+
+  log "❌ BFT connections did not reach $min_peers within 5 minutes."
+  return 1
+}
+
 # Blocks until the node with the given index has at least one peer to sync from (or times out).
 function wait_for_sync_peers() {
   local node_index=$1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3328,9 +3328,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -200,10 +200,13 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route("/find/transactionID/{transition_id}", get(Self::find_transaction_id_from_transition_id))
             .route("/find/transitionID/{input_or_output_id}", get(Self::find_transition_id))
 
-            // GET ../peers/..
+            // GET ../peers/.. (with /connections/p2p/.. aliases)
             .route("/peers/count", get(Self::get_peers_count))
             .route("/peers/all", get(Self::get_peers_all))
             .route("/peers/all/metrics", get(Self::get_peers_all_metrics))
+            .route("/connections/p2p/count", get(Self::get_peers_count))
+            .route("/connections/p2p/all", get(Self::get_peers_all))
+            .route("/connections/p2p/all/metrics", get(Self::get_peers_all_metrics))
 
             // GET ../program/..
             .route("/program/{id}", get(Self::get_program))
@@ -234,6 +237,14 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route("/committee/latest", get(Self::get_committee_latest))
             .route("/committee/{height}", get(Self::get_committee))
             .route("/delegators/{validator}", get(Self::get_delegators_for_validator));
+
+        // If the node is a validator, enable the BFT connections endpoints.
+        let routes = match self.consensus {
+            Some(_) => routes
+                .route("/connections/bft/count", get(Self::get_bft_connections_count))
+                .route("/connections/bft/all", get(Self::get_bft_connections_all)),
+            None => routes,
+        };
 
         // If the node is a validator and `telemetry` features is enabled, enable the additional endpoint.
         #[cfg(feature = "telemetry")]

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -200,7 +200,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route("/find/transactionID/{transition_id}", get(Self::find_transaction_id_from_transition_id))
             .route("/find/transitionID/{input_or_output_id}", get(Self::find_transition_id))
 
-            // GET ../peers/.. (with /connections/p2p/.. aliases)
+            // GET ../connections/p2p/.. (with ../peers/.. aliases)
             .route("/peers/count", get(Self::get_peers_count))
             .route("/peers/all", get(Self::get_peers_all))
             .route("/peers/all/metrics", get(Self::get_peers_all_metrics))

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -565,19 +565,35 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         }
     }
 
-    /// GET /<network>/peers/count
+    /// GET /<network>/peers/count (alias: /connections/p2p/count)
     pub(crate) async fn get_peers_count(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.routing.router().number_of_connected_peers())
     }
 
-    /// GET /<network>/peers/all
+    /// GET /<network>/peers/all (alias: /connections/p2p/all)
     pub(crate) async fn get_peers_all(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.routing.router().connected_peers())
     }
 
-    /// GET /<network>/peers/all/metrics
+    /// GET /<network>/peers/all/metrics (alias: /connections/p2p/all/metrics)
     pub(crate) async fn get_peers_all_metrics(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.routing.router().connected_metrics())
+    }
+
+    /// GET /<network>/connections/bft/count
+    pub(crate) async fn get_bft_connections_count(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
+        match rest.consensus {
+            Some(consensus) => Ok(ErasedJson::pretty(consensus.bft().primary().gateway().number_of_connected_peers())),
+            None => Err(RestError::service_unavailable(anyhow!("Route isn't available for this node type"))),
+        }
+    }
+
+    /// GET /<network>/connections/bft/all
+    pub(crate) async fn get_bft_connections_all(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
+        match rest.consensus {
+            Some(consensus) => Ok(ErasedJson::pretty(consensus.bft().primary().gateway().connected_peers())),
+            None => Err(RestError::service_unavailable(anyhow!("Route isn't available for this node type"))),
+        }
     }
 
     /// GET /<network>/node/address


### PR DESCRIPTION
## Motivation
Currently, one can query the connected router peers (through `{network}/peers/..`) but not validators connected through the gateway.

This PR adds a new set of endpoints `{network}/connection/bft/..` and `{network}/connections/p2p/..`. The former allows querying connected validators, while the latter is just an alias for the `{network}/peers/..` endpoint.

## Test Plan
The new endpoint is used in the sync benchmark to test that validators are fully connected to each other. Successfully running that benchmark validates that the endpoint works as expected.

## Backwards compatibility
Initially, I hoped we could just include the validators in the existing `peers` endpoint, but I added the new endpoints to avoid breaking existing functionality.

## Benchmark fixes
Recent changes on staging broke the benchmark workflow. This PR also contains a commit that fixes the workflow.
