### PR TITLE
[CI] Fix DB backup script and add ci-runner logging

### DIFF
--- a/.ci/bench_bft_sync.sh
+++ b/.ci/bench_bft_sync.sh
@@ -88,7 +88,7 @@ for node_index in $(seq 1 "$num_nodes"); do
 done
 
 # Block until nodes are running and connected to each other.
-wait_for_nodes $((num_nodes+1)) 0
+wait_for_nodes $((num_nodes+1)) 0 "$network_name"
 
 SECONDS=0
 

--- a/.ci/bench_bft_sync.sh
+++ b/.ci/bench_bft_sync.sh
@@ -35,8 +35,7 @@ snapshot_info=$(<info.txt)
 echo "Snapshot_info: ${snapshot_info}"
 
 # Create log directory
-log_dir=".logs-$(date +"%Y%m%d%H%M%S")"
-mkdir -p "$log_dir"
+init_log_dir
 
 # Define a trap handler that cleans up all processes on exit.
 # shellcheck disable=SC2329

--- a/.ci/bench_cdn_sync.sh
+++ b/.ci/bench_cdn_sync.sh
@@ -18,12 +18,11 @@ poll_interval=1 # Check block heights every second
 # shellcheck source=SCRIPTDIR/utils.sh
 . ./.ci/utils.sh
 
+# Create log directory
+init_log_dir
+
 network_name=$(get_network_name $network_id)
 echo "Using network: $network_name (ID: $network_id)"
-
-# Create log directory
-log_dir=".logs-$(date +"%Y%m%d%H%M%S")"
-mkdir -p "$log_dir"
 
 # Define a trap handler that cleans up all processes on exit.
 # shellcheck disable=SC2329

--- a/.ci/bench_p2p_sync.sh
+++ b/.ci/bench_p2p_sync.sh
@@ -133,12 +133,12 @@ for client_index in $(seq 1 "$num_clients"); do
 done
 
 # Block until nodes are running and connected to each other.
-wait_for_nodes $((num_clients+1)) 0
+wait_for_nodes $((num_clients+1)) 0 "$network_name"
 
 # It takes about 30s for nodes to connect. Do not measure this time.
 SECONDS=0
 for node_index in $(seq 0 "$num_clients"); do
-  if ! (wait_for_peers "$node_index" $num_clients); then
+  if ! (wait_for_peers "$node_index" $num_clients "$network_name"); then
     exit 1
   fi
 done

--- a/.ci/bench_p2p_sync.sh
+++ b/.ci/bench_p2p_sync.sh
@@ -27,6 +27,9 @@ poll_interval=1 # Check block heights every second
 # shellcheck source=SCRIPTDIR/utils.sh
 . ./.ci/utils.sh
 
+# Create log directory
+init_log_dir
+
 # Running sums for variance: use sum and sumsq for unbiased sample variance
 sum_speed=0
 sumsq_speed=0
@@ -83,10 +86,6 @@ echo "Using network: $network_name (ID: $network_id)"
 
 snapshot_info=$(<info.txt)
 echo "Snapshot_info: ${snapshot_info}"
-
-# Create log directory
-log_dir=".logs-$(date +"%Y%m%d%H%M%S")"
-mkdir -p "$log_dir"
 
 # Define a trap handler that cleans up all processes on exit.
 trap stop_nodes EXIT

--- a/.ci/bench_rest_api.sh
+++ b/.ci/bench_rest_api.sh
@@ -17,6 +17,9 @@ log_filter="info,snarkos_node_sync=debug,snarkos_node_tcp=warn,snarkos_node_rest
 #shellcheck source=SCRIPTDIR/utils.sh
 . ./.ci/utils.sh
 
+# Create log directory
+init_log_dir
+
 branch_name=$(git rev-parse --abbrev-ref HEAD)
 echo "On branch: ${branch_name}"
 
@@ -25,10 +28,6 @@ echo "Using network: $network_name (ID: $network_id)"
 
 snapshot_info=$(<info.txt)
 echo "Snapshot_info: ${snapshot_info}"
-
-# Create log directory
-log_dir=".logs-$(date +"%Y%m%d%H%M%S")"
-mkdir -p "$log_dir"
 
 # Define a trap handler that cleans up all processes on exit.
 trap stop_nodes EXIT

--- a/.ci/db_backup_ci.sh
+++ b/.ci/db_backup_ci.sh
@@ -40,7 +40,8 @@ for ((validator_index = 0; validator_index < total_validators; validator_index++
 
   log_file="$log_dir/validator-$validator_index.log"
   snarkos start --nodisplay --network $network_id --dev $validator_index --dev-num-validators $total_validators \
-    --validator --jwt-secret $jwt_secret --jwt-timestamp $jwt_ts --verbosity $log_verbosity "--logfile=$log_file" &
+    --validator --jwt-secret $jwt_secret --jwt-timestamp $jwt_ts --verbosity $log_verbosity "--logfile=$log_file" \
+    "--node-data-storage=/tmp/node_data_$validator_index" "--ledger-storage=/tmp/ledger_$validator_index" &
   PIDS[validator_index]=$!
   log "Started validator $validator_index with PID ${PIDS[$validator_index]}"
   # Add 1-second delay between starting nodes to avoid hitting rate limits
@@ -95,15 +96,16 @@ while (( total_wait < 600 )); do  # 10 minutes max
       wait
 
       for ((validator_index = 0; validator_index < total_validators; validator_index++)); do
-        # Remove the original ledger
-        if (( num_checkpoints == 1 )); then
-          snarkos clean "--network=$network_id" "--dev=$validator_index"
+        # Remove the ledger storage. The node data is not backed up yet and will be kept. 
+        if (( num_checkpoints == 1 )); then 
+          # Remove the original ledger
+          snarkos clean "--network=$network_id" "--dev=$validator_index" --keep-node-data \
+              "--ledger-storage=/tmp/ledger_$validator_index"
         else
+          # Remove the checkpoint
           suffix="${validator_index}_$((num_checkpoints-2))"
-          # only remove ledger, until node-data is backed up properly.
-          rm -rf "/tmp/checkpoint_$suffix"
-          #snarkos clean "--network=$network_id" "--dev=validator_index" \
-          #    "--node-data-storage=/tmp/node_data" "--ledger-storage=/tmp/checkpoint_$suffix"
+          snarkos clean "--network=$network_id" "--dev=$validator_index" --keep-node-data \
+              "--ledger-storage=/tmp/ledger_checkpoint_$suffix"
         fi
         # Wait until the cleanup concludes
         sleep 1
@@ -113,7 +115,7 @@ while (( total_wait < 600 )); do  # 10 minutes max
         log_file="$log_dir/validator-$validator_index.log"
         snarkos start --nodisplay "--network=$network_id" "--dev=$validator_index" "--dev-num-validators=$total_validators" \
           --validator "--jwt-secret=$jwt_secret" "--jwt-timestamp=$jwt_ts" --verbosity $log_verbosity "--logfile=$log_file" \
-          "--node-data-storage=/tmp/node_data" "--ledger-storage=/tmp/checkpoint_$suffix" &
+          "--node-data-storage=/tmp/node_data_$validator_index" "--ledger-storage=/tmp/ledger_checkpoint_$suffix" &
         PIDS[validator_index]=$!
         log "Restarted validator $validator_index with PID ${PIDS[$validator_index]}"
         # Add 1-second delay between starting nodes to avoid hitting rate limits

--- a/.ci/db_backup_ci.sh
+++ b/.ci/db_backup_ci.sh
@@ -3,6 +3,9 @@
 #shellcheck source=SCRIPTDIR/utils.sh
 . ./.ci/utils.sh
 
+# Change this to increase/decrease log verbosity
+log_verbosity=2
+
 # Network parameters
 total_validators=4
 network_id=0
@@ -13,6 +16,9 @@ checkpoint_height=3
 rollback_height=10
 num_checkpoints=0
 remaining_checkpoints=2
+
+# Create log directory
+init_log_dir
 
 # Use fixed JWT values in order to be able to create checkpoints
 jwt_secret="ZGJjaGVja3BvaW50dGVzdA=="
@@ -26,15 +32,17 @@ jwt[3]="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbGVvMTJ1eDNnZGF1Y2swdjY
 trap stop_nodes EXIT
 
 # Define a trap handler that prints a message when an error occurs 
-trap 'echo "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
+trap 'log "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
 
 # Start all validator nodes in the background
 for ((validator_index = 0; validator_index < total_validators; validator_index++)); do
   snarkos clean --dev $validator_index --network=$network_id
 
-  snarkos start --nodisplay --network $network_id --dev $validator_index --dev-num-validators $total_validators --validator --jwt-secret $jwt_secret --jwt-timestamp $jwt_ts &
+  log_file="$log_dir/validator-$validator_index.log"
+  snarkos start --nodisplay --network $network_id --dev $validator_index --dev-num-validators $total_validators \
+    --validator --jwt-secret $jwt_secret --jwt-timestamp $jwt_ts --verbosity $log_verbosity "--logfile=$log_file" &
   PIDS[validator_index]=$!
-  echo "Started validator $validator_index with PID ${PIDS[$validator_index]}"
+  log "Started validator $validator_index with PID ${PIDS[$validator_index]}"
   # Add 1-second delay between starting nodes to avoid hitting rate limits
   sleep 1
 done
@@ -52,18 +60,18 @@ function create_checkpoints() {
     fi
   done
 
-  echo "All nodes created a checkpoint"
+  log "All nodes created a checkpoint"
   return 0
 }
 
-wait_for_nodes "$total_validators" 0 
+wait_for_nodes "$total_validators" 0 "$network_name"
 
 # Check heights periodically with a timeout
 total_wait=0
 checkpoint_created=false
 while (( total_wait < 600 )); do  # 10 minutes max
   # Apply short-circuiting
-  if [[ $checkpoint_created = true ]] || check_heights  "$total_validators" 0 "$checkpoint_height" "$network_name"; then
+  if [[ $checkpoint_created = true ]] || check_heights  0 "$total_validators" "$checkpoint_height" "$network_name"; then
     if [[ $checkpoint_created = false ]]; then
       # Create checkpoints at the specified height
       create_checkpoints $num_checkpoints
@@ -71,13 +79,13 @@ while (( total_wait < 600 )); do  # 10 minutes max
       checkpoint_height=$((checkpoint_height+2))
       num_checkpoints=$((num_checkpoints+1))
 
-      echo "num_checkpoints: $num_checkpoints"
+      log "num_checkpoints: $num_checkpoints"
       sleep 2
     fi
 
     # Wait until the specified rollback height is reached
-    if check_heights "$total_validators" 0 "$rollback_height" "$network_name"; then
-      echo "All nodes reached rollback height."
+    if check_heights 0 "$total_validators" "$rollback_height" "$network_name"; then
+      log "All nodes reached rollback height."
 
       checkpoint_created=false
 
@@ -92,32 +100,38 @@ while (( total_wait < 600 )); do  # 10 minutes max
           snarkos clean "--network=$network_id" "--dev=$validator_index"
         else
           suffix="${validator_index}_$((num_checkpoints-2))"
-          snarkos clean "--network=$network_id" "--dev=validator_index" "--path=/tmp/checkpoint_$suffix"
+          # only remove ledger, until node-data is backed up properly.
+          rm -rf "/tmp/checkpoint_$suffix"
+          #snarkos clean "--network=$network_id" "--dev=validator_index" \
+          #    "--node-data-storage=/tmp/node_data" "--ledger-storage=/tmp/checkpoint_$suffix"
         fi
         # Wait until the cleanup concludes
         sleep 1
+
         # Restart using the checkpoint
         suffix="${validator_index}_$((num_checkpoints-1))"
+        log_file="$log_dir/validator-$validator_index.log"
         snarkos start --nodisplay "--network=$network_id" "--dev=$validator_index" "--dev-num-validators=$total_validators" \
-          --validator "--jwt-secret=$jwt_secret" "--jwt-timestamp=$jwt_ts" "--storage=/tmp/checkpoint_$suffix" &
+          --validator "--jwt-secret=$jwt_secret" "--jwt-timestamp=$jwt_ts" --verbosity $log_verbosity "--logfile=$log_file" \
+          "--node-data-storage=/tmp/node_data" "--ledger-storage=/tmp/checkpoint_$suffix" &
         PIDS[validator_index]=$!
-        echo "Restarted validator $validator_index with PID ${PIDS[$validator_index]}"
+        log "Restarted validator $validator_index with PID ${PIDS[$validator_index]}"
         # Add 1-second delay between starting nodes to avoid hitting rate limits
         sleep 1
 
         port=$((3030 + validator_index))
         height=$(curl -s "http://127.0.0.1:$port/$network_name/block/height/latest" || echo "0")
-        echo "Node height after restart: $height"
+        log "Node height after restart: $height"
 
         # Ensure that the height is below the rollback height
         if [[ "$height" =~ ^[0-9]+$ ]] && (( height >= rollback_height )) && (( height < checkpoint_height )); then
-          echo "❌ Test failed!"
+          log "❌ Test failed!"
           exit 1
         fi
       done
 
       if (( remaining_checkpoints == 0 )); then
-        echo "SUCCESS!"
+        log "SUCCESS!"
         exit 0
       fi
 
@@ -128,9 +142,9 @@ while (( total_wait < 600 )); do  # 10 minutes max
   # Continue waiting
   sleep 3
   total_wait=$((total_wait + 3))
-  echo "Waited $total_wait seconds so far..."
+  log "Waited $total_wait seconds so far..."
 done
 
 # The main loop has expired by now
-echo "❌ Test failed!"
+log "❌ Test failed!"
 exit 1

--- a/.ci/devnet_ci.sh
+++ b/.ci/devnet_ci.sh
@@ -32,9 +32,7 @@ network_name=$(get_network_name "$network_id")
 echo "Using network: $network_name (ID: $network_id)"
 
 # Create log directory
-log_dir="$PWD/.logs-$(date +"%Y%m%d%H%M%S")"
-mkdir -p "$log_dir"
-chmod 755 "$log_dir"
+init_log_dir
 
 # Ensures we use IPv4 localhost everywhere.
 localhost="127.0.0.1"
@@ -52,7 +50,7 @@ function exit_handler() {
 trap exit_handler EXIT
 
 # Define a trap handler that prints a message when an error occurs 
-trap 'echo "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
+trap 'log "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
 
 # Flags used by all nodes.
 common_flags=(
@@ -74,7 +72,7 @@ for validator_index in $(seq 0 $((total_validators-1))); do
       --validator "--logfile=$log_file" "--rest=127.0.0.1:$((3030+validator_index))" &
   fi
   PIDS[validator_index]=$!
-  echo "Started validator $validator_index with PID ${PIDS[$validator_index]}"
+  log "Started validator $validator_index with PID ${PIDS[$validator_index]}"
 
   # Add 1-second delay between starting nodes to avoid hitting rate limits
   sleep 1
@@ -91,7 +89,7 @@ for client_index in $(seq 0 $((total_clients-1))); do
   snarkos start "${common_flags[@]}" "--dev=$node_index" \
     --client "--logfile=$log_file" "--rest=127.0.0.1:$((3030+node_index))" &
   PIDS[node_index]=$!
-  echo "Started client $client_index with PID ${PIDS[$node_index]}"
+  log "Started client $client_index with PID ${PIDS[$node_index]}"
   # Add 1-second delay between starting nodes to avoid hitting rate limits
   if (( client_index < total_clients-1)); then
     sleep 1
@@ -101,15 +99,17 @@ done
 # Ensure all nodes are up and running.
 wait_for_nodes "$total_validators" "$total_clients" "$network_name"
 
-# Ensure all nodes have at least one peer
-echo "ℹ️ Waiting for all nodes to have at least one peer..."
+# Wait for all clients to be connected to another client or a validator.
+# TODO(kaimast): also check that validators are connected to each other.
+log "ℹ️ Waiting for all nodes to have at least one peer..."
 SECONDS=0
-for node_index in $(seq 0 $((total_clients+total_validators-1))); do
-  if ! (wait_for_peers "$node_index" 1 "$network_name"); then
+for node_index in $(seq 0 $((total_clients))); do
+  client_index=$node_index+total_validators
+  if ! (wait_for_peers "$client_index" 1 "$network_name"); then
     exit 1
   fi
 done
-echo "✅ All nodes have at least one peer"
+log "✅ All nodes have at least one peer"
 
 last_seen_consensus_version=0
 last_seen_height=0
@@ -120,19 +120,19 @@ function consensus_version_stable() {
   height=$(curl -s "http://$localhost:3030/v2/$network_name/block/height/latest")
 
   if (! is_integer "$consensus_version"); then
-    echo "❌ Failed to retrieve consensus version: $consensus_version"
+    log "❌ Failed to retrieve consensus version: $consensus_version"
     return 1
   elif (! is_integer "$height"); then
-    echo "❌ Failed to retrieve height: $height"
+    log "❌ Failed to retrieve height: $height"
     return 1
   else
     # If the consensus version is greater than the last seen, we update it.
     if (( consensus_version > last_seen_consensus_version )); then
-      echo "✅ Consensus version updated to $consensus_version"
+      log "✅ Consensus version updated to $consensus_version"
     # If the consensus version is the same whereas the block height is different and at least 10, we can assume that the consensus version is stable
     else
       if (( (height != last_seen_height) && (height >= 10) )); then
-        echo "✅ Consensus version is stable at $consensus_version with height $height"
+        log "✅ Consensus version is stable at $consensus_version with height $height"
         return 0
       fi
     fi
@@ -145,7 +145,7 @@ function consensus_version_stable() {
 }
 
 # Check consensus versions periodically with a timeout
-echo "ℹ️ Waiting for consensus version to stabilize..."
+log "ℹ️ Waiting for consensus version to stabilize..."
 SECONDS=0
 version_stable=false
 while (( SECONDS < 300 )); do  # 5 minutes max
@@ -156,11 +156,11 @@ while (( SECONDS < 300 )); do  # 5 minutes max
 
   # Continue waiting
   sleep 30
-  echo "Waited $SECONDS seconds so far..."
+  log "Waited $SECONDS seconds so far..."
 done
 
 if ! $version_stable; then
-  echo "❌ Test failed! Consensus version did not stabilize within 5 minutes."
+  log "❌ Test failed! Consensus version did not stabilize within 5 minutes."
   exit 1
 fi
 
@@ -190,44 +190,44 @@ echo "{
 " > program/program.json
 
 # Deploy the test program and wait for the deployment to be processed.
-echo "● Testing program deployment..."
+log "● Testing program deployment..."
 _deploy_result=$(cd program && snarkos developer deploy --dev-key 0 --network "$network_id" --endpoint=localhost:3030 --broadcast --wait --timeout 20 "$program_name")
 
 # Ensure we are able to fetch the program from the node.
 status_code=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:3030/v2/$network_name/program/${program_name}/0")
 if (( status_code == 200 )); then
-  echo "✅ Program exists on the node"
+  log "✅ Program exists on the node"
 else
-  echo "❌ Test failed! Failed to get program. Code was ${status_code}"
+  log "❌ Test failed! Failed to get program. Code was ${status_code}"
   exit 1
 fi
 
 # Ensure the latest edition is indeed 0.
-echo "● Testing retrieval of program editions..."
+log "● Testing retrieval of program editions..."
 edition=$(curl -s -o /dev/null "http://localhost:3030/v2/$network_name/program/${program_name}/latest_edition")
 if (( edition != 0 )); then
-  echo "❌ Test failed! Invalid latest edition {} for test program returned, not 0."
+  log "❌ Test failed! Invalid latest edition {} for test program returned, not 0."
   exit 1
 fi
 
 # Also check that the latest edition for the default program (credits.aleo) is 0.
 edition=$(curl -s -o /dev/null "http://localhost:3030/v2/$network_name/program/credits.aleo/latest_edition")
 if (( edition != 0 )); then
-  echo "❌ Test failed! Invalid latest edition {} for credits.aleo returned, not 0."
+  log "❌ Test failed! Invalid latest edition {} for credits.aleo returned, not 0."
   exit 1
 fi
 
 # Finally, check that we cannot fetch a non-existing edition of a program
 status_code=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:3030/v2/$network_name/program/${program_name}/1")
 if (( status_code == 404 )); then
-  echo "✅ Only program edition 0 exists on the node"
+  log "✅ Only program edition 0 exists on the node"
 else
-  echo "❌ Test failed! Invalid edition returnd ${status_code}, not 404."
+  log "❌ Test failed! Invalid edition returnd ${status_code}, not 404."
   exit 1
 fi
 
 # Execute a function in the deployed program and wait for the execution to be processed.
-echo "● Testing program execution with V2 API..."
+log "● Testing program execution with V2 API..."
 execute_result=$(cd program && snarkos developer execute --dev-key 0 --network "$network_id" --broadcast --endpoint=http://localhost:3030 \
     "$program_name" main 1u32 1u32 --wait --timeout 10)
 
@@ -240,12 +240,12 @@ if (( found < 200 || found >= 300 )); then
     "$execute_result" "$found"
   exit 1
 else
-  echo "✅ Transaction executed successfully: $execute_result"
+  log "✅ Transaction executed successfully: $execute_result"
 fi
 
 # Use the old flags here `--query` and `--broadcast=URL` to test they still work.
 # Also, use the v1 API to test it still works.
-echo "● Testing program execution with V1 API..."
+log "● Testing program execution with V1 API..."
 execute_result=$(cd program && snarkos developer execute --dev-key 0 --network "$network_id" --query=http://$localhost:3030/v1 \
     "--broadcast=http://$localhost:3030/v1/$network_name/transaction/broadcast" "$program_name" main 1u32 1u32 --wait --timeout 10)
 
@@ -258,11 +258,11 @@ if (( found < 200 || found >= 300 )); then
     "$execute_result" "$found"
   exit 1
 else
-  echo "✅ Transaction executed successfully: $execute_result"
+  log "✅ Transaction executed successfully: $execute_result"
 fi
 
 # Fail if status does not exist or is not set to "accepted".
-echo "● Testing confirmed transaction endpoint..."
+log "● Testing confirmed transaction endpoint..."
 rest_confirmed=$(curl -s "http://$localhost:3030/v2/$network_name/transaction/confirmed/$tx")
 
 rest_status=$(jq --raw-output '.status' <<< "$rest_confirmed")
@@ -271,10 +271,10 @@ if [ "$rest_status" != "accepted" ]; then
   exit 1
 fi
 
-echo "ℹ️Testing REST API and REST Error Handling"
+log "ℹ️Testing REST API and REST Error Handling"
 
 # Test invalid transaction data (JsonDataError) returns 422 Unprocessable Content
-echo "● Testing invalid transaction data returns 422 status code..."
+log "● Testing invalid transaction data returns 422 status code..."
 (cd program && snarkos developer execute --dev-key 0 --network "$network_id" \
   "--endpoint=$localhost:3030"  --store txn_data.json --store-format=string \
   "$program_name" main 1u32 1u32)
@@ -291,9 +291,9 @@ invalid_tx_status=$(curl -s -w "%{http_code}" -X POST \
   -o /dev/null)
 
 if (( invalid_tx_status == 422 )); then
-  echo "✅ Invalid transaction correctly returned 422 Unprocessable Content"
+  log "✅ Invalid transaction correctly returned 422 Unprocessable Content"
 else
-  echo "❌ Test failed! Invalid transaction returned $invalid_tx_status instead of 422"
+  log "❌ Test failed! Invalid transaction returned $invalid_tx_status instead of 422"
   exit 1
 fi
 
@@ -305,11 +305,11 @@ json_error=$(curl -s -X POST \
 
 # Ensure the top-level error message is "Invalid transaction"
 if ! jq -e '.message | test("Invalid transaction")' <<< "$json_error" > /dev/null ; then 
-  echo "❌ Test failed! Invalid JSON returned: \"$json_error\""
+  log "❌ Test failed! Invalid JSON returned: \"$json_error\""
   exit 1
 fi
 
-echo "✅ Invalid transaction return valid JSON error"
+log "✅ Invalid transaction return valid JSON error"
 
 # Test malformed JSON syntax (JsonSyntaxError) returns 400 Bad Request
 malformed_json_response=$(curl -s -w "%{http_code}" -X POST \
@@ -319,7 +319,7 @@ malformed_json_response=$(curl -s -w "%{http_code}" -X POST \
   -o /dev/null)
 
 if (( malformed_json_response == 400 )); then
-  echo "✅ Malformed JSON correctly returned 400 Bad Request"
+  log "✅ Malformed JSON correctly returned 400 Bad Request"
 else
   echo "❌ Test failed! Malformed JSON returned $malformed_json_response instead of 400"
   exit 1
@@ -333,28 +333,28 @@ malformed_json_error=$(curl -s -X POST \
 
 # Verify the message contains JSON-related error text
 if ! jq -e '.message | test("Invalid JSON")' <<< "$malformed_json_error" > /dev/null; then
-  echo "❌ Test failed! Malformed JSON response message doesn't contain expected JSON error text: \"$malformed_json_error\""
+  log "❌ Test failed! Malformed JSON response message doesn't contain expected JSON error text: \"$malformed_json_error\""
   exit 1
 fi
 
-echo "✅ Malformed JSON returns properly formatted RestError with JSON syntax error message"
+log "✅ Malformed JSON returns properly formatted RestError with JSON syntax error message"
 
 # Test invalid Content-Type header returns 400 Bad Request
-echo "● Testing missing Content-Type header returns 400 status code..."
+log "● Testing missing Content-Type header returns 400 status code..."
 missing_content_type_response=$(curl -s -w "%{http_code}" -X POST \
   -d '{"valid": "json"}' \
   "http://$localhost:3030/v2/$network_name/transaction/broadcast" \
   -o /dev/null)
 
 if (( missing_content_type_response == 400 )); then
-  echo "✅ Missing Content-Type correctly returned 400 Bad Request"
+  log "✅ Missing Content-Type correctly returned 400 Bad Request"
 else
-  echo "❌ Test failed! Missing Content-Type returned $missing_content_type_response instead of 400"
+  log "❌ Test failed! Missing Content-Type returned $missing_content_type_response instead of 400"
   exit 1
 fi
 
 # Test that missing Content-Type returns a properly formatted RestError
-echo "● Testing missing Content-Type returns valid RestError format..."
+log "● Testing missing Content-Type returns valid RestError format..."
 
 missing_content_type_error=$(curl -s -X POST \
   -d '{"valid": "json"}' \
@@ -362,38 +362,38 @@ missing_content_type_error=$(curl -s -X POST \
 
 # Verify the response is valid JSON
 if ! jq . <<< "$missing_content_type_error" > /dev/null 2>&1; then
-  echo "❌ Test failed! Missing Content-Type response is not valid JSON: \"$missing_content_type_error\""
+  log "❌ Test failed! Missing Content-Type response is not valid JSON: \"$missing_content_type_error\""
   exit 1
 fi
 
 # Verify the message contains Content-Type related error text
 if ! jq -e '.message | test("Content-Type|application/json")' <<< "$missing_content_type_error" > /dev/null; then
-  echo "❌ Test failed! Missing Content-Type response message doesn't contain expected error text: \"$missing_content_type_error\""
+  log "❌ Test failed! Missing Content-Type response message doesn't contain expected error text: \"$missing_content_type_error\""
   exit 1
 fi
 
-echo "✅ Missing Content-Type returns properly formatted RestError with Content-Type error message"
+log "✅ Missing Content-Type returns properly formatted RestError with Content-Type error message"
 
 # Scan the network for records.
-echo "● Testing \`snarkos developer scan\`..."
+log "● Testing \`snarkos developer scan\`..."
 
 scan_result=$(snarkos developer scan --dev-key 0 --network "$network_id" --start 0 "--endpoint=$localhost:3030")
 num_records=$(echo "$scan_result" | grep -c "owner")
 # Fail if the scan did not return 4 records.
 if (( num_records != 4 )); then
-  echo "❌ Test failed! Expected 4 records, but found $num_records: $scan_result"
+  log "❌ Test failed! Expected 4 records, but found $num_records: $scan_result"
   exit 1
 else
-  echo "✅ Scan returned 4 records correctly: $scan_result"
+  log "✅ Scan returned 4 records correctly: $scan_result"
 fi
 
-echo "ℹ️Testing network progress"
+log "ℹ️Testing network progress"
 
 # Check heights periodically with a timeout
 total_wait=0
 while (( total_wait < 600 )); do  # 10 minutes max
   if check_heights 0 $((total_validators+total_clients)) "$min_height" "$network_name" "$total_wait"; then
-    echo "🎉 Test passed! All nodes reached minimum height."
+    log "🎉 Test passed! All nodes reached minimum height."
 
     if check_logs "$log_dir" "$total_validators" "$total_clients"; then
       exit 0
@@ -405,11 +405,11 @@ while (( total_wait < 600 )); do  # 10 minutes max
   # Continue waiting
   sleep 30
   total_wait=$((total_wait + 30))
-  echo "Waited $total_wait seconds so far..."
+  log "Waited $total_wait seconds so far..."
 done
 
-echo "❌ Test failed! Not all nodes reached minimum height within 15 minutes."
-print_validator_logs "$log_dir" "$total_validators" "$total_clients"
-print_client_logs "$log_dir" "$total_validators" "$total_clients"
+log "❌ Test failed! Not all nodes reached minimum height within 15 minutes."
+log_validator_logs "$log_dir" "$total_validators" "$total_clients"
+log_client_logs "$log_dir" "$total_validators" "$total_clients"
 
 exit 1

--- a/.ci/devnet_ci.sh
+++ b/.ci/devnet_ci.sh
@@ -61,16 +61,17 @@ common_flags=(
 )
 
 # Start all validator nodes in the background
-for ((validator_index = 0; validator_index < total_validators; validator_index++)); do
+for validator_index in $(seq 0 $((total_validators-1))); do
   snarkos clean "--dev=$validator_index" "--network=$network_id"
 
   log_file="$log_dir/validator-$validator_index.log"
-  if [ $validator_index -eq 0 ]; then
+  if (( validator_index == 0 )); then
     snarkos start "${common_flags[@]}" "--dev=$validator_index" \
-      --validator "--logfile=$log_file" --metrics --no-dev-txs &
+      --validator "--logfile=$log_file" "--rest=127.0.0.1:$((3030+validator_index))" \
+      --metrics --no-dev-txs &
   else
     snarkos start "${common_flags[@]}" "--dev=$validator_index" \
-      --validator "--logfile=$log_file" &
+      --validator "--logfile=$log_file" "--rest=127.0.0.1:$((3030+validator_index))" &
   fi
   PIDS[validator_index]=$!
   echo "Started validator $validator_index with PID ${PIDS[$validator_index]}"
@@ -80,7 +81,7 @@ for ((validator_index = 0; validator_index < total_validators; validator_index++
 done
 
 # Start all client nodes in the background.
-for ((client_index = 0; client_index < total_clients; client_index++)); do
+for client_index in $(seq 0 $((total_clients-1))); do
   # compute the absolute index for this node.
   node_index=$((client_index + total_validators))
 
@@ -88,7 +89,7 @@ for ((client_index = 0; client_index < total_clients; client_index++)); do
 
   log_file="$log_dir/client-$client_index.log"
   snarkos start "${common_flags[@]}" "--dev=$node_index" \
-    --client "--logfile=$log_file" &
+    --client "--logfile=$log_file" "--rest=127.0.0.1:$((3030+node_index))" &
   PIDS[node_index]=$!
   echo "Started client $client_index with PID ${PIDS[$node_index]}"
   # Add 1-second delay between starting nodes to avoid hitting rate limits
@@ -98,13 +99,13 @@ for ((client_index = 0; client_index < total_clients; client_index++)); do
 done
 
 # Ensure all nodes are up and running.
-wait_for_nodes "$total_validators" "$total_clients"
+wait_for_nodes "$total_validators" "$total_clients" "$network_name"
 
 # Ensure all nodes have at least one peer
 echo "ℹ️ Waiting for all nodes to have at least one peer..."
 SECONDS=0
-for node_index in $(seq 0 $((total_clients+total_validators))); do
-  if ! (wait_for_peers "$node_index" 1); then
+for node_index in $(seq 0 $((total_clients+total_validators-1))); do
+  if ! (wait_for_peers "$node_index" 1 "$network_name"); then
     exit 1
   fi
 done
@@ -145,9 +146,9 @@ function consensus_version_stable() {
 
 # Check consensus versions periodically with a timeout
 echo "ℹ️ Waiting for consensus version to stabilize..."
-total_wait=0
+SECONDS=0
 version_stable=false
-while (( total_wait < 300 )); do  # 5 minutes max
+while (( SECONDS < 300 )); do  # 5 minutes max
   if consensus_version_stable; then
     version_stable=true
     break
@@ -155,8 +156,7 @@ while (( total_wait < 300 )); do  # 5 minutes max
 
   # Continue waiting
   sleep 30
-  total_wait=$((total_wait + 30))
-  echo "Waited $total_wait seconds so far..."
+  echo "Waited $SECONDS seconds so far..."
 done
 
 if ! $version_stable; then

--- a/.ci/generate_ledger.sh
+++ b/.ci/generate_ledger.sh
@@ -29,16 +29,14 @@ poll_interval=10
 #shellcheck source=SCRIPTDIR/utils.sh
 . ./.ci/utils.sh
 
+# Create log directory
+init_log_dir
+
 git_commit=$(git rev-parse --short=10 HEAD)
 echo "On git commit ${git_commit}"
 
 network_name=$(get_network_name "$network_id")
 echo "Network set to $network_name with $total_validators validators"
-
-# Create log directory
-log_dir="$PWD/.logs-$(date +"%Y%m%d%H%M%S")"
-mkdir -p "$log_dir"
-chmod 755 "$log_dir"
 
 # Define a trap handler that cleans up all processes on exit.
 #shellcheck disable=SC2329

--- a/.ci/upgrade_nodes_ci.sh
+++ b/.ci/upgrade_nodes_ci.sh
@@ -39,22 +39,8 @@ WAIT_BETWEEN_UPGRADES="${WAIT_BETWEEN_UPGRADES:-60}"
 # shellcheck disable=SC1091
 . ./.ci/utils.sh
 
-########################################
-# Logging helpers
-########################################
-
-# Log a message to the console.
-function log() {
-  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
-}
-
-# Checks that the given command is available in the PATH.
-function require_cmd() {
-  if ! command -v "$1" >/dev/null 2>&1; then
-    echo "ERROR: required command '$1' not found in PATH" >&2
-    exit 1
-  fi
-}
+# Set up logging directory
+init_log_dir
 
 # Reuse the same target dir for all builds (release + PR) to get incremental builds.
 export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$PWD/.ci/target}"
@@ -186,10 +172,6 @@ SNARKOS_CURRENT_BIN="${SNARKOS_CURRENT_BIN:-snarkos}"
 network_name=$(get_network_name "$network_id")
 log "Using network: $network_name (ID: $network_id)"
 
-log_dir="$PWD/.logs-upgrade-$(date +"%Y%m%d%H%M%S")"
-mkdir -p "$log_dir"
-chmod 755 "$log_dir"
-
 declare -a PIDS
 
 # Handler that stops all nodes on shutdown.
@@ -200,7 +182,7 @@ exit_handler() {
 
 # Install signal handlers.
 trap exit_handler EXIT
-trap 'echo "Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
+trap 'log "⛔️ Error in $BASH_SOURCE at line $LINENO: \"$BASH_COMMAND\" failed (exit $?)"' ERR
 
 common_flags=(
   --nodisplay "--network=$network_id" "--verbosity=$NODE_VERBOSITY"

--- a/.ci/utils.sh
+++ b/.ci/utils.sh
@@ -7,6 +7,9 @@
 # Array to store PIDs of all processes
 declare -a PIDS
 
+# The log directory variable. Will be initialized by init_log_dirl
+log_dir="$PWD/.logs-$(date +"%Y%m%d%H%M%S")"
+
 # How many cores should each node use?
 # (Should be half of the number of (v)CPUs)
 # NOTE: when you update this, update TASKSET1/2 as well.
@@ -40,6 +43,28 @@ function check_node_stopped() {
   return 1
 }
 
+# Set up a logging directory that nodes and "ci-runner: logs are storeed in
+function init_log_dir() {
+  mkdir -p "$log_dir"
+  chmod 755 "$log_dir"
+  log "Created log directory: $log_dir"
+}
+
+# Checks that the given command is available in the PATH.
+function require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: required command '$1' not found in PATH" >&2
+    exit 1
+  fi
+}
+
+# Write a log message to the console and "ci-runner.log".
+function log() {
+  msg="[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+  echo "$msg" >> "$log_dir/ci-runner.log"
+  echo "$msg"
+}
+
 # Function checking that each node in the given range [start_index, end_index)
 # reached a minimum block height.
 function check_heights() {
@@ -51,6 +76,11 @@ function check_heights() {
 
   local all_reached=true
   local highest_height=0
+
+  if (( end_index <= start_index )); then
+    log "❌ Invalid range: $end_index <= $start_index"
+    exit 1 
+  fi
 
   for node_index in $(seq "$start_index" $((end_index-1))); do
     port=$((3030 + node_index))
@@ -92,12 +122,12 @@ function check_logs() {
 
   for validator_index in $(seq 0 $((total_validators-1))); do 
     if [ ! -s "$log_dir/validator-${validator_index}.log" ]; then
-      echo "❌ Test failed! Validator #${validator_index} did not create any logs in \"$log_dir\"."
+      log "❌ Test failed! Validator #${validator_index} did not create any logs in \"$log_dir\"."
       return 1
     fi
 
     if grep -q "ERROR" "$log_dir/validator-${validator_index}.log"; then
-      echo "❌ Test failed! Validator #${validator_index} logs contain errors."
+      log "❌ Test failed! Validator #${validator_index} logs contain errors."
       # Print the errors to the console.
       grep "ERROR" "$log_dir/validator-${validator_index}.log"
       return 1
@@ -106,12 +136,12 @@ function check_logs() {
 
   for client_index in $(seq 0 $((total_clients-1))); do
     if [ ! -s "$log_dir/client-${client_index}.log" ]; then
-      echo "❌ Test failed! Client #${client_index} did not create any logs in \"$log_dir\"."
+      log "❌ Test failed! Client #${client_index} did not create any logs in \"$log_dir\"."
       return 1
     fi
 
     if grep -q "ERROR" "$log_dir/client-${client_index}.log"; then
-      echo "❌ Test failed! Client #${client_index} logs contain errors."
+      log "❌ Test failed! Client #${client_index} logs contain errors."
       # Print the errors to the console.
       grep "ERROR" "$log_dir/client-${client_index}.log"
       return 1
@@ -145,7 +175,7 @@ function get_network_name() {
 
 # Stops all running processe in the given list.
 function stop_nodes() {
-  echo "🚨 Cleaning up ${#PIDS[@]} process(es)…"
+  log "🚨 Cleaning up ${#PIDS[@]} process(es)…"
   for pid in "${PIDS[@]}"; do
     if kill -0 "$pid" 2>/dev/null; then
       kill -9 "$pid" 2>/dev/null || true
@@ -167,7 +197,7 @@ function check_nodes() {
     status=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$port/v2/$network_name/version")
     # Fail if the HTTP response is not 2XX.
     if (( status < 200 || status > 300 )); then
-      echo "Node #${node_index} (port=$port) is not ready yet"
+      log "Node #${node_index} (port=$port) is not ready yet"
       return 1
     fi
   done
@@ -199,24 +229,31 @@ function wait_for_peers() {
   local min_peers=$2
   local network_name=$3
 
-  local total_wait=0
   local max_wait=300
   local poll_interval=1
   local port=$((3030+node_index))
+
+  SECONDS=0
   
-  while (( total_wait < max_wait )); do
+  while (( SECONDS < max_wait )); do
     result=$(curl -s "http://localhost:$port/v2/$network_name/peers/count")
 
-    if (is_integer "$result") && (( result >= min_peers )); then
+    if (is_integer "$result"); then
+      if (( result < min_peers )); then
+        log "Node #${node_index} (port=$port) has $result peers, expected at least $min_peers. Will wait and retry..."
+      else 
+        return 0
+      fi
+    else
+      log "Failed to get number of peers for node #${node_index} (port=$port). Will retry..."
       return 0
     fi
 
     # Continue waiting
     sleep $poll_interval
-    total_wait=$((total_wait+poll_interval))
   done
 
-  echo "❌ Nodes did not connect within 5 minutes."
+  log "❌ Nodes did not connect within 5 minutes."
   return 1
 }
 
@@ -248,7 +285,7 @@ function wait_for_sync_peers() {
 
 # Blocks until the network is ready.
 function wait_for_nodes() {
-  echo "Waiting for nodes to become ready"
+  log "Waiting for nodes to become ready"
   
   local total_validators=$1
   local total_clients=$2
@@ -261,12 +298,12 @@ function wait_for_nodes() {
 
   while (( SECONDS < max_wait )); do
     if check_node_stopped; then
-      echo "ERROR: one or more nodes stopped unexpectedly"
+      log "ERROR: one or more nodes stopped unexpectedly"
       return 1
     fi
     
     if check_nodes "$total_validators" "$total_clients" "$network_name"; then
-      echo "✅ All nodes are ready!"
+      log  "✅ All nodes are ready!"
       return 0
     fi
 
@@ -274,7 +311,7 @@ function wait_for_nodes() {
     sleep $poll_interval
   done
 
-  echo "❌ Nodes did not become ready within 60 seconds."
+  log "❌ Nodes did not become ready within 60 seconds."
   return 1
 }
 

--- a/.ci/utils.sh
+++ b/.ci/utils.sh
@@ -36,7 +36,7 @@ function check_node_stopped() {
   for i in "${!PIDS[@]}"; do
     local pid="${PIDS[i]}"
     if ! kill -0 "$pid" 2>/dev/null; then
-      echo "Node #${i} (pid=$pid) has exited unexpectedly"
+      log "Node #${i} (pid=$pid) has exited unexpectedly"
       return 0
     fi
   done
@@ -92,18 +92,18 @@ function check_heights() {
     fi
     
     if ! (is_integer "$height") || (( height < min_height )); then
-      echo "Node #${node_index} (port=$port) only reached height $height, expected at least $min_height"
+      log "Node #${node_index} (port=$port) only reached height $height, expected at least $min_height"
       all_reached=false
     fi
   done
   
   if $all_reached; then
-    echo "✅ SUCCESS: All nodes reached minimum height of $min_height"
+    log "✅ SUCCESS: All nodes reached minimum height of $min_height"
     return 0
   else
     if (( elapsed > 0 && ((elapsed % 60) == 0) )); then
       elapsed_mins=$((elapsed / 60))
-      echo "⏳ WAITING: Not all nodes reached minimum height of $min_height (highest so far: $highest_height, elapsed: $elapsed_mins minutes)"
+      log "⏳ WAITING: Not all nodes reached minimum height of $min_height (highest so far: $highest_height, elapsed: $elapsed_mins minutes)"
     fi
 
     return 1
@@ -112,7 +112,7 @@ function check_heights() {
 
 # Function checking that nodes created logs on disk and they contain no errors.
 function check_logs() {
-  echo "Checking logs exist for all nodes..."
+  log "Checking logs exist for all nodes..."
   local log_dir=$1
   local total_validators=$2
   local total_clients=$3

--- a/.ci/utils.sh
+++ b/.ci/utils.sh
@@ -43,7 +43,7 @@ function check_node_stopped() {
   return 1
 }
 
-# Set up a logging directory that nodes and "ci-runner: logs are storeed in
+# Set up a logging directory that node and ci-runner logs are stored in
 function init_log_dir() {
   mkdir -p "$log_dir"
   chmod 755 "$log_dir"

--- a/.ci/utils.sh
+++ b/.ci/utils.sh
@@ -90,7 +90,7 @@ function check_logs() {
   local all_reached=true
   local highest_height=0
 
-  for ((validator_index = 0; validator_index < total_validators; validator_index++)); do
+  for validator_index in $(seq 0 $((total_validators-1))); do 
     if [ ! -s "$log_dir/validator-${validator_index}.log" ]; then
       echo "❌ Test failed! Validator #${validator_index} did not create any logs in \"$log_dir\"."
       return 1
@@ -104,7 +104,7 @@ function check_logs() {
     fi
   done
 
-  for ((client_index = 0; client_index < total_clients; client_index++)); do
+  for client_index in $(seq 0 $((total_clients-1))); do
     if [ ! -s "$log_dir/client-${client_index}.log" ]; then
       echo "❌ Test failed! Client #${client_index} did not create any logs in \"$log_dir\"."
       return 1
@@ -160,12 +160,14 @@ function stop_nodes() {
 function check_nodes() {
   local total_validators=$1
   local total_clients=$2
+  local network_name=$3
 
-  for ((node_index = 0; node_index < total_validators + total_clients; node_index++)); do
+  for node_index in $(seq 0 $((total_validators+total_clients-1))); do
     port=$((3030 + node_index))
-    status=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:3030/v2/$network_name/version")
+    status=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$port/v2/$network_name/version")
     # Fail if the HTTP response is not 2XX.
     if (( status < 200 || status > 300 )); then
+      echo "Node #${node_index} (port=$port) is not ready yet"
       return 1
     fi
   done
@@ -195,13 +197,15 @@ function is_float() {
 function wait_for_peers() {
   local node_index=$1
   local min_peers=$2
+  local network_name=$3
 
   local total_wait=0
   local max_wait=300
   local poll_interval=1
+  local port=$((3030+node_index))
   
   while (( total_wait < max_wait )); do
-    result=$(curl -s "http://localhost:3030/v2/$network_name/peers/count")
+    result=$(curl -s "http://localhost:$port/v2/$network_name/peers/count")
 
     if (is_integer "$result") && (( result >= min_peers )); then
       return 0
@@ -248,21 +252,30 @@ function wait_for_nodes() {
   
   local total_validators=$1
   local total_clients=$2
+  local network_name=$3
 
-  while true; do
+  local max_wait=60
+  local poll_interval=1
+
+  SECONDS=0
+
+  while (( SECONDS < max_wait )); do
     if check_node_stopped; then
       echo "ERROR: one or more nodes stopped unexpectedly"
       return 1
     fi
     
-    if check_nodes "$total_validators" "$total_clients"; then
-      echo "All nodes are ready!"
+    if check_nodes "$total_validators" "$total_clients" "$network_name"; then
+      echo "✅ All nodes are ready!"
       return 0
     fi
 
     # Pause to give the nodes time to start up.
-    sleep 1
+    sleep $poll_interval
   done
+
+  echo "❌ Nodes did not become ready within 60 seconds."
+  return 1
 }
 
 # Compute the throughput for a number of operation over some time.

--- a/cli/src/commands/clean.rs
+++ b/cli/src/commands/clean.rs
@@ -40,8 +40,12 @@ pub struct Clean {
     #[clap(long, alias = "path")]
     pub ledger_storage: Option<PathBuf>,
 
+    /// Keep the node data directory (disabled by default).
+    #[clap(long)]
+    pub keep_node_data: bool,
+
     /// Sets a custom path for the node configuration. Overrides the default path (also for dev).
-    #[clap(long, alias = "node-data-path")]
+    #[clap(long, alias = "node-data-path", conflicts_with = "keep_node_data")]
     pub node_data_storage: Option<PathBuf>,
 }
 
@@ -49,8 +53,10 @@ impl Clean {
     /// Cleans the snarkOS node storage.
     pub fn parse(self) -> Result<String> {
         // Remove the specified node configuration from storage.
-        let node_data_dir = parse_node_data_dir(&self.node_data_storage, self.network, self.dev)?;
-        println!("{}", Self::remove_node_data(&node_data_dir)?);
+        if !self.keep_node_data {
+            let node_data_dir = parse_node_data_dir(&self.node_data_storage, self.network, self.dev)?;
+            println!("{}", Self::remove_node_data(&node_data_dir)?);
+        }
 
         // Remove the specified ledger from storage.
         let storage_mode = match self.ledger_storage {

--- a/cli/src/commands/clean.rs
+++ b/cli/src/commands/clean.rs
@@ -36,25 +36,24 @@ pub struct Clean {
     #[clap(long)]
     pub dev: Option<u16>,
 
-    /// Specify the path to a directory containing the ledger. Overrides the default path (also for
-    /// dev).
-    #[clap(long = "path")]
-    pub path: Option<PathBuf>,
+    /// Specify the path to a directory containing the ledger. Overrides the default path (also for dev).
+    #[clap(long, alias = "path")]
+    pub ledger_storage: Option<PathBuf>,
 
-    /// Sets a custom path for the node configuration.
-    #[clap(long)]
-    pub node_data_path: Option<PathBuf>,
+    /// Sets a custom path for the node configuration. Overrides the default path (also for dev).
+    #[clap(long, alias = "node-data-path")]
+    pub node_data_storage: Option<PathBuf>,
 }
 
 impl Clean {
     /// Cleans the snarkOS node storage.
     pub fn parse(self) -> Result<String> {
         // Remove the specified node configuration from storage.
-        let node_data_dir = parse_node_data_dir(&self.node_data_path, self.network, self.dev)?;
+        let node_data_dir = parse_node_data_dir(&self.node_data_storage, self.network, self.dev)?;
         println!("{}", Self::remove_node_data(&node_data_dir)?);
 
         // Remove the specified ledger from storage.
-        let storage_mode = match self.path {
+        let storage_mode = match self.ledger_storage {
             Some(path) => StorageMode::Custom(path),
             None => match self.dev {
                 Some(id) => StorageMode::Development(id),

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -565,17 +565,17 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         }
     }
 
-    /// GET /<network>/peers/count
+    /// GET /<network>/peers/count (alias: /connections/p2p/count)
     pub(crate) async fn get_peers_count(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.routing.router().number_of_connected_peers())
     }
 
-    /// GET /<network>/peers/all
+    /// GET /<network>/peers/all (alias: /connections/p2p/all)
     pub(crate) async fn get_peers_all(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.routing.router().connected_peers())
     }
 
-    /// GET /<network>/peers/all/metrics
+    /// GET /<network>/peers/all/metrics (alias: /connections/p2p/all/metrics)
     pub(crate) async fn get_peers_all_metrics(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.routing.router().connected_metrics())
     }

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -565,17 +565,17 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         }
     }
 
-    /// GET /<network>/peers/count (alias: /connections/p2p/count)
+    /// GET /<network>/peers/count
     pub(crate) async fn get_peers_count(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.routing.router().number_of_connected_peers())
     }
 
-    /// GET /<network>/peers/all (alias: /connections/p2p/all)
+    /// GET /<network>/peers/all
     pub(crate) async fn get_peers_all(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.routing.router().connected_peers())
     }
 
-    /// GET /<network>/peers/all/metrics (alias: /connections/p2p/all/metrics)
+    /// GET /<network>/peers/all/metrics
     pub(crate) async fn get_peers_all_metrics(State(rest): State<Self>) -> ErasedJson {
         ErasedJson::pretty(rest.routing.router().connected_metrics())
     }


### PR DESCRIPTION
This PR properly handles "node-data" in `db_backup_ci.sh`. It also adds an alias for `snarkos clean` arguments that match those of `snarkos run`, and a `--keep-node-data` option.

Finally, it changes existing CI scripts to use a `log` command, similar to the one that was already available in `db_backup_ci.sh`. The command will log each CI runner output with a timestamp and also write it to a file name `ci-runner.log`. This makes it a lot easier to determine what a script is doing or stuck on when there is a lot of output.