### PR TITLE
[Fix] Robust broadcast counters

### DIFF
--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -36,7 +36,7 @@ use snarkos_node_sync::BlockSync;
 use snarkvm::{
     console::{program::ProgramID, types::Field},
     ledger::narwhal::Data,
-    prelude::{Ledger, Network, cfg_into_iter, store::ConsensusStorage},
+    prelude::{Ledger, Network, VM, cfg_into_iter, store::ConsensusStorage},
 };
 
 use anyhow::{Context, Result};
@@ -53,10 +53,7 @@ use axum_extra::response::ErasedJson;
 use locktick::parking_lot::Mutex;
 #[cfg(not(feature = "locktick"))]
 use parking_lot::Mutex;
-use std::{
-    net::SocketAddr,
-    sync::{Arc, atomic::AtomicUsize},
-};
+use std::{net::SocketAddr, sync::Arc};
 use tokio::{net::TcpListener, sync::Semaphore, task::JoinHandle};
 use tower_governor::{GovernorLayer, governor::GovernorConfigBuilder};
 use tower_http::{
@@ -87,9 +84,9 @@ pub struct Rest<N: Network, C: ConsensusStorage<N>, R: Routing<N>> {
     /// A reference to BlockSync,
     block_sync: Arc<BlockSync<N>>,
     /// The number of ongoing deploy transaction verifications via REST.
-    num_verifying_deploys: Arc<AtomicUsize>,
+    num_verifying_deploys: Arc<Semaphore>,
     /// The number of ongoing execute transaction verifications via REST.
-    num_verifying_executions: Arc<AtomicUsize>,
+    num_verifying_executions: Arc<Semaphore>,
     /// The number of ongoing solution verifications via REST.
     num_verifying_solutions: Arc<Semaphore>,
 }
@@ -113,8 +110,8 @@ impl<N: Network, C: 'static + ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> 
             cdn_sync,
             block_sync,
             handles: Default::default(),
-            num_verifying_deploys: Default::default(),
-            num_verifying_executions: Default::default(),
+            num_verifying_deploys: Arc::new(Semaphore::new(VM::<N, C>::MAX_PARALLEL_DEPLOY_VERIFICATIONS)),
+            num_verifying_executions: Arc::new(Semaphore::new(VM::<N, C>::MAX_PARALLEL_EXECUTE_VERIFICATIONS)),
             num_verifying_solutions: Arc::new(Semaphore::new(N::MAX_SOLUTIONS)),
         };
         // Spawn the server.

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -57,7 +57,7 @@ use std::{
     net::SocketAddr,
     sync::{Arc, atomic::AtomicUsize},
 };
-use tokio::{net::TcpListener, task::JoinHandle};
+use tokio::{net::TcpListener, sync::Semaphore, task::JoinHandle};
 use tower_governor::{GovernorLayer, governor::GovernorConfigBuilder};
 use tower_http::{
     cors::{Any, CorsLayer},
@@ -91,7 +91,7 @@ pub struct Rest<N: Network, C: ConsensusStorage<N>, R: Routing<N>> {
     /// The number of ongoing execute transaction verifications via REST.
     num_verifying_executions: Arc<AtomicUsize>,
     /// The number of ongoing solution verifications via REST.
-    num_verifying_solutions: Arc<AtomicUsize>,
+    num_verifying_solutions: Arc<Semaphore>,
 }
 
 impl<N: Network, C: 'static + ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
@@ -115,7 +115,7 @@ impl<N: Network, C: 'static + ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> 
             handles: Default::default(),
             num_verifying_deploys: Default::default(),
             num_verifying_executions: Default::default(),
-            num_verifying_solutions: Default::default(),
+            num_verifying_solutions: Arc::new(Semaphore::new(N::MAX_SOLUTIONS)),
         };
         // Spawn the server.
         server.spawn_server(rest_ip, rest_rps).await?;

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -20,7 +20,7 @@ use snarkos_node_router::messages::UnconfirmedSolution;
 use snarkvm::ledger::store::helpers::MapRead;
 use snarkvm::{
     ledger::puzzle::Solution,
-    prelude::{Address, Identifier, LimitedWriter, Plaintext, Program, ToBytes, VM, block::Transaction},
+    prelude::{Address, Identifier, LimitedWriter, Plaintext, Program, ToBytes, block::Transaction},
 };
 
 use axum::{Json, extract::rejection::JsonRejection};
@@ -31,7 +31,7 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_with::skip_serializing_none;
-use std::{collections::HashMap, fs, sync::atomic::Ordering};
+use std::{collections::HashMap, fs};
 
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
@@ -716,32 +716,14 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         let check_transaction = check_transaction.check_transaction.unwrap_or(false);
 
         if check_transaction {
-            // Select counter and limit based on transaction type.
-            let (counter, limit, err_msg) = if tx.is_execute() {
-                (
-                    &rest.num_verifying_executions,
-                    VM::<N, C>::MAX_PARALLEL_EXECUTE_VERIFICATIONS,
-                    "Too many execution verifications in progress",
-                )
+            // Select the semaphore based on the transaction type.
+            let (slot, err_msg) = if tx.is_execute() {
+                (rest.num_verifying_executions.acquire().await, "Too many execution verifications in progress")
             } else {
-                (
-                    &rest.num_verifying_deploys,
-                    VM::<N, C>::MAX_PARALLEL_DEPLOY_VERIFICATIONS,
-                    "Too many deploy verifications in progress",
-                )
+                (rest.num_verifying_deploys.acquire().await, "Too many deploy verifications in progress")
             };
 
-            // Try to acquire a slot.
-            if counter
-                .fetch_update(
-                    Ordering::Relaxed,
-                    Ordering::Relaxed,
-                    |val| {
-                        if val < limit { Some(val + 1) } else { None }
-                    },
-                )
-                .is_err()
-            {
+            if slot.is_err() {
                 return Err(RestError::too_many_requests(anyhow!("{err_msg}")));
             }
 
@@ -756,8 +738,6 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
                     }
                 }
             });
-            // Release the slot.
-            counter.fetch_sub(1, Ordering::Relaxed);
             // Propagate error if any.
             res?;
         }

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -815,22 +815,10 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         let check_solution = check_solution.check_solution.unwrap_or(false);
 
         if check_solution {
-            // Select counter and limit.
-            let (counter, limit, err_msg) =
-                (&rest.num_verifying_solutions, N::MAX_SOLUTIONS, "Too many solution verifications in progress");
-
             // Try to acquire a slot.
-            if counter
-                .fetch_update(
-                    Ordering::Relaxed,
-                    Ordering::Relaxed,
-                    |val| {
-                        if val < limit { Some(val + 1) } else { None }
-                    },
-                )
-                .is_err()
-            {
-                return Err(RestError::too_many_requests(anyhow!("{err_msg}")));
+            let slot = rest.num_verifying_solutions.acquire().await;
+            if slot.is_err() {
+                return Err(RestError::too_many_requests(anyhow!("Too many solution verifications in progress")));
             }
 
             // Compute the current epoch hash.
@@ -872,8 +860,6 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
                         return Err(RestError::internal_server_error(anyhow!("Tokio error: {err}")));
                     }
                 };
-            // Release the slot.
-            counter.fetch_sub(1, Ordering::Relaxed);
             // Propagate error if any.
             res?;
         }


### PR DESCRIPTION
No need to manually keep track of broadcast limits ourselves; using a `Semaphore` we don't have to worry about the atomic ordering involved, or about cleanups.