### PR TITLE
Improve logging and documentation

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -397,7 +397,10 @@ impl<N: Network> Gateway<N> {
         match self.resolve_to_aleo_addr(ip) {
             // Determine if the peer IP is an authorized validator.
             Some(address) => self.is_authorized_validator_address(address),
-            None => false,
+            None => {
+                warn!("{CONTEXT} Could not resolve the Aleo address for '{ip}'");
+                false
+            }
         }
     }
 

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -760,6 +760,10 @@ impl<N: Network> Primary<N> {
         }
 
         // Ensure that the batch proposal's committee ID matches the expected committee ID.
+        // This may happen when the network forks. A transaction referencing a
+        // state root from one side of the fork will be aborted on the other
+        // side of the fork. This leads to a different view of stake and
+        // therefore a different view of the committee ID.
         let expected_committee_id = self.ledger.get_committee_lookback_for_round(batch_round)?.id();
         if expected_committee_id != batch_header.committee_id() {
             // Proceed to disconnect the validator.


### PR DESCRIPTION
A recent network outage surfaced two unexpected error messages:
- "Malicious peer - proposed batch has a different committee ID" - Added some documentation: 0605b461f
- "Malicious peer - Received a batch certificate from an unauthorized validator IP" - Improved logging to improve future analysis: 53e560430