### PR TITLE
Harden TCP connection config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -788,7 +788,7 @@ workflows:
           filters:
             branches:
               only:
-                - ci/log-ci-runner-canary
+                - patch/tcp-socket-creation-2
                 - canary
                 - testnet
                 - mainnet
@@ -798,7 +798,7 @@ workflows:
           filters:
             branches:
               only:
-                - ci/log-ci-runner-canary
+                - patch/tcp-socket-creation-2
                 - canary
                 - testnet
                 - mainnet
@@ -810,7 +810,7 @@ workflows:
           filters:
             branches:
               only:
-                - ci/log-ci-runner-canary
+                - patch/tcp-socket-creation-2
                 - canary
                 - testnet
                 - mainnet

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1858,7 +1858,7 @@ mod prop_tests {
         }
 
         let tcp_config = gateway.tcp().config();
-        assert_eq!(tcp_config.max_connections, Committee::<CurrentNetwork>::max_committee_size().unwrap());
+        assert_eq!(tcp_config.max_connections, Committee::<CurrentNetwork>::max_committee_size().unwrap() * 10);
         assert_eq!(gateway.account().address(), account.address());
     }
 

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1828,7 +1828,7 @@ mod prop_tests {
         assert_eq!(tcp_config.desired_listening_port, Some(MEMORY_POOL_PORT + dev.port().unwrap()));
 
         let tcp_config = gateway.tcp().config();
-        assert_eq!(tcp_config.max_connections, Committee::<CurrentNetwork>::max_committee_size().unwrap());
+        assert_eq!(tcp_config.max_connections, Committee::<CurrentNetwork>::max_committee_size().unwrap() * 10);
         assert_eq!(gateway.account().address(), account.address());
     }
 

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -216,7 +216,7 @@ impl<N: Network> Gateway<N> {
             (Some(ip), _) => ip,
         };
         // Initialize the TCP stack.
-        let tcp = Tcp::new(Config::new(ip, Committee::<N>::max_committee_size()?));
+        let tcp = Tcp::new(Config::new(ip, Committee::<N>::max_committee_size()? * 10));
 
         // Prepare the collection of the initial peers.
         let mut initial_peers = HashMap::new();

--- a/node/tcp/src/tcp.rs
+++ b/node/tcp/src/tcp.rs
@@ -33,7 +33,7 @@ use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use tokio::{
     io::split,
-    net::{TcpListener, TcpStream},
+    net::{TcpListener, TcpSocket, TcpStream},
     sync::oneshot,
     task::JoinHandle,
     time::timeout,
@@ -266,10 +266,7 @@ impl Tcp {
         // Bind the tcp socket to the configured listener ip if it's set.
         // Otherwise default to the system's default interface.
         let res = if let Some(listen_ip) = self.config().listener_ip {
-            let sock =
-                if listen_ip.is_ipv4() { tokio::net::TcpSocket::new_v4()? } else { tokio::net::TcpSocket::new_v6()? };
-            sock.bind(SocketAddr::new(listen_ip, 0))?;
-            timeout(timeout_duration, sock.connect(addr)).await
+            timeout(timeout_duration, self.connect_with_specific_interface(listen_ip, addr)).await
         } else {
             timeout(timeout_duration, TcpStream::connect(addr)).await
         };
@@ -296,6 +293,13 @@ impl Tcp {
         }
 
         ret.map_err(|err| err.into())
+    }
+
+    async fn connect_with_specific_interface(&self, listen_ip: IpAddr, addr: SocketAddr) -> io::Result<TcpStream> {
+        let sock = if listen_ip.is_ipv4() { TcpSocket::new_v4()? } else { TcpSocket::new_v6()? };
+        // Lock the socket to a specific interface.
+        sock.bind(SocketAddr::new(listen_ip, 0))?;
+        sock.connect(addr).await
     }
 
     /// Disconnects from the provided `SocketAddr`.


### PR DESCRIPTION
## Motivation

We recently observed an updated validator taking dozens of minutes before it was connected to > 90% of other nodes. We also observed that connections were refused due to too many pending connections, potentially the *same* peers filling up the precious pending TCP cache.

This PR introduces:
- 9cdfcd5025a52ad4c2dae49779204d411045d383 We catch and cleanup if issues were to happen in socket creation or binding.
- edcf75657ff4e2ee6781ebd0d2396cde71576d3f A 10x increase in the TCP connection limit. The worst case impact on resource usage should be negligible, and we ultimately only connect to validators in the committee anyway.

## Test Plan

- [x] CI should be sufficient.

## Documentation

This needs a new snarkOS mainnet release