### PR TITLE
[CI] Make benchmarks work with new logging prefix

### DIFF
--- a/.ci/bench_bft_sync.sh
+++ b/.ci/bench_bft_sync.sh
@@ -59,7 +59,8 @@ common_flags=(
 )
 
 # The validator that has the ledger to by synced from.
-run_with_prefix "validator-0" "$TASKSET1" snarkos start --dev 0 --validator "${common_flags[@]}" \
+# shellcheck disable=SC2086
+run_with_prefix "validator-0" $TASKSET1 snarkos start --dev 0 --validator "${common_flags[@]}" \
   --logfile="$log_dir/validator-0.log"
 PIDS[0]=$!
 
@@ -73,7 +74,8 @@ for node_index in $(seq 1 "$num_nodes"); do
   # Ensure there are no old ledger files and the node syncs from scratch
   snarkos clean "--dev=$node_index" "--network=$network_id" || true
 
-  run_with_prefix "$name" "$TASKSET2" snarkos start "--dev=$node_index" --validator \
+  # shellcheck disable=SC2086
+  run_with_prefix "$name" $TASKSET2 snarkos start "--dev=$node_index" --validator \
     "${common_flags[@]}" "--validators=$validators" \
     "--logfile=$log_dir/$name.log"
   PIDS[node_index]=$!

--- a/.ci/bench_cdn_sync.sh
+++ b/.ci/bench_cdn_sync.sh
@@ -47,7 +47,8 @@ args=(
 
 # Spawn the client that will sync the ledger.
 # Use the same CPU cores as in the other benchmarks, so the numbers are comparable.
-run_with_prefix "client-0" "$TASKSET2" snarkos start --client "${args[@]}"
+# shellcheck disable=SC2086
+run_with_prefix "client-0" $TASKSET2 snarkos start --client "${args[@]}"
 PIDS[0]=$!
 
 wait_for_nodes 0 1 "$network_name"

--- a/.ci/bench_p2p_sync.sh
+++ b/.ci/bench_p2p_sync.sh
@@ -105,7 +105,8 @@ common_flags=(
 
 # The client that has the ledger
 # (runs on the first two cores)
-run_with_prefix "client-0" "$TASKSET1" snarkos start "--dev=$num_validators" --client "${common_flags[@]}" \
+# shellcheck disable=SC2086
+run_with_prefix "client-0" $TASKSET1 snarkos start "--dev=$num_validators" --client "${common_flags[@]}" \
   "--logfile=$log_dir/client-0.log" "--storage=.ledger-$network_id-0" \
   "--node=127.0.0.1:4130" "--rest=127.0.0.1:3030"
 PIDS[0]=$!
@@ -121,7 +122,8 @@ for client_index in $(seq 1 "$num_clients"); do
   # Ensure there are no old ledger files and the node syncs from scratch
   snarkos clean "--dev=$node_index" "--network=$network_id" "--path=.ledger-$network_id-$client_index" || true
 
-  run_with_prefix "$name" "$TASKSET2" snarkos start "--dev=$node_index" --client \
+  # shellcheck disable=SC2086
+  run_with_prefix "$name" $TASKSET2 snarkos start "--dev=$node_index" --client \
     "${common_flags[@]}" "--peers=127.0.0.1:$prev_port" "--node=$node_addr" \
     "--rest=127.0.0.1:$((3030+client_index))" \
     "--logfile=$log_dir/$name.log" "--storage=.ledger-$network_id-$client_index"

--- a/.ci/bench_rest_api.sh
+++ b/.ci/bench_rest_api.sh
@@ -47,7 +47,8 @@ common_flags=(
 )
 
 # The node that has the ledger (runs on the first two cores)
-run_with_prefix "client-0" "$TASKSET1" snarkos start --dev 0 --client "${common_flags[@]}" --logfile="$log_dir/client-0.log"
+# shellcheck disable=SC2086
+run_with_prefix "client-0" $TASKSET1 snarkos start --dev 0 --client "${common_flags[@]}" --logfile="$log_dir/client-0.log"
 PIDS[0]=$!
 
 # Block until node is running.

--- a/.ci/utils.sh
+++ b/.ci/utils.sh
@@ -181,10 +181,10 @@ function init_log_dir() {
 
 # Write a log message to the console and "ci-runner.log".
 function log() {
-  msg="[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+  msg="$(date -u +"%Y-%m-%dT%H:%M:%SZ") $*"
   echo "$msg" >> "$log_dir/ci-runner.log"
   # Print to message to stderr so it is always visible.
-  >&2 echo "$msg"
+  >&2 echo "[ci-runner] $msg"
 }
 
 ###########################################


### PR DESCRIPTION
#4107 broke the benchmark scripts, but, fortunately, the needed fix is small.

In this PR I also added a prefix for the ci-runner logs and made it use a similar datetime format, so the output looks more uniform. See the pasted output below for an example.
```
[ci-runner] 2026-02-16T21:40:50Z Created log directory: /Users/kaimast/dev/snarkOS/.logs-20260216134050
[ci-runner] 2026-02-16T21:40:50Z On branch: heads/staging
[ci-runner] 2026-02-16T21:40:50Z Using network: testnet (ID: 1)
[ci-runner] 2026-02-16T21:40:50Z Snapshot_info: num_validators=40, git_commit=9ec2291c57, snapshot_height=250
[client-0] 2026-02-16T21:40:50.447486Z  INFO snarkos_cli::commands::start: Development mode enabled with index=40 and num_validators=40.
[client-0] 2026-02-16T21:40:50.447579Z  INFO snarkos_cli::commands::start: CDN disabled because the following flags are set: --dev and --nocdn.
[client-0] 2026-02-16T21:40:50.506865Z  WARN snarkos_cli::commands::start: Custom path set for `--ledger-storage`, but not for `--node-data-storage`. The latter will use the default path.
[client-0] 2026-02-16T21:40:50.507360Z  INFO snarkvm_ledger: Loading the ledger from storage...
```