### PR TITLE
[Fix] Use the correct address to resolve peers as a BootstrapClient

### DIFF
--- a/node/src/bootstrap_client/handshake.rs
+++ b/node/src/bootstrap_client/handshake.rs
@@ -200,7 +200,7 @@ impl<N: Network> BootstrapClient<N> {
         *listener_addr = Some(SocketAddr::new(peer_addr.ip(), peer_port));
 
         // Introduce the peer into the peer pool.
-        self.add_connecting_peer(peer_addr)?;
+        self.add_connecting_peer(listener_addr.unwrap())?;
 
         // Verify the challenge request.
         if !self.verify_challenge_request(peer_addr, &mut framed, &peer_request).await? {


### PR DESCRIPTION
Found this while looking into a potential client-related bug on Canary.

Tested it locally.