### PR TITLE
[Fix] Update DAG when syncing pending blocks in canary

### DIFF
--- a/.ci/db_backup_ci.sh
+++ b/.ci/db_backup_ci.sh
@@ -40,7 +40,8 @@ for ((validator_index = 0; validator_index < total_validators; validator_index++
 
   log_file="$log_dir/validator-$validator_index.log"
   snarkos start --nodisplay --network $network_id --dev $validator_index --dev-num-validators $total_validators \
-    --validator --jwt-secret $jwt_secret --jwt-timestamp $jwt_ts --verbosity $log_verbosity "--logfile=$log_file" &
+    --validator --jwt-secret $jwt_secret --jwt-timestamp $jwt_ts --verbosity $log_verbosity "--logfile=$log_file" \
+    "--node-data-storage=/tmp/node_data_$validator_index" "--ledger-storage=/tmp/ledger_$validator_index" &
   PIDS[validator_index]=$!
   log "Started validator $validator_index with PID ${PIDS[$validator_index]}"
   # Add 1-second delay between starting nodes to avoid hitting rate limits
@@ -95,15 +96,16 @@ while (( total_wait < 600 )); do  # 10 minutes max
       wait
 
       for ((validator_index = 0; validator_index < total_validators; validator_index++)); do
-        # Remove the original ledger
-        if (( num_checkpoints == 1 )); then
-          snarkos clean "--network=$network_id" "--dev=$validator_index"
+        # Remove the ledger storage. The node data is not backed up yet and will be kept. 
+        if (( num_checkpoints == 1 )); then 
+          # Remove the original ledger
+          snarkos clean "--network=$network_id" "--dev=$validator_index" --keep-node-data \
+              "--ledger-storage=/tmp/ledger_$validator_index"
         else
+          # Remove the checkpoint
           suffix="${validator_index}_$((num_checkpoints-2))"
-          # only remove ledger, until node-data is backed up properly.
-          rm -rf "/tmp/checkpoint_$suffix"
-          #snarkos clean "--network=$network_id" "--dev=validator_index" \
-          #    "--node-data-storage=/tmp/node_data" "--ledger-storage=/tmp/checkpoint_$suffix"
+          snarkos clean "--network=$network_id" "--dev=$validator_index" --keep-node-data \
+              "--ledger-storage=/tmp/ledger_checkpoint_$suffix"
         fi
         # Wait until the cleanup concludes
         sleep 1
@@ -113,7 +115,7 @@ while (( total_wait < 600 )); do  # 10 minutes max
         log_file="$log_dir/validator-$validator_index.log"
         snarkos start --nodisplay "--network=$network_id" "--dev=$validator_index" "--dev-num-validators=$total_validators" \
           --validator "--jwt-secret=$jwt_secret" "--jwt-timestamp=$jwt_ts" --verbosity $log_verbosity "--logfile=$log_file" \
-          "--node-data-storage=/tmp/node_data" "--ledger-storage=/tmp/checkpoint_$suffix" &
+          "--node-data-storage=/tmp/node_data_$validator_index" "--ledger-storage=/tmp/ledger_checkpoint_$suffix" &
         PIDS[validator_index]=$!
         log "Restarted validator $validator_index with PID ${PIDS[$validator_index]}"
         # Add 1-second delay between starting nodes to avoid hitting rate limits

--- a/.ci/utils.sh
+++ b/.ci/utils.sh
@@ -394,31 +394,8 @@ function wait_for_peers() {
 
 # Succeeds if the node with the given index has the specified number of BFT connections (or greater)
 function wait_for_bft_connections() {
-  local node_index=$1
-  local min_peers=$2
-  local network_name=$3
-
-  local max_wait=300
-  local poll_interval=1
-  local port=$((3030 + node_index))
-  
-  while (( total_wait < max_wait )); do
-    result=$(curl -s "http://$localhost:$port/v2/$network_name/connections/bft/count")
-
-    if ! (is_integer "$result"); then
-      log "Failed to get number of BFT connections for node #${node_index} (port=$port). Will retry..."
-    elif (( result < min_peers )); then
-      log "Node #${node_index} (port=$port) has $result BFT connections, expected at least $min_peers. Will wait and retry..."
-    else
-      return 0
-    fi
-
-    # Continue waiting
-    sleep $poll_interval
-  done
-
-  log "❌ BFT connections did not reach $min_peers within 5 minutes."
-  return 1
+  # Not implemented on canary
+  return 0
 }
 
 # Blocks until the node with the given index has at least one peer to sync from (or times out).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,9 +586,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2-sys"
@@ -1748,9 +1748,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git2"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2b37e2f62729cdada11f0e6b3b6fe383c69c29fc619e391223e12856af308c"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
@@ -2887,9 +2887,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-derive"
@@ -6186,9 +6186,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -6203,15 +6203,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/cli/src/commands/clean.rs
+++ b/cli/src/commands/clean.rs
@@ -40,8 +40,12 @@ pub struct Clean {
     #[clap(long, alias = "path")]
     pub ledger_storage: Option<PathBuf>,
 
+    /// Keep the node data directory (disabled by default).
+    #[clap(long)]
+    pub keep_node_data: bool,
+
     /// Sets a custom path for the node configuration. Overrides the default path (also for dev).
-    #[clap(long, alias = "node-data-path")]
+    #[clap(long, alias = "node-data-path", conflicts_with = "keep_node_data")]
     pub node_data_storage: Option<PathBuf>,
 }
 
@@ -49,8 +53,10 @@ impl Clean {
     /// Cleans the snarkOS node storage.
     pub fn parse(self) -> Result<String> {
         // Remove the specified node configuration from storage.
-        let node_data_dir = parse_node_data_dir(&self.node_data_storage, self.network, self.dev)?;
-        println!("{}", Self::remove_node_data(&node_data_dir)?);
+        if !self.keep_node_data {
+            let node_data_dir = parse_node_data_dir(&self.node_data_storage, self.network, self.dev)?;
+            println!("{}", Self::remove_node_data(&node_data_dir)?);
+        }
 
         // Remove the specified ledger from storage.
         let storage_mode = match self.ledger_storage {

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -908,6 +908,7 @@ impl<N: Network> BFT<N> {
             mut rx_primary_certificate,
             mut rx_sync_bft_dag_at_bootup,
             mut rx_sync_bft,
+            mut rx_sync_block_committed,
         } = bft_receiver;
 
         // Process the current round from the primary.
@@ -947,6 +948,19 @@ impl<N: Network> BFT<N> {
                 // Send the callback **after** updating the DAG.
                 // Note: We must await the DAG update before proceeding.
                 callback.send(result).ok();
+            }
+        });
+
+        // Handler for new blocks that were synced wit BFT.
+        //
+        // Note: This is just a workaround until other sync changes are merged.
+        // BFT sync logic should always use DAG commits within GC, but uses pending blocks in rare cases.
+        // This sender ensures that the DAG is still updated accordingly if that happens.
+        let self_ = self.clone();
+        self.spawn(async move {
+            while let Some((leader_certificate, callback)) = rx_sync_block_committed.recv().await {
+                self_.dag.write().commit(&leader_certificate, self_.storage().max_gc_rounds());
+                callback.send(Ok(())).ok();
             }
         });
     }

--- a/node/bft/src/helpers/channels.rs
+++ b/node/bft/src/helpers/channels.rs
@@ -65,8 +65,11 @@ pub fn init_consensus_channels<N: Network>() -> (ConsensusSender<N>, ConsensusRe
 pub struct BFTSender<N: Network> {
     pub tx_primary_round: mpsc::Sender<(u64, oneshot::Sender<bool>)>,
     pub tx_primary_certificate: mpsc::Sender<(BatchCertificate<N>, oneshot::Sender<Result<()>>)>,
+    /// Notifies that sync without BFT is done.
     pub tx_sync_bft_dag_at_bootup: mpsc::Sender<Vec<BatchCertificate<N>>>,
     pub tx_sync_bft: mpsc::Sender<(BatchCertificate<N>, oneshot::Sender<Result<()>>)>,
+    /// Notifies that we synced a block with BFT.
+    pub tx_sync_block_committed: mpsc::Sender<(BatchCertificate<N>, oneshot::Sender<Result<()>>)>,
 }
 
 impl<N: Network> BFTSender<N> {
@@ -108,6 +111,7 @@ pub struct BFTReceiver<N: Network> {
     pub rx_primary_certificate: mpsc::Receiver<(BatchCertificate<N>, oneshot::Sender<Result<()>>)>,
     pub rx_sync_bft_dag_at_bootup: mpsc::Receiver<Vec<BatchCertificate<N>>>,
     pub rx_sync_bft: mpsc::Receiver<(BatchCertificate<N>, oneshot::Sender<Result<()>>)>,
+    pub rx_sync_block_committed: mpsc::Receiver<(BatchCertificate<N>, oneshot::Sender<Result<()>>)>,
 }
 
 /// Initializes the BFT channels, and returns the sending and receiving ends.
@@ -116,9 +120,22 @@ pub fn init_bft_channels<N: Network>() -> (BFTSender<N>, BFTReceiver<N>) {
     let (tx_primary_certificate, rx_primary_certificate) = mpsc::channel(MAX_CHANNEL_SIZE);
     let (tx_sync_bft_dag_at_bootup, rx_sync_bft_dag_at_bootup) = mpsc::channel(MAX_CHANNEL_SIZE);
     let (tx_sync_bft, rx_sync_bft) = mpsc::channel(MAX_CHANNEL_SIZE);
+    let (tx_sync_block_committed, rx_sync_block_committed) = mpsc::channel(MAX_CHANNEL_SIZE);
 
-    let sender = BFTSender { tx_primary_round, tx_primary_certificate, tx_sync_bft_dag_at_bootup, tx_sync_bft };
-    let receiver = BFTReceiver { rx_primary_round, rx_primary_certificate, rx_sync_bft_dag_at_bootup, rx_sync_bft };
+    let sender = BFTSender {
+        tx_primary_round,
+        tx_primary_certificate,
+        tx_sync_bft_dag_at_bootup,
+        tx_sync_bft,
+        tx_sync_block_committed,
+    };
+    let receiver = BFTReceiver {
+        rx_primary_round,
+        rx_primary_certificate,
+        rx_sync_bft_dag_at_bootup,
+        rx_sync_bft,
+        rx_sync_block_committed,
+    };
 
     (sender, receiver)
 }

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -928,7 +928,7 @@ impl<N: Network> Sync<N> {
                 let ledger = self.ledger.clone();
                 let storage = self.storage.clone();
 
-                spawn_blocking!({
+                let leader_certificate: Option<BatchCertificate<N>> = spawn_blocking!({
                     let block = ledger.check_block_content(pending_block).with_context(|| {
                         format!("Failed to check contents of pending block {hash} at height {height}")
                     })?;
@@ -940,8 +940,26 @@ impl<N: Network> Sync<N> {
                     // Sync the round with the block.
                     storage.sync_round_with_block(block.round());
 
-                    Ok(())
-                })?
+                    if let Authority::Quorum(subdag) = block.authority() {
+                        Ok(Some(subdag.leader_certificate().clone()))
+                    } else {
+                        Ok(None)
+                    }
+                })?;
+
+                // If a BFT sender was provided, send the leader certificate to the BFT.
+                // This will update the primary's DAG as expected.
+                if let Some(leader_certificate) = leader_certificate
+                    && let Some(bft_sender) = self.bft_sender.get()
+                {
+                    let (callback_tx, callback_rx) = oneshot::channel();
+                    bft_sender
+                        .tx_sync_block_committed
+                        .send((leader_certificate, callback_tx))
+                        .await
+                        .with_context(|| "Failed to mark leader certificate as committed")?;
+                    callback_rx.await?.with_context(|| "Failed to mark leader certificate as committed")?;
+                }
             }
         } else {
             trace!("No pending block are ready to be committed ({} block(s) are pending)", pending_blocks.len());

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -33,7 +33,7 @@ use snarkvm::{
 };
 
 use anyhow::Context;
-use colored::Colorize;
+use colored::{ColoredString, Colorize};
 use indexmap::{IndexMap, IndexSet};
 #[cfg(feature = "locktick")]
 use locktick::parking_lot::{Mutex, RwLock};
@@ -165,6 +165,17 @@ impl<N: Network> Worker<N> {
 }
 
 impl<N: Network> Worker<N> {
+    // Helper to print the transmission ID and checksum (if any).
+    fn format_transmission_id(&self, transmission_id: TransmissionID<N>) -> ColoredString {
+        if let Some(checksum) = transmission_id.checksum() {
+            // fmt_id will suffix with `..`, so we should not use `.`  as a separator.
+            format!("{}:{}", fmt_id(transmission_id), fmt_id(checksum))
+        } else {
+            fmt_id(transmission_id)
+        }
+        .dimmed()
+    }
+
     /// Returns `true` if the transmission ID exists in the ready queue, proposed batch, storage, or ledger.
     pub fn contains_transmission(&self, transmission_id: impl Into<TransmissionID<N>>) -> bool {
         let transmission_id = transmission_id.into();
@@ -284,10 +295,9 @@ impl<N: Network> Worker<N> {
                 // If the transmission was not fetched, then attempt to fetch it again.
                 Err(e) => {
                     warn!(
-                        "Worker {} - Failed to fetch transmission '{}.{}' from '{peer_ip}' (ping) - {e}",
+                        "Worker {} - Failed to fetch transmission '{}' from '{peer_ip}' (ping) - {e}",
                         self_.id,
-                        fmt_id(transmission_id),
-                        fmt_id(transmission_id.checksum().unwrap_or_default()).dimmed()
+                        self_.format_transmission_id(transmission_id),
                     );
                 }
             }
@@ -331,10 +341,9 @@ impl<N: Network> Worker<N> {
         // If the transmission ID and transmission type matches, then insert the transmission into the ready queue.
         if is_well_formed && self.ready.write().insert(transmission_id, transmission) {
             trace!(
-                "Worker {} - Added transmission '{}.{}' from '{peer_ip}'",
+                "Worker {} - Added transmission '{}' from '{peer_ip}'",
                 self.id,
-                fmt_id(transmission_id),
-                fmt_id(transmission_id.checksum().unwrap_or_default()).dimmed()
+                self.format_transmission_id(transmission_id),
             );
         }
     }
@@ -368,10 +377,9 @@ impl<N: Network> Worker<N> {
         // Adds the solution to the ready queue.
         if self.ready.write().insert(transmission_id, transmission) {
             trace!(
-                "Worker {} - Added unconfirmed solution '{}.{}'",
+                "Worker {} - Added unconfirmed solution '{}'",
                 self.id,
-                fmt_id(solution_id),
-                fmt_id(checksum).dimmed()
+                self.format_transmission_id(transmission_id),
             );
         }
         Ok(true)
@@ -413,10 +421,9 @@ impl<N: Network> Worker<N> {
         // Adds the transaction to the ready queue.
         if self.ready.write().insert(transmission_id, transmission) {
             trace!(
-                "Worker {}.{} - Added unconfirmed transaction '{}'",
+                "Worker {} - Added unconfirmed transaction '{}'",
                 self.id,
-                fmt_id(transaction_id),
-                fmt_id(checksum).dimmed()
+                self.format_transmission_id(transmission_id),
             );
         }
         Ok(true)
@@ -495,21 +502,20 @@ impl<N: Network> Worker<N> {
         // Insert the transmission ID into the pending queue.
         self.pending.insert(transmission_id, peer_ip, Some((callback_sender, should_send_request)));
 
-        // Helper to print the transmission ID and checksum.
-        let print_transmission_id = |transmission_id: TransmissionID<N>| {
-            format!("{}.{}", fmt_id(transmission_id), fmt_id(transmission_id.checksum().unwrap_or_default()).dimmed())
-        };
-
         // If the number of requests is less than or equal to the the redundancy factor, send the transmission request to the peer.
         if should_send_request {
+            trace!("Requesting transmission {} from peer '{peer_ip}'", self.format_transmission_id(transmission_id));
             // Send the transmission request to the peer.
             if self.gateway.send(peer_ip, Event::TransmissionRequest(transmission_id.into())).await.is_none() {
-                bail!("Unable to fetch transmission - failed to send request")
+                bail!(
+                    "Unable to fetch transmission {} - failed to send request",
+                    self.format_transmission_id(transmission_id)
+                )
             }
         } else {
             debug!(
                 "Skipped sending request for transmission {} to '{peer_ip}' ({num_sent_requests} redundant requests)",
-                print_transmission_id(transmission_id)
+                self.format_transmission_id(transmission_id)
             );
         }
         // Wait for the transmission to be fetched.
@@ -517,9 +523,11 @@ impl<N: Network> Worker<N> {
         let transmission = timeout(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS), callback_receiver)
             .await
             .with_context(|| {
-                format!("Unable to fetch transmission {} (timeout)", print_transmission_id(transmission_id),)
+                format!("Unable to fetch transmission {} (timeout)", self.format_transmission_id(transmission_id))
             })?
-            .with_context(|| format!("Unable to fetch transmission {}", print_transmission_id(transmission_id),))?;
+            .with_context(|| {
+                format!("Unable to fetch transmission {}", self.format_transmission_id(transmission_id))
+            })?;
 
         Ok((transmission_id, transmission))
     }
@@ -535,6 +543,10 @@ impl<N: Network> Worker<N> {
             // Ensure the transmission is not a fee and matches the transmission ID.
             match self.ledger.ensure_transmission_is_well_formed(transmission_id, &mut transmission) {
                 Ok(()) => {
+                    trace!(
+                        "Received valid transmission response from peer '{peer_ip}' for transmission '{}'",
+                        self.format_transmission_id(transmission_id)
+                    );
                     // Remove the transmission ID from the pending queue.
                     self.pending.remove(transmission_id, Some(transmission));
                 }


### PR DESCRIPTION
This PR is a temporary fix -- until #4039 is merged -- for a bug where sync advances the ledger but does not also update the BFT's DAG.
