### PR TITLE
Fix devnet script. snarkos clean has no concept of dev-num-validators

### DIFF
--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -74,7 +74,7 @@ if [[ $clear_ledger == "y" ]]; then
 
   for ((index = 0; index < $((total_validators + total_clients)); index++)); do
     # Run 'snarkos clean' for each node in the background
-    "${binary_path}snarkos" clean "--network=$network_id" "--dev=$index" "--dev-num-validators=$total_validators" &
+    "${binary_path}snarkos" clean "--network=$network_id" "--dev=$index" &
 
     # Store the process ID of the background task
     clean_processes+=($!)


### PR DESCRIPTION
## Motivation

Running the devnet script threw:
```
error: unexpected argument '--dev-num-validators' found

  tip: a similar argument exists: '--dev'

Usage: snarkos clean --network <NETWORK> --dev <DEV>

For more information, try '--help'.
```


## Test Plan

Ran the devnet script after this PR.