### PR TITLE
[Fix] Detach the BFT metrics from events

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -284,6 +284,18 @@ impl<N: Network> Gateway<N> {
         self.enable_disconnect().await;
         self.enable_on_connect().await;
 
+        // Spawn a loop for periodic metrics.
+        #[cfg(feature = "metrics")]
+        {
+            let gateway = self.clone();
+            self.spawn(async move {
+                loop {
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    gateway.update_metrics();
+                }
+            });
+        }
+
         // Enable the TCP listener. Note: This must be called after the above protocols.
         let listen_addr = self.tcp.enable_listener().await.expect("Failed to enable the TCP listener");
         debug!("Listening for validator connections at address {listen_addr:?}");
@@ -793,9 +805,6 @@ impl<N: Network> Gateway<N> {
                     self.insert_candidate_peers(valid_addrs);
                 }
 
-                #[cfg(feature = "metrics")]
-                self.update_metrics();
-
                 Ok(true)
             }
             Event::WorkerPing(ping) => {
@@ -829,7 +838,7 @@ impl<N: Network> Gateway<N> {
         let self_clone = self.clone();
         self.spawn(async move {
             // Sleep briefly to ensure the other nodes are ready to connect.
-            tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+            tokio::time::sleep(Duration::from_millis(1000)).await;
             info!("Starting the heartbeat of the gateway...");
             loop {
                 // Process a heartbeat in the gateway.
@@ -1368,8 +1377,6 @@ impl<N: Network> Disconnect for Gateway<N> {
             // of members.
             self.cache.clear_outbound_validators_requests(peer_ip);
             self.cache.clear_outbound_block_requests(peer_ip);
-            #[cfg(feature = "metrics")]
-            self.update_metrics();
         }
     }
 }
@@ -1459,8 +1466,6 @@ impl<N: Network> Handshake for Gateway<N> {
                             ConnectionMode::Gateway,
                         );
                     }
-                    #[cfg(feature = "metrics")]
-                    self.update_metrics();
                     info!("{CONTEXT} Connected to '{addr}'");
                 }
                 Err(error) => {


### PR DESCRIPTION
This PR decouples the connection-related BFT metrics from events, in order to provide a clearer picture regardless of any potential slowdowns.

Fixes https://github.com/ProvableHQ/snarkOS/issues/4145.