### PR TITLE
[Fix] Do not start nodes if proposal cache and ledger rounds are too far apart

### DIFF
--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -179,6 +179,20 @@ impl<N: Network> Primary<N> {
                     let (latest_certificate_round, proposed_batch, signed_proposals, pending_certificates) =
                         proposal_cache.into();
 
+                    // Verify that the proposal cache is not too far ahead of the ledger.
+                    // If the cache round exceeds the ledger round by more than MAX_GC_ROUNDS, the ledger
+                    // snapshot is too old to recover from the cached state. The operator must restore a
+                    // more recent ledger snapshot before restarting the node.
+                    let ledger_round = self.ledger.latest_round();
+                    let max_gc_rounds = BatchHeader::<N>::MAX_GC_ROUNDS as u64;
+                    if latest_certificate_round > ledger_round.saturating_add(max_gc_rounds) {
+                        bail!(
+                            "The proposal cache (round {latest_certificate_round}) is more than {max_gc_rounds} \
+                             rounds ahead of the ledger (round {ledger_round}). \
+                             Please restore a more recent ledger snapshot before restarting the node."
+                        );
+                    }
+
                     // Write the proposed batch.
                     *self.proposed_batch.write() = proposed_batch;
                     // Write the signed proposals.


### PR DESCRIPTION
Partially fixes #4106.

An ideal solution to the proposal cache being too far in the "future" would be to defer it from being loaded until later. This approach is much simpler: it simply will tell the user to fetch a more recent ledger snapshot. 

Generally, it is unlikely for this to happen in production, nodes would need to revert to a much older snapshot or delete their ledger entirely. However, it is good to add this check, so that nodes do not start with outdated proposal caches and get stuck with confusing error messages.