### PR TITLE
[Fix] Log errors at shutdown on non-interactive sessions

### DIFF
--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -347,7 +347,7 @@ impl Start {
         }
     }
 
-    /// Returns the CDN to prefetch initial blocks from, from the given configurations.
+    /// Returns the CDN to prefetch initial blocks from, or `None` if fetching from the CDN is disabled.
     fn parse_cdn<N: Network>(&self) -> Result<Option<http::Uri>> {
         // Disable CDN if:
         //  1. The node is in development mode.
@@ -692,7 +692,7 @@ impl Start {
         // Parse the development configurations.
         self.parse_development(&mut trusted_peers, &mut trusted_validators)?;
 
-        // Parse the CDN.
+        // Determine if the node should sync from CDn..
         let cdn = self.parse_cdn::<N>().with_context(|| "Failed to parse given CDN URL")?;
 
         // Parse the genesis block.
@@ -829,7 +829,7 @@ impl Start {
         };
 
         // TODO(kaimast): start the display earlier and show sync progress.
-        if !self.nodisplay && !self.nocdn {
+        if !self.nodisplay && cdn.is_some() {
             println!("🪧 The terminal UI will not start until the node has finished syncing from the CDN. If this step takes too long, consider restarting with `--nodisplay`.");
         }
 

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -58,6 +58,7 @@ use serde::{Deserialize, Serialize};
 
 use std::{
     fs,
+    io::IsTerminal,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4, ToSocketAddrs},
     path::{Path, PathBuf},
     sync::{Arc, atomic::AtomicBool},
@@ -313,6 +314,13 @@ impl Start {
             shutdown.clone(),
         )
         .with_context(|| "Failed to set up logger")?;
+
+        // When running in a non-interactive session, disallow the use of the terminal UI.
+        if !std::io::stdout().is_terminal() && !self.nodisplay {
+            anyhow::bail!(
+                "snarkOS cannot use the terminal UI in a non-interactive session. Please restart with `--nodisplay`."
+            );
+        }
 
         // Initialize the runtime.
         Self::runtime().block_on(async move {

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -14,15 +14,15 @@
 // limitations under the License.
 
 use snarkos_cli::{commands::CLI, helpers::Updater};
-use snarkvm::utilities::display_error;
+use snarkvm::utilities::{display_error, flatten_error};
 
 use clap::Parser;
 #[cfg(feature = "locktick")]
 use locktick::lock_snapshots;
 #[cfg(feature = "locktick")]
 use std::time::Instant;
-use std::{backtrace::Backtrace, env, panic::catch_unwind};
-use tracing::log::logger;
+use std::{backtrace::Backtrace, env, io, io::IsTerminal, panic::catch_unwind};
+use tracing::{log::logger, subscriber::NoSubscriber};
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 use tikv_jemallocator::Jemalloc;
@@ -34,17 +34,32 @@ static GLOBAL: Jemalloc = Jemalloc;
 // Obtain information on the build.
 include!(concat!(env!("OUT_DIR"), "/built.rs"));
 
-/// Prints a message using `tracing::error` if logging is enabled, otherwise uses `eprintln`.
+/// True if a real tracing subscriber is set (not the default no-op).
+fn has_tracing_subscriber() -> bool {
+    tracing::dispatcher::get_default(|d| !d.is::<NoSubscriber>())
+}
+
+/// Uses stderr when interactive or when no logger is set; otherwise logs via tracing.
 macro_rules! print_error {
     ($($arg:tt)*) => {
-        if tracing::log::log_enabled!(tracing::log::Level::Error) {
-            tracing::error!($($arg)*);
-        } else {
+        if io::stderr().is_terminal() || !has_tracing_subscriber() {
             eprintln!($($arg)*);
+        } else {
+            tracing::error!($($arg)*);
         }
     };
 }
 
+/// Uses stdout when interactive or when no logger is set; otherwise logs via tracing.
+macro_rules! print_info {
+    ($($arg:tt)*) => {
+        if io::stderr().is_terminal() || !has_tracing_subscriber() {
+            println!($($arg)*);
+        } else {
+            tracing::info!($($arg)*);
+        }
+    };
+}
 /// Stops the process with the given exit code.
 fn exit(exitcode: i32) -> ! {
     tracing::debug!("Stopping process with exitcode {exitcode}");
@@ -130,7 +145,7 @@ fn main() {
         if !cli.noupdater
             && let Some(msg) = Updater::print_cli()
         {
-            println!("{msg}");
+            print_info!("{msg}");
         }
 
         // Run the CLI.
@@ -140,15 +155,18 @@ fn main() {
     // Process any errors (including panics).
     match result {
         Ok(Ok(output)) => {
-            println!("{output}\n");
+            print_info!("{output}\n");
             exit(0);
         }
         Ok(Err(err)) => {
-            // A regular error occurred.
-            display_error(&err);
-            eprintln!();
-            eprintln!("Use `--help` for instructions on how to use this command");
-
+            // A regular error occurred during startup.
+            if io::stderr().is_terminal() || !has_tracing_subscriber() {
+                display_error(&err);
+                eprintln!();
+                eprintln!("Use `--help` for instructions on how to use this command");
+            } else {
+                tracing::error!("{}", flatten_error(&err));
+            }
             exit(1);
         }
         Err(_) => {
@@ -171,7 +189,7 @@ fn check_for_version() {
             let mut features = FEATURES_LOWERCASE_STR.to_owned();
             features.retain(|c| c != ' ');
 
-            println!("snarkos {branch} {commit} features=[{features}]");
+            print_info!("snarkos {branch} {commit} features=[{features}]");
 
             exit(0);
         }


### PR DESCRIPTION
I recently noticed that some of the shutdown routines write errors to stderr, instead of `tracing::log`. This is because not all snarkOS commands enable a logger, but this also means that some startup errors do not show up in the logs which can make it unclear why a node shut down.

This PR will log, instead of print, output in `src/main.rs` if in a non-interactive session (e.g., snarkOS was started by systemd) and logging is enabled.

Finally, the PR introduces a check that ensures in non-interactive sessions snarkOS is always started with `--nodisplay`, as the terminal UI will not work correctly in this context.

### Testing
To test this do the following, you need to start snarkOS with some invalid configuration that will generate an error. For example, you can instruct it to use the `node-data` from a different network. 

First, run it in an interactive session, i.e., directly invoke `snarkos start` in the terminal. You should get an error message like this.
```
⚠️ Failed to start node
     ↳ Failed to initialize the ledger
     ↳ Incorrect genesis block (run 'snarkos clean' and try again)
```

Then, run it in a non-interactive session. The easiest way to do this is by piping the commands output to a file, e.g, `snarkos start --validator --network 0 --verbosity=5 --dev 0 --nodisplay &> foo`.

You should then see the same error being logged.
```
2026-03-04T06:00:25.459936Z ERROR snarkos: Failed to start node — Failed to initialize the ledger — Incorrect genesis block (run 'snarkos clean' and try again)
2026-03-04T06:00:25.459956Z DEBUG snarkos: Stopping process with exitcode 1
```