### PR TITLE
Initialize the block height metric on startup

### DIFF
--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -68,6 +68,11 @@ pub struct CoreLedgerService<N: Network, C: ConsensusStorage<N>> {
 impl<N: Network, C: ConsensusStorage<N>> CoreLedgerService<N, C> {
     /// Initializes a new core ledger service.
     pub fn new(ledger: Ledger<N, C>, stoppable: Arc<dyn Stoppable>) -> Self {
+        // Initialize the block height metric.
+        #[cfg(feature = "metrics")]
+        {
+            metrics::gauge(metrics::bft::HEIGHT, ledger.latest_block().height() as f64);
+        }
         Self { ledger, latest_leader: Default::default(), stoppable }
     }
 }


### PR DESCRIPTION
## Motivation

When nodes restart, their height is briefly reported as 0, making Grafana dashboards harder to read.

CC @mike2194
