### PR TITLE
[Feat] Automated ledger checkpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4901,6 +4901,7 @@ dependencies = [
 name = "snarkos-node-rest"
 version = "4.4.0"
 dependencies = [
+ "aleo-std",
  "anyhow",
  "axum 0.8.8",
  "axum-extra",

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -252,6 +252,10 @@ pub struct Start {
     #[clap(long, verbatim_doc_comment)]
     pub node_data_storage: Option<PathBuf>,
 
+    /// If specified, the node will automatically save database checkpoints.
+    #[clap(long)]
+    pub auto_db_checkpoints: Option<PathBuf>,
+
     /// Enables the node to prefetch initial blocks from a CDN
     #[clap(long, conflicts_with = "nocdn")]
     pub cdn: Option<http::Uri>,
@@ -834,9 +838,9 @@ impl Start {
 
         // Initialize the node.
         let node = match node_type {
-            NodeType::Validator => Node::new_validator(node_ip, self.bft, rest_ip, self.rest_rps, account, &trusted_peers, &trusted_validators, genesis, cdn, storage_mode, node_data_dir, self.trusted_peers_only, dev_txs, self.dev, signal_handler.clone()).await,
+            NodeType::Validator => Node::new_validator(node_ip, self.bft, rest_ip, self.rest_rps, account, &trusted_peers, &trusted_validators, genesis, cdn, storage_mode, node_data_dir, self.trusted_peers_only, self.auto_db_checkpoints.clone(), dev_txs, self.dev, signal_handler.clone()).await,
             NodeType::Prover => Node::new_prover(node_ip, account, &trusted_peers, genesis, node_data_dir, self.trusted_peers_only, self.dev, signal_handler.clone()).await,
-            NodeType::Client => Node::new_client(node_ip, rest_ip, self.rest_rps, account, &trusted_peers, genesis, cdn, storage_mode, node_data_dir, self.trusted_peers_only, self.dev, signal_handler.clone()).await,
+            NodeType::Client => Node::new_client(node_ip, rest_ip, self.rest_rps, account, &trusted_peers, genesis, cdn, storage_mode, node_data_dir, self.trusted_peers_only, self.auto_db_checkpoints.clone(), self.dev, signal_handler.clone()).await,
             NodeType::BootstrapClient => Node::new_bootstrap_client(node_ip, account, *genesis.header(), self.dev).await,
         }?;
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -32,6 +32,9 @@ serial = [
   "snarkos-node-consensus/serial"
 ] 
 
+[dependencies.aleo-std]
+workspace = true
+
 [dependencies.anyhow]
 workspace = true
 

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -23,12 +23,13 @@ use snarkvm::{
 
 use axum::{Json, extract::rejection::JsonRejection};
 
+use aleo_std::aleo_ledger_dir;
 use anyhow::{Context, anyhow};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_with::skip_serializing_none;
-use std::{collections::HashMap, sync::atomic::Ordering};
+use std::{collections::HashMap, fs, sync::atomic::Ordering};
 
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
@@ -903,9 +904,26 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         State(rest): State<Self>,
         backup_path: Query<BackupPath>,
     ) -> Result<ErasedJson, RestError> {
-        rest.ledger.backup_database(&backup_path.path)?;
+        // Create a checkpoint at the given location.
+        let mut backup_path = backup_path.path.clone();
+        rest.ledger.backup_database(&backup_path)?;
 
-        Ok(ErasedJson::pretty(()))
+        // Dump the block tree.
+        let ret = ErasedJson::pretty(());
+        if let Err(e) = rest.ledger.cache_block_tree() {
+            warn!("Couldn't cache the block tree for a ledger checkpoint: {e}");
+            return Ok(ret);
+        }
+
+        // Copy the block tree file to the new checkpoint.
+        let mut block_tree_path = aleo_ledger_dir(N::ID, rest.ledger.vm().block_store().storage_mode());
+        block_tree_path.push("block_tree");
+        backup_path.push("block_tree");
+        if let Err(e) = fs::copy(block_tree_path, backup_path) {
+            warn!("Couldn't copy the block tree file to a ledger checkpoint: {e}");
+        }
+
+        Ok(ret)
     }
 
     /// GET /{network}/program/{id}/mapping/{name}/{key}/history/{height}

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -125,7 +125,7 @@ pub struct Client<N: Network, C: ConsensusStorage<N>> {
     /// The amount of executions currently being verified.
     num_verifying_executions: Arc<AtomicUsize>,
     /// The spawned handles.
-    handles: Arc<Mutex<Vec<JoinHandle<()>>>>,
+    pub(crate) handles: Arc<Mutex<Vec<JoinHandle<()>>>>,
     /// Keeps track of sending pings.
     ping: Arc<Ping<N>>,
     /// The signal handling logic.

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -339,7 +339,6 @@ impl<N: Network> Node<N> {
         }
 
         // Spawn a loop that will periodically create the checkpoints.
-        let node = self.clone();
         let handle = tokio::spawn(async move {
             info!("Starting the automatic ledger checkpoint routine...");
 
@@ -350,13 +349,10 @@ impl<N: Network> Node<N> {
             block_tree_path.push("block_tree");
 
             loop {
-                // A small delay that's smaller than block time.
+                // A small delay that's smaller than block time. There are technically situations when
+                // blocks can be inserted one after the other more quickly (syncing, multiple blocks in
+                // a Subdag), those are edge cases unlikely to be encountered under normal conditions.
                 tokio::time::sleep(Duration::from_millis(500)).await;
-
-                // Don't create checkpoints while syncing.
-                if !node.is_block_synced() {
-                    continue;
-                }
 
                 // Skip if we've already created a checkpoint during this run, and the
                 // number of blocks baked since then is lower than the configured threshold.
@@ -388,7 +384,7 @@ impl<N: Network> Node<N> {
                     // Copy the block tree file to the new checkpoint.
                     checkpoint_path.push("block_tree");
                     if let Err(e) = fs::copy(source_block_tree_path, checkpoint_path) {
-                        warn!("Couldn't move the block tree file to a ledger checkpoint: {e}");
+                        warn!("Couldn't copy the block tree file to a ledger checkpoint: {e}");
                     }
                 });
 

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -37,14 +37,21 @@ use snarkvm::prelude::{
     store::helpers::{memory::ConsensusMemory, rocksdb::ConsensusDB},
 };
 
-use aleo_std::StorageMode;
-use anyhow::Result;
+use aleo_std::{StorageMode, aleo_ledger_dir};
+use anyhow::{Result, bail};
 
 #[cfg(feature = "locktick")]
 use locktick::parking_lot::RwLock;
 #[cfg(not(feature = "locktick"))]
 use parking_lot::RwLock;
-use std::{collections::HashMap, net::SocketAddr, sync::Arc};
+use std::{cmp, collections::HashMap, fs, net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc, time::Duration};
+use tokio::task;
+
+/// The number of blocks between automatic database checkpoints.
+const CHECKPOINT_BLOCK_FREQUENCY: u32 = 1000;
+
+/// The maximum number of automatic database checkpoints kept at any time.
+const MAX_AUTO_CHECKPOINTS: usize = 5;
 
 #[derive(Clone)]
 pub enum Node<N: Network> {
@@ -73,11 +80,12 @@ impl<N: Network> Node<N> {
         storage_mode: StorageMode,
         node_data_dir: NodeDataDir,
         trusted_peers_only: bool,
+        auto_db_checkpoints: Option<PathBuf>,
         dev_txs: bool,
         dev: Option<u16>,
         signal_handler: Arc<SignalHandler>,
     ) -> Result<Self> {
-        Ok(Self::Validator(Arc::new(
+        let validator = Arc::new(
             Validator::new(
                 node_ip,
                 bft_ip,
@@ -96,7 +104,18 @@ impl<N: Network> Node<N> {
                 signal_handler,
             )
             .await?,
-        )))
+        );
+
+        let node = Self::Validator(validator.clone());
+
+        // Perform automatic ledger checkpoints.
+        if let Some(path) = auto_db_checkpoints {
+            if let Some(handle) = node.perform_auto_checkpoints(path)? {
+                validator.handles.lock().push(handle);
+            }
+        }
+
+        Ok(node)
     }
 
     /// Initializes a new prover node.
@@ -137,10 +156,11 @@ impl<N: Network> Node<N> {
         storage_mode: StorageMode,
         node_data_dir: NodeDataDir,
         trusted_peers_only: bool,
+        auto_db_checkpoints: Option<PathBuf>,
         dev: Option<u16>,
         signal_handler: Arc<SignalHandler>,
     ) -> Result<Self> {
-        Ok(Self::Client(Arc::new(
+        let client = Arc::new(
             Client::new(
                 node_ip,
                 rest_ip,
@@ -156,7 +176,18 @@ impl<N: Network> Node<N> {
                 signal_handler,
             )
             .await?,
-        )))
+        );
+
+        let node = Self::Client(client.clone());
+
+        // Perform automatic ledger checkpoints.
+        if let Some(path) = auto_db_checkpoints {
+            if let Some(handle) = node.perform_auto_checkpoints(path)? {
+                client.handles.lock().push(handle);
+            }
+        }
+
+        Ok(node)
     }
 
     /// Initializes a new bootstrap client node.
@@ -289,5 +320,131 @@ impl<N: Network> Node<N> {
             Self::Client(node) => node.wait_for_signals(signal_handler).await,
             Self::BootstrapClient(node) => node.wait_for_signals(signal_handler).await,
         }
+    }
+
+    /// Periodically creates automated ledger checkpoints.
+    pub fn perform_auto_checkpoints(&self, auto_checkpoint_path: PathBuf) -> Result<Option<task::JoinHandle<()>>> {
+        // Only perform checkpoints if there's a database involved.
+        let Some(ledger) = self.ledger().cloned() else {
+            return Ok(None);
+        };
+
+        // Ensure that the target path exists as a folder or create it.
+        if !auto_checkpoint_path.exists() {
+            if let Err(e) = fs::create_dir_all(&auto_checkpoint_path) {
+                bail!("Couldn't create the specified path for the automatic ledger checkpoints: {e}");
+            }
+        } else if auto_checkpoint_path.exists() && !auto_checkpoint_path.is_dir() {
+            bail!("The specified path for automatic ledger checkpoints is not a directory");
+        }
+
+        // Spawn a loop that will periodically create the checkpoints.
+        let node = self.clone();
+        let handle = tokio::spawn(async move {
+            info!("Starting the automatic ledger checkpoint routine...");
+
+            // Prepare some object that will be useful throughout the routine.
+            let mut last_checkpoint_height = None;
+            let mut existing_checkpoints = Vec::with_capacity(MAX_AUTO_CHECKPOINTS + 1);
+            let mut block_tree_path = aleo_ledger_dir(N::ID, ledger.vm().block_store().storage_mode());
+            block_tree_path.push("block_tree");
+
+            loop {
+                // A small delay that's smaller than block time.
+                tokio::time::sleep(Duration::from_millis(500)).await;
+
+                // Don't create checkpoints while syncing.
+                if !node.is_block_synced() {
+                    continue;
+                }
+
+                // Skip if we've already created a checkpoint during this run, and the
+                // number of blocks baked since then is lower than the configured threshold.
+                let current_height = ledger.vm().block_store().current_block_height();
+                if last_checkpoint_height.is_some_and(|checkpoint_height| {
+                    current_height.saturating_sub(checkpoint_height) < CHECKPOINT_BLOCK_FREQUENCY
+                }) {
+                    continue;
+                }
+
+                // Create a checkpoint.
+                let mut checkpoint_path = auto_checkpoint_path.clone();
+                checkpoint_path.push(format!("checkpoint_{current_height}"));
+                if let Err(e) = ledger.backup_database(&checkpoint_path) {
+                    warn!("Couldn't automatically store a checkpoint at {}: {e}", checkpoint_path.display());
+                    continue;
+                }
+                last_checkpoint_height = Some(current_height);
+
+                // Immediately procure and copy the applicable block tree in the background.
+                let ledger_clone = ledger.clone();
+                let source_block_tree_path = block_tree_path.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = ledger_clone.cache_block_tree() {
+                        warn!("Couldn't cache the block tree for a ledger checkpoint: {e}");
+                        return;
+                    }
+
+                    // Copy the block tree file to the new checkpoint.
+                    checkpoint_path.push("block_tree");
+                    if let Err(e) = fs::copy(source_block_tree_path, checkpoint_path) {
+                        warn!("Couldn't move the block tree file to a ledger checkpoint: {e}");
+                    }
+                });
+
+                // Count the existing auto checkpoints.
+                existing_checkpoints.clear();
+                let checkpoint_dir = match auto_checkpoint_path.read_dir() {
+                    Ok(dir) => dir,
+                    Err(e) => {
+                        warn!("IO error while accessing the automatic checkpoints: {e}");
+                        continue;
+                    }
+                };
+                for entry in checkpoint_dir {
+                    // Handle possible IO errors.
+                    let entry = match entry {
+                        Ok(entry) => entry,
+                        Err(e) => {
+                            warn!("IO error while counting the automatic checkpoints: {e}");
+                            continue;
+                        }
+                    };
+
+                    // Skip non-directories.
+                    let path = entry.path();
+                    if !path.is_dir() {
+                        continue;
+                    }
+
+                    // Recognize checkpoints by the "checkpoint_height" name.
+                    let file_name = entry.file_name().into_string().unwrap(); // can't fail - we create Unicode filenames
+                    let mut name_iter = file_name.split("_");
+                    if name_iter.next() != Some("checkpoint") {
+                        continue;
+                    }
+                    let Some(height) = name_iter.next() else {
+                        continue;
+                    };
+                    let Ok(height) = u32::from_str(height) else {
+                        continue;
+                    };
+                    existing_checkpoints.push((path, height));
+                }
+                existing_checkpoints.sort_unstable_by_key(|(_, height)| cmp::Reverse(*height));
+
+                // If we have a sufficient number of checkpoints, delete the oldest one(s).
+                let surplus_checkpoints = existing_checkpoints.len().saturating_sub(MAX_AUTO_CHECKPOINTS);
+                for _ in 0..surplus_checkpoints {
+                    if let Some((checkpoint_path, _)) = existing_checkpoints.pop() {
+                        if let Err(e) = fs::remove_dir_all(checkpoint_path) {
+                            warn!("Couldn't remove an automatic ledger checkpoint: {e}");
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(Some(handle))
     }
 }

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -70,7 +70,7 @@ pub struct Validator<N: Network, C: ConsensusStorage<N>> {
     /// The block synchronization logic (used in the Router impl).
     sync: Arc<BlockSync<N>>,
     /// The spawned handles.
-    handles: Arc<Mutex<Vec<JoinHandle<()>>>>,
+    pub(crate) handles: Arc<Mutex<Vec<JoinHandle<()>>>>,
     /// Keeps track of sending pings.
     ping: Arc<Ping<N>>,
 }


### PR DESCRIPTION
This PR introduces an optional feature (enabled via `--auto_db_checkpoints=<path>`), which automatically creates ledger backups (via RocksDB checkpoints, i.e. hardlink-based) at a frequency of every 1k blocks, and with a maximum of 5 checkpoints present at any time (a "rolling" set). The applicable block tree is also stored alongside them.

The auto-checkpoint eligibility interval is every 500ms, basically guaranteeing the "height precision" of the checkpoints and block tree dumps.

I successfully tested it with a local devnet and a lower checkpoint threshold.

Closes https://github.com/ProvableHQ/snarkOS/issues/4103.