### PR TITLE
[Fix] Ban peers with invalid/outdated consensus versions

### DIFF
--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -30,6 +30,7 @@ use snarkos_node_router::{
         UnconfirmedTransaction,
     },
 };
+use snarkos_node_sync::InsertBlockResponseError;
 use snarkos_node_tcp::{Connection, ConnectionSide, Tcp};
 use snarkvm::{
     console::network::{ConsensusVersion, Network},
@@ -133,6 +134,8 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
         // Process the message. Disconnect if the peer violated the protocol.
         if let Err(error) = self.inbound(peer_addr, message).await {
             warn!("Failed to process inbound message from '{peer_addr}' - {error}");
+
+            //TODO(kaimast): set disconnect reason based on error
             if let Some(peer_ip) = self.router().resolve_to_listener(peer_addr) {
                 warn!("Disconnecting from '{peer_ip}' for protocol violation");
                 self.router().send(peer_ip, Message::Disconnect(DisconnectReason::ProtocolViolation.into()));
@@ -219,6 +222,16 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Client<N, C> {
         // We do not need to explicitly sync here because insert_block_response, will wake up the sync task.
         if let Err(err) = self.sync.insert_block_responses(peer_ip, blocks, latest_consensus_version) {
             warn!("Failed to insert block response from '{peer_ip}' - {err}");
+
+            // If the error indicates the peer missed an upgrade and forked, ban it.
+            if matches!(
+                err,
+                InsertBlockResponseError::ConsensusVersionMismatch { .. }
+                    | InsertBlockResponseError::NoConsensusVersion
+            ) {
+                self.router().ip_ban_peer(peer_ip, Some(&err.to_string()));
+            }
+
             false
         } else {
             true

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -473,36 +473,47 @@ impl<N: Network> BlockSync<N> {
         blocks: Vec<Block<N>>,
         latest_consensus_version: Option<ConsensusVersion>,
     ) -> Result<(), InsertBlockResponseError> {
-        let Some(last_height) = blocks.as_slice().last().map(|b| b.height()) else {
-            return Err(InsertBlockResponseError::EmptyBlockResponse);
+        // Attempt to insert the block responses, and break if we encounter an error.
+        let result = 'outer: {
+            let Some(last_height) = blocks.as_slice().last().map(|b| b.height()) else {
+                break 'outer Err(InsertBlockResponseError::EmptyBlockResponse);
+            };
+
+            let expected_consensus_version = N::CONSENSUS_VERSION(last_height)?;
+
+            // Perform consensus version check, if possible.
+            // This check is only enabled after nodes have reached V12.
+            if expected_consensus_version >= ConsensusVersion::V12 {
+                if let Some(peer_version) = latest_consensus_version {
+                    if peer_version != expected_consensus_version {
+                        break 'outer Err(InsertBlockResponseError::ConsensusVersionMismatch {
+                            peer_version,
+                            expected_version: expected_consensus_version,
+                            last_height,
+                        });
+                    }
+                } else {
+                    break 'outer Err(InsertBlockResponseError::NoConsensusVersion);
+                }
+            }
+
+            // Insert the candidate blocks into the sync pool.
+            for block in blocks {
+                if let Err(error) = self.insert_block_response(peer_ip, block) {
+                    break 'outer Err(error.into());
+                }
+            }
+
+            Ok(())
         };
 
-        let expected_consensus_version = N::CONSENSUS_VERSION(last_height)?;
-
-        // Perform consensus version check, if possible.
-        // This check is only enabled after nodes have reached V12.
-        if expected_consensus_version >= ConsensusVersion::V12 {
-            if let Some(peer_version) = latest_consensus_version {
-                if peer_version != expected_consensus_version {
-                    return Err(InsertBlockResponseError::ConsensusVersionMismatch {
-                        peer_version,
-                        expected_version: expected_consensus_version,
-                        last_height,
-                    });
-                }
-            } else {
-                return Err(InsertBlockResponseError::NoConsensusVersion);
-            }
+        // On failure, remove all block requests to the peer.
+        if result.is_err() {
+            self.remove_block_requests_to_peer(&peer_ip);
         }
 
-        // Insert the candidate blocks into the sync pool.
-        for block in blocks {
-            if let Err(error) = self.insert_block_response(peer_ip, block) {
-                self.remove_block_requests_to_peer(&peer_ip);
-                return Err(error.into());
-            }
-        }
-        Ok(())
+        // Return the result.
+        result
     }
 
     /// Returns the next block for the given `next_height` if the request is complete,


### PR DESCRIPTION
This PR ensures that nodes do not repeatedly attempt to sync from a peer that does not have the correct consensus version.