### PR TITLE
[Fix] 4.5.1 mainnet backports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,9 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
-#git = "https://github.com/ProvableHQ/snarkVM.git"
-#rev = "ba7bf28"
-version = "=4.5.0"
+git = "https://github.com/ProvableHQ/snarkVM.git"
+rev = "eb6d42f"
+# version = "=4.5.0"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1303,6 +1303,7 @@ impl<N: Network> OnConnect for Gateway<N> {
         if let Some(listener_addr) = self.resolve_to_listener(&peer_addr) {
             if let Some(peer) = self.get_connected_peer(listener_addr) {
                 if peer.node_type == NodeType::BootstrapClient {
+                    self.cache.increment_outbound_validators_requests(listener_addr);
                     let _ =
                         <Self as Transport<N>>::send(self, listener_addr, Event::ValidatorsRequest(ValidatorsRequest))
                             .await;

--- a/node/bft/tests/gateway_e2e.rs
+++ b/node/bft/tests/gateway_e2e.rs
@@ -26,7 +26,7 @@ use snarkos_account::Account;
 use snarkos_node_bft::{Gateway, helpers::init_primary_channels};
 use snarkos_node_bft_events::{ChallengeRequest, ChallengeResponse, Event};
 use snarkos_node_network::PeerPoolHandling;
-use snarkos_node_tcp::P2P;
+use snarkos_node_tcp::{P2P, protocols::Handshake};
 use snarkvm::{ledger::narwhal::Data, prelude::TestRng};
 
 use std::time::Duration;
@@ -79,7 +79,10 @@ async fn handshake_responder_side_timeout() {
     // Check the tcp stack's connection counts, wait longer than the gateway's timeout to ensure
     // connecting peers are cleared.
     let gateway_clone = gateway.clone();
-    deadline!(Duration::from_secs(5), move || gateway_clone.tcp().num_connecting() == 0);
+    deadline!(Duration::from_millis(<Gateway<CurrentNetwork> as Handshake>::TIMEOUT_MS + 2_000), move || gateway_clone
+        .tcp()
+        .num_connecting()
+        == 0);
 
     // Check the test peer hasn't been added to the gateway's connected peers.
     assert!(gateway.connected_peers().is_empty());

--- a/node/tcp/src/helpers/config.rs
+++ b/node/tcp/src/helpers/config.rs
@@ -84,7 +84,7 @@ impl Default for Config {
             allow_random_port: true,
             fatal_io_errors: vec![ConnectionReset, ConnectionAborted, BrokenPipe, InvalidData, UnexpectedEof],
             max_connections: 100,
-            connection_timeout_ms: 1_000,
+            connection_timeout_ms: 3_000,
         }
     }
 }

--- a/node/tcp/src/protocols/handshake.rs
+++ b/node/tcp/src/protocols/handshake.rs
@@ -39,8 +39,8 @@ where
 {
     /// The maximum time allowed for a connection to perform a handshake before it is rejected.
     ///
-    /// The default value is 3000ms.
-    const TIMEOUT_MS: u64 = 3_000;
+    /// The default value is 5s.
+    const TIMEOUT_MS: u64 = 5_000;
 
     /// Prepares the node to perform specified network handshakes.
     async fn enable_handshake(&self) {


### PR DESCRIPTION
A few backports for the `mainnet`:
- https://github.com/ProvableHQ/snarkVM/pull/3182
- https://github.com/ProvableHQ/snarkOS/pull/4157
- https://github.com/ProvableHQ/snarkOS/pull/4158