### PR TITLE
logs: print detailed errors in block sync and CDN sync

### DIFF
--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -19,17 +19,12 @@
 
 use snarkos_utilities::{SignalHandler, Stoppable};
 
-use snarkvm::prelude::{
-    Deserialize,
-    DeserializeOwned,
-    Ledger,
-    Network,
-    Serialize,
-    block::Block,
-    store::ConsensusStorage,
+use snarkvm::{
+    prelude::{Deserialize, DeserializeOwned, Ledger, Network, Serialize, block::Block, store::ConsensusStorage},
+    utilities::flatten_error,
 };
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use colored::Colorize;
 #[cfg(feature = "locktick")]
 use locktick::{parking_lot::Mutex, tokio::Mutex as TMutex};
@@ -83,9 +78,6 @@ pub struct CdnBlockSync {
 
 impl CdnBlockSync {
     /// Spawn a background task that loads blocks from a CDN into the ledger.
-    ///
-    /// On success, this function returns the completed block height.
-    /// On failure, this function returns the last successful block height (if any), along with the error.
     pub fn new<N: Network, C: ConsensusStorage<N>>(
         base_url: http::Uri,
         ledger: Ledger<N, C>,
@@ -108,6 +100,9 @@ impl CdnBlockSync {
     }
 
     /// Wait for CDN sync to finish. Can only be called once.
+    ///
+    /// On success, this function returns the completed block height.
+    /// On failure, this function returns the last successful block height (if any), along with the error.
     pub async fn wait(&self) -> Result<SyncResult> {
         let Some(hdl) = self.task.lock().take() else {
             bail!("CDN task was already awaited");
@@ -128,35 +123,41 @@ impl CdnBlockSync {
         // Load the blocks from the CDN into the ledger.
         let ledger_clone = ledger.clone();
         let result = load_blocks(&base_url, start_height, None, stoppable, move |block: Block<N>| {
-            ledger_clone.advance_to_next_block(&block)
+            ledger_clone
+                .advance_to_next_block(&block)
+                .with_context(|| format!("Failed to advance to block {} at height {}", block.hash(), block.height()))
         })
         .await;
 
         // TODO (howardwu): Find a way to resolve integrity failures.
         // If the sync failed, check the integrity of the ledger.
-        if let Err((completed_height, error)) = &result {
-            warn!("{error}");
+        match result {
+            Ok(completed_height) => Ok(completed_height),
+            Err((completed_height, error)) => {
+                warn!("{}", flatten_error(error.context("Failed to sync block(s) from the CDN")));
 
-            // If the sync made any progress, then check the integrity of the ledger.
-            if *completed_height != start_height {
-                debug!("Synced the ledger up to block {completed_height}");
+                // If the sync made any progress, then check the integrity of the ledger.
+                if completed_height != start_height {
+                    debug!("Synced the ledger up to block {completed_height}");
 
-                // Retrieve the latest height, according to the ledger.
-                let node_height = *ledger.vm().block_store().heights().max().unwrap_or_default();
-                // Check the integrity of the latest height.
-                if &node_height != completed_height {
-                    return Err((*completed_height, anyhow!("The ledger height does not match the last sync height")));
+                    // Retrieve the latest height, according to the ledger.
+                    let node_height = *ledger.vm().block_store().heights().max().unwrap_or_default();
+                    // Check the integrity of the latest height.
+                    if node_height != completed_height {
+                        return Err((
+                            completed_height,
+                            anyhow!("The ledger height does not match the last sync height"),
+                        ));
+                    }
+
+                    // Fetch the latest block from the ledger.
+                    if let Err(err) = ledger.get_block(node_height) {
+                        return Err((completed_height, err));
+                    }
                 }
 
-                // Fetch the latest block from the ledger.
-                if let Err(err) = ledger.get_block(node_height) {
-                    return Err((*completed_height, err));
-                }
+                Ok(completed_height)
             }
-
-            Ok(*completed_height)
-        } else {
-            result
         }
     }
 

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -215,7 +215,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
 
         // Set up everything else after CDN sync is done.
         if let Some(cdn_sync) = cdn_sync {
-            if let Err(error) = cdn_sync.wait().await {
+            if let Err(error) = cdn_sync.wait().await.with_context(|| "Failed to synchronize from the CDN") {
                 crate::log_clean_error(&storage_mode);
                 node.shut_down().await;
                 return Err(error);

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -175,7 +175,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
 
         // Set up everything else after CDN sync is done.
         if let Some(cdn_sync) = cdn_sync {
-            if let Err(error) = cdn_sync.wait().await {
+            if let Err(error) = cdn_sync.wait().await.with_context(|| "Failed to synchronize from the CDN") {
                 crate::log_clean_error(&storage_mode);
                 node.shut_down().await;
                 return Err(error);

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -399,8 +399,9 @@ impl<N: Network> BlockSync<N> {
         // Insert the chunk of block requests.
         for (height, (hash, previous_hash, _)) in requests.iter() {
             // Insert the block request into the sync pool using the sync IPs from the last block request in the chunk.
-            if let Err(error) = self.insert_block_request(*height, (*hash, *previous_hash, sync_ips.clone())) {
-                warn!("Block sync failed - {error}");
+            if let Err(err) = self.insert_block_request(*height, (*hash, *previous_hash, sync_ips.clone())) {
+                let err = err.context(format!("Failed to insert block request for height {height}"));
+                warn!("{}", flatten_error(&err));
                 return false;
             }
         }
@@ -576,20 +577,22 @@ impl<N: Network> BlockSync<N> {
                     Ok(_) => match ledger.advance_to_next_block(&block) {
                         Ok(_) => true,
                         Err(err) => {
-                            warn!(
-                                "Failed to advance to next block (height: {}, hash: '{}'): {err}",
+                            let err = err.context(format!(
+                                "Failed to advance to next block (height: {}, hash: '{}')",
                                 block.height(),
                                 block.hash()
-                            );
+                            ));
+                            warn!("{}", flatten_error(&err));
                             false
                         }
                     },
                     Err(err) => {
-                        warn!(
-                            "The next block (height: {}, hash: '{}') is invalid - {err}",
+                        let err = err.context(format!(
+                            "The next block (height: {}, hash: '{}') is invalid",
                             block.height(),
                             block.hash()
-                        );
+                        ));
+                        warn!("{}", flatten_error(&err));
                         false
                     }
                 }


### PR DESCRIPTION
This PR adds more detailed errors to sync logs, which will help debugging any issues that pop up v4.5.0.