### PR TITLE
Backport deadlock fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -788,7 +788,7 @@ workflows:
           filters:
             branches:
               only:
-                - patch/tcp-socket-creation-2
+                - fix/4.5.3-hotfixes
                 - canary
                 - testnet
                 - mainnet
@@ -798,7 +798,7 @@ workflows:
           filters:
             branches:
               only:
-                - patch/tcp-socket-creation-2
+                - fix/4.5.3-hotfixes
                 - canary
                 - testnet
                 - mainnet
@@ -810,7 +810,7 @@ workflows:
           filters:
             branches:
               only:
-                - patch/tcp-socket-creation-2
+                - fix/4.5.3-hotfixes
                 - canary
                 - testnet
                 - mainnet

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4404,7 +4404,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos"
-version = "4.5.3"
+version = "4.5.4"
 dependencies = [
  "built",
  "clap",
@@ -4872,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -4895,7 +4895,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4923,7 +4923,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "blst",
  "cc",
@@ -4934,7 +4934,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4948,7 +4948,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4958,7 +4958,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4968,7 +4968,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4978,7 +4978,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "indexmap 2.13.0",
  "itertools",
@@ -4996,12 +4996,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -5012,7 +5012,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5026,7 +5026,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5054,7 +5054,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -5063,7 +5063,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5073,7 +5073,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5085,7 +5085,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5097,7 +5097,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5108,7 +5108,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5120,7 +5120,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -5133,7 +5133,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -5144,7 +5144,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -5160,7 +5160,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -5172,7 +5172,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -5192,7 +5192,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "anyhow",
  "bech32",
@@ -5210,7 +5210,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -5231,7 +5231,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -5246,7 +5246,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5257,7 +5257,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -5265,7 +5265,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5275,7 +5275,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5286,7 +5286,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5297,7 +5297,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5308,7 +5308,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5319,7 +5319,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "rand 0.8.5",
  "rustc_version",
@@ -5332,7 +5332,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5349,7 +5349,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5380,7 +5380,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -5392,7 +5392,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -5414,7 +5414,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -5433,7 +5433,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -5446,7 +5446,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "indexmap 2.13.0",
  "rayon",
@@ -5459,7 +5459,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "indexmap 2.13.0",
  "rayon",
@@ -5472,7 +5472,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5483,7 +5483,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "indexmap 2.13.0",
  "rayon",
@@ -5498,7 +5498,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5511,7 +5511,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -5520,7 +5520,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5540,7 +5540,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5563,7 +5563,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5580,7 +5580,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -5608,7 +5608,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5626,7 +5626,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "metrics",
 ]
@@ -5634,7 +5634,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5657,7 +5657,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5691,7 +5691,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "aleo-std",
  "colored 3.1.1",
@@ -5716,7 +5716,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "enum-iterator",
  "indexmap 2.13.0",
@@ -5735,7 +5735,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "bincode",
  "serde_json",
@@ -5748,7 +5748,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5771,7 +5771,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.5.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=eb6d42f#eb6d42f2bd7307ac3d3c51d4014a7da28abe6250"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5e0b1837f#5e0b1837f930ae0d4fb51677f3c99d9ec0256d94"
 dependencies = [
  "proc-macro2",
  "quote 1.0.44",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkos"
-version = "4.5.3"
+version = "4.5.4"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A decentralized operating system"
 homepage = "https://aleo.org"
@@ -48,7 +48,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "eb6d42f"
+rev = "5e0b1837f"
 # version = "=4.5.0"
 default-features = false
 


### PR DESCRIPTION
## Motivation

See https://github.com/ProvableHQ/snarkVM/pull/3184 for context

## Test Plan

- [ ] Running [prerelease CI prerelease-v4.5.23](https://aleostresstest.grafana.net/d/prerelease-devnet/prerelease-devnet?from=2026-03-16T10:30:42.029Z&to=2026-03-16T14:30:42.029Z&refresh=5s&timezone=browser&orgId=1), it's failing!