### PR TITLE
[Perf] Use unchecked deserialization in CDN sync

### DIFF
--- a/node/cdn/src/blocks.rs
+++ b/node/cdn/src/blocks.rs
@@ -21,7 +21,7 @@ use snarkos_utilities::{SignalHandler, Stoppable};
 
 use snarkvm::{
     prelude::{Deserialize, DeserializeOwned, Ledger, Network, Serialize, block::Block, store::ConsensusStorage},
-    utilities::flatten_error,
+    utilities::{flatten_error, unchecked_deserialize},
 };
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -479,7 +479,7 @@ async fn cdn_get<T: 'static + DeserializeOwned + Send>(client: Client, url: &str
     };
 
     // Parse the objects.
-    match tokio::task::spawn_blocking(move || (bincode::deserialize::<T>(&bytes), bytes)).await {
+    match tokio::task::spawn_blocking(move || (unchecked_deserialize::<T>(&bytes), bytes)).await {
         Ok((Ok(objects), _)) => Ok(objects),
         Ok((Err(error), response_bytes)) => {
             let bytes_as_string = String::from_utf8_lossy(&response_bytes);


### PR DESCRIPTION
This was a lot simpler than I expected - we can easily tap into the setup we're already using for retrieving trusted data from local storage. This results in a pretty solid boost in performance, most likely (hard to measure accurately due to the variance in download speed block size etc.) around 15% or more, depending on committee size (since most of the omitted checks are related to signature verification).