### PR TITLE
[Fix] Update snarkVM to support atomic `prepare_next_block`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -788,7 +788,7 @@ workflows:
           filters:
             branches:
               only:
-                - ci/updated_network_delay_test 
+                - fix/atomic_prepare_next_block
                 - canary
                 - testnet
                 - mainnet

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -1426,7 +1426,9 @@ mod tests {
             subdag_map.insert(commit_round - 1, previous_cert_map.clone());
             let subdag = Subdag::from(subdag_map.clone())?;
             let ledger = core_ledger.clone();
-            spawn_blocking!(ledger.prepare_advance_to_next_quorum_block(subdag, Default::default()))?
+
+            tokio::task::spawn_blocking(move || ledger.prepare_advance_to_next_quorum_block(subdag, Default::default()))
+                .await??
         };
         // Insert block 1.
         let ledger = core_ledger.clone();
@@ -1449,7 +1451,11 @@ mod tests {
             subdag_map_2.insert(leader_round_2 - 1, previous_cert_map_2.clone());
             let subdag_2 = Subdag::from(subdag_map_2.clone())?;
             let ledger = core_ledger.clone();
-            spawn_blocking!(ledger.prepare_advance_to_next_quorum_block(subdag_2, Default::default()))?
+
+            tokio::task::spawn_blocking(move || {
+                ledger.prepare_advance_to_next_quorum_block(subdag_2, Default::default())
+            })
+            .await??
         };
         // Insert block 2.
         let ledger = core_ledger.clone();
@@ -1472,7 +1478,11 @@ mod tests {
             subdag_map_3.insert(leader_round_3 - 1, previous_cert_map_3.clone());
             let subdag_3 = Subdag::from(subdag_map_3.clone())?;
             let ledger = core_ledger.clone();
-            spawn_blocking!(ledger.prepare_advance_to_next_quorum_block(subdag_3, Default::default()))?
+
+            tokio::task::spawn_blocking(move || {
+                ledger.prepare_advance_to_next_quorum_block(subdag_3, Default::default())
+            })
+            .await??
         };
         // Insert block 3.
         let ledger = core_ledger.clone();


### PR DESCRIPTION
Prerequisite for #4039.

Depends on #4095 and https://github.com/ProvableHQ/snarkVM/pull/3070.