### PR TITLE
[Fix] Correct the Router heartbeat interval

### DIFF
--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -779,7 +779,7 @@ impl<N: Network> BFT<N> {
                 }
 
                 info!(
-                    "\n\nCommitting a subDAG with anchor round {anchor_round} and {num_transmissions} transmissions: {subdag_metadata:?} (syncing={IS_SYNCING})\n",
+                    "Committing a subDAG with anchor round {anchor_round} and {num_transmissions} transmissions: {subdag_metadata:?} (syncing={IS_SYNCING})"
                 );
             }
 

--- a/node/router/src/routing.rs
+++ b/node/router/src/routing.rs
@@ -50,21 +50,17 @@ pub trait Routing<N: Network>:
     fn initialize_heartbeat(&self) {
         let self_clone = self.clone();
         self.router().spawn(async move {
-            let mut last_update = Instant::now();
-
             loop {
+                let start = Instant::now();
                 // Process a heartbeat in the router.
                 self_clone.heartbeat().await;
+                let end = Instant::now();
 
-                // The heartbeat itself may take a while (as it is waiting for connection attempts to complete).
-                // Take this time into account when rate-limiting the heartbeat.
-                let now = Instant::now();
-                let elapsed = now.saturating_duration_since(last_update);
-
-                // Sleep for the remaining time.
-                tokio::time::sleep(Self::HEARTBEAT_INTERVAL.saturating_sub(elapsed)).await;
-                // Update the last update time.
-                last_update = now;
+                // The heartbeat may take a while (as it is waiting for connection attempts to complete).
+                // Take this into account when calculating its sleep time.
+                let took = end.saturating_duration_since(start);
+                let sleep_time = Self::HEARTBEAT_INTERVAL.saturating_sub(took);
+                tokio::time::sleep(sleep_time).await;
             }
         });
     }

--- a/node/router/src/routing.rs
+++ b/node/router/src/routing.rs
@@ -54,11 +54,10 @@ pub trait Routing<N: Network>:
                 let start = Instant::now();
                 // Process a heartbeat in the router.
                 self_clone.heartbeat().await;
-                let end = Instant::now();
+                let took = start.elapsed();
 
                 // The heartbeat may take a while (as it is waiting for connection attempts to complete).
                 // Take this into account when calculating its sleep time.
-                let took = end.saturating_duration_since(start);
                 let sleep_time = Self::HEARTBEAT_INTERVAL.saturating_sub(took);
                 tokio::time::sleep(sleep_time).await;
             }


### PR DESCRIPTION
During log analysis I've realized that the `Router` heartbeat fires twice in a row every time, which is caused by a sneaky miscalculation in its sleep time. This may cause not only confusion while debugging, but  also issues with `Router` connections. I've confirmed locally that this change fixes it.

As a drive-by, remove one empty line log missed in https://github.com/ProvableHQ/snarkOS/pull/4161.