### PR TITLE
[CI] Remove proposal cache in minority reset test

### DIFF
--- a/.ci/test_reset_minority.sh
+++ b/.ci/test_reset_minority.sh
@@ -80,7 +80,7 @@ for iter in $(seq 1 "$num_resets"); do
 
   for target_index in "${target_indices[@]}"; do
     # Remove the original ledger
-    snarkos clean "--network=$network_id" "--dev=$target_index" --keep-node-data
+    snarkos clean "--network=$network_id" "--dev=$target_index"
     # Wait until the cleanup concludes
     sleep 1
     # Restart

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -788,7 +788,7 @@ workflows:
           filters:
             branches:
               only:
-                - ci/updated_network_delay_test 
+                - ci/minority-reset-no-cache
                 - canary
                 - testnet
                 - mainnet


### PR DESCRIPTION
The recently introduced check in #4126 broke the minority reset test. The test does not delete node data, which can then not be loaded on restart.

This PR changes the test to delete the node data on reset. This prevents the possibility of the ledger and proposal cache being out of sync.