### PR TITLE
[Fix] Correct the historical mapping route

### DIFF
--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -255,7 +255,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
 
         // If the `history` feature is enabled, enable the additional endpoint.
         #[cfg(feature = "history")]
-        let routes = routes.route("/block/{blockHeight}/history/{mapping}", get(Self::get_history));
+        let routes = routes.route("/program/{id}/mapping/{name}/{key}/history/{height}", get(Self::get_history));
 
         routes
             // Pass in `Rest` to make things convenient.


### PR DESCRIPTION
Double-checked it with a local dev validator using:
```
curl -v -X GET http://127.0.0.1:3030/testnet/program/credits.aleo/mapping/metadata/aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc/history/0
```
and got
```
"4u32"
```