### PR TITLE
[Logs] Remove empty log entries

### DIFF
--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -395,7 +395,7 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
             metrics::update_block_metrics(block);
         }
 
-        tracing::info!("\n\nAdvanced to block {} at round {} - {}\n", block.height(), block.round(), block.hash());
+        tracing::info!("Advanced to block {} at round {} - {}", block.height(), block.round(), block.hash());
         Ok(())
     }
 

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -251,7 +251,7 @@ impl<N: Network> PrimaryCallback<N> for BFT<N> {
                 let leader_round = leader_certificate.round();
                 match leader_round == current_round {
                     true => {
-                        info!("\n\nRound {current_round} elected a leader - {}\n", leader_certificate.author());
+                        info!("Round {current_round} elected a leader - {}", leader_certificate.author());
                         #[cfg(feature = "metrics")]
                         metrics::increment_counter(metrics::bft::LEADERS_ELECTED);
                     }
@@ -259,8 +259,8 @@ impl<N: Network> PrimaryCallback<N> for BFT<N> {
                 }
             } else {
                 match is_ready {
-                    true => info!("\n\nRound {current_round} reached quorum without a leader\n"),
-                    false => info!("{}", format!("\n\nRound {current_round} did not elect a leader (yet)\n").dimmed()),
+                    true => info!("Round {current_round} reached quorum without a leader"),
+                    false => info!("{}", format!("Round {current_round} did not elect a leader (yet)").dimmed()),
                 }
             }
         }

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -1697,7 +1697,7 @@ impl<N: Network> Primary<N> {
         // Log the certified batch.
         let num_transmissions = certificate.transmission_ids().len();
         let round = certificate.round();
-        info!("\n\nOur batch with {num_transmissions} transmissions for round {round} was certified!\n");
+        info!("Our batch with {num_transmissions} transmissions for round {round} was certified!");
         // Increment to the next round.
         self.try_increment_to_the_next_round(round + 1).await
     }

--- a/snarkos/main.rs
+++ b/snarkos/main.rs
@@ -155,7 +155,7 @@ fn main() {
     // Process any errors (including panics).
     match result {
         Ok(Ok(output)) => {
-            print_info!("{output}\n");
+            print_info!("{output}");
             exit(0);
         }
         Ok(Err(err)) => {


### PR DESCRIPTION
While practical locally, the empty log lines are unhelpful when browsing them in bulk:
<img width="894" height="578" alt="provable grafana net_explore_schemaVersion=1 panes=%7B%22fy0%22%3A%7B%22datasource%22%3A%22bf6hh0chl7xtse%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22datasource%22%3A%7B%22type%22%3A%22googlecloud-logging-datasource%22%2C%22uid%22%3A%22bf6hh" src="https://github.com/user-attachments/assets/e00796b0-ac07-4fc4-92b0-a3104119f111" />
Since the devs can easily apply extra ad-hoc visibility to any logs at any point in time, I propose that we remove the additional newlines by default.