### PR TITLE
Don't disable CDN if nodetype was not given

### DIFF
--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -345,15 +345,11 @@ impl Start {
 
     /// Returns the CDN to prefetch initial blocks from, from the given configurations.
     fn parse_cdn<N: Network>(&self) -> Result<Option<http::Uri>> {
-        // Determine if the node type is not declared.
-        let is_no_node_type = !(self.validator || self.prover || self.client);
-
         // Disable CDN if:
         //  1. The node is in development mode.
         //  2. The user has explicitly disabled CDN.
         //  3. The node is a prover (no need to sync).
-        //  4. The node type is not declared (defaults to client) (no need to sync).
-        if self.dev.is_some() || self.nocdn || self.prover || is_no_node_type {
+        if self.dev.is_some() || self.nocdn || self.prover {
             Ok(None)
         }
         // Enable the CDN otherwise.

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -1236,9 +1236,9 @@ mod tests {
 
         // Default (Prod)
         let config = Start::try_parse_from(["snarkos"].iter()).unwrap();
-        assert!(config.parse_cdn::<CurrentNetwork>()?.is_none());
+        assert!(config.parse_cdn::<CurrentNetwork>()?.is_some());
         let config = Start::try_parse_from(["snarkos", "--cdn", "url"].iter()).unwrap();
-        assert!(config.parse_cdn::<CurrentNetwork>()?.is_none());
+        assert!(config.parse_cdn::<CurrentNetwork>()?.is_some());
         let config = Start::try_parse_from(["snarkos", "--nocdn"].iter()).unwrap();
         assert!(config.parse_cdn::<CurrentNetwork>()?.is_none());
 

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -40,7 +40,7 @@ use snarkvm::{
         committee::{Committee, MIN_DELEGATOR_STAKE, MIN_VALIDATOR_STAKE},
         store::{ConsensusStore, helpers::memory::ConsensusMemory},
     },
-    prelude::{FromBytes, ToBits, ToBytes},
+    prelude::{FromBytes, Itertools, ToBits, ToBytes},
     synthesizer::VM,
     utilities::to_bytes_le,
 };
@@ -349,7 +349,12 @@ impl Start {
         //  1. The node is in development mode.
         //  2. The user has explicitly disabled CDN.
         //  3. The node is a prover (no need to sync).
-        if self.dev.is_some() || self.nocdn || self.prover {
+        let no_cdn_reasons = [("--dev", self.dev.is_some()), ("--nocdn", self.nocdn), ("--prover", self.prover)]
+            .into_iter()
+            .filter_map(|(reason, flag_set)| flag_set.then_some(reason))
+            .join(" and ");
+        if !no_cdn_reasons.is_empty() {
+            info!("CDN disabled because the following flags are set: {no_cdn_reasons}.");
             Ok(None)
         }
         // Enable the CDN otherwise.


### PR DESCRIPTION
## Motivation

Our documentation says we default to `--client`, but if we do, we should enable CDN sync.

CC @14MR 
