### PR TITLE
[Feature] Add Slipstream Plugin Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2161,7 +2161,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3074,6 +3074,7 @@ dependencies = [
  "cfg-if",
  "foreign-types",
  "libc",
+ "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3514,7 +3515,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3552,7 +3553,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5864,13 +5865,34 @@ dependencies = [
  "parking_lot",
  "paste",
  "rand 0.10.1",
- "reqwest",
  "serde_json",
  "sha2 0.11.0",
  "snarkvm-curves",
  "snarkvm-utilities",
  "thiserror 2.0.18",
  "ureq",
+]
+
+[[package]]
+name = "snarkvm-slipstream-plugin-interface"
+version = "4.6.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
+name = "snarkvm-slipstream-plugin-manager"
+version = "4.6.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+dependencies = [
+ "anyhow",
+ "json5",
+ "libloading",
+ "serde_json",
+ "snarkvm-slipstream-plugin-interface",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5076,7 +5076,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -5099,7 +5099,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5127,7 +5127,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "blst",
  "cc",
@@ -5138,7 +5138,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5152,7 +5152,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -5162,7 +5162,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -5172,7 +5172,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -5182,7 +5182,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5202,12 +5202,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -5218,7 +5218,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5232,7 +5232,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -5247,7 +5247,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5260,7 +5260,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -5269,7 +5269,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5279,7 +5279,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5291,7 +5291,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5303,7 +5303,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5314,7 +5314,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5326,7 +5326,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -5339,7 +5339,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -5350,7 +5350,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -5366,7 +5366,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "locktick",
@@ -5380,7 +5380,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -5400,7 +5400,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -5418,7 +5418,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -5439,7 +5439,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -5454,7 +5454,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5465,7 +5465,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -5473,7 +5473,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5483,7 +5483,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5494,7 +5494,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5505,7 +5505,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5516,7 +5516,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5527,7 +5527,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "rand 0.10.1",
  "rustc_version",
@@ -5540,7 +5540,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5557,7 +5557,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5589,7 +5589,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "anyhow",
  "rand 0.10.1",
@@ -5601,7 +5601,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5624,7 +5624,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5643,7 +5643,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -5656,7 +5656,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5669,7 +5669,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5682,7 +5682,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5693,7 +5693,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5708,7 +5708,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5721,7 +5721,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -5730,7 +5730,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5751,7 +5751,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5774,7 +5774,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5791,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -5820,7 +5820,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5838,7 +5838,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "metrics",
 ]
@@ -5846,7 +5846,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5869,7 +5869,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-slipstream-plugin-interface"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "anyhow",
  "tracing",
@@ -5878,7 +5878,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-slipstream-plugin-manager"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "anyhow",
  "json5",
@@ -5894,7 +5894,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5929,7 +5929,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-error"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-environment",
@@ -5940,7 +5940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "colored 3.1.1",
@@ -5967,7 +5967,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "enum-iterator",
  "indexmap 2.14.0",
@@ -5988,7 +5988,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "bincode",
  "serde_json",
@@ -6001,7 +6001,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6024,7 +6024,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,9 +357,15 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
+<<<<<<< HEAD
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+=======
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 
 [[package]]
 name = "base64"
@@ -463,7 +469,11 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
+<<<<<<< HEAD
  "digest 0.10.7",
+=======
+ "digest",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -487,6 +497,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "block-buffer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +507,8 @@ dependencies = [
 ]
 
 [[package]]
+=======
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "blst"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+<<<<<<< HEAD
 name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +643,8 @@ dependencies = [
 ]
 
 [[package]]
+=======
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,20 +718,29 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
+<<<<<<< HEAD
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+=======
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "cc",
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
+=======
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,12 +848,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+<<<<<<< HEAD
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+=======
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,12 +927,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+<<<<<<< HEAD
 name = "cpubits"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
 
 [[package]]
+=======
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +945,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +955,8 @@ dependencies = [
 ]
 
 [[package]]
+=======
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1034,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
+<<<<<<< HEAD
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
@@ -1015,15 +1050,22 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
+<<<<<<< HEAD
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+=======
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "generic-array",
  "typenum",
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "crypto-common"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,6 +1076,8 @@ dependencies = [
 ]
 
 [[package]]
+=======
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1088,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,9 +1105,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
+<<<<<<< HEAD
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
+=======
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1149,6 +1200,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
+<<<<<<< HEAD
  "const-oid 0.9.6",
  "zeroize",
 ]
@@ -1225,12 +1277,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
+<<<<<<< HEAD
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+=======
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "subtle",
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "digest"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,6 +1302,8 @@ dependencies = [
 ]
 
 [[package]]
+=======
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1379,17 @@ dependencies = [
  "rfc6979",
  "signature 3.0.0-rc.10",
  "zeroize",
+=======
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -1327,7 +1399,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
+<<<<<<< HEAD
  "signature 2.2.0",
+=======
+ "signature",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -1339,8 +1415,13 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
+<<<<<<< HEAD
  "sha2 0.10.9",
  "signature 2.2.0",
+=======
+ "sha2",
+ "signature",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "subtle",
  "zeroize",
 ]
@@ -1365,6 +1446,19 @@ dependencies = [
  "rand_core 0.10.1",
  "rustcrypto-ff",
  "rustcrypto-group",
+=======
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "rand_core 0.6.4",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "sec1",
  "subtle",
  "zeroize",
@@ -1494,6 +1588,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+<<<<<<< HEAD
+=======
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1717,12 +1824,22 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
+<<<<<<< HEAD
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+=======
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+dependencies = [
+ "typenum",
+ "version_check",
+ "zeroize",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -1824,6 +1941,20 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
+=======
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1942,11 +2073,19 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
+<<<<<<< HEAD
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.2",
+=======
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -2038,6 +2177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
+<<<<<<< HEAD
 name = "hybrid-array"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,6 +2189,8 @@ dependencies = [
 ]
 
 [[package]]
+=======
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2381,9 +2523,15 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
+<<<<<<< HEAD
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+=======
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "memchr",
  "serde",
@@ -2491,6 +2639,12 @@ checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
+=======
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2531,6 +2685,16 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sha2 0.11.0",
+=======
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "sha2",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -2640,9 +2804,15 @@ dependencies = [
 
 [[package]]
 name = "line-clipping"
+<<<<<<< HEAD
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+=======
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -2853,9 +3023,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
+<<<<<<< HEAD
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+=======
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "libc",
  "log",
@@ -2987,9 +3163,15 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
+<<<<<<< HEAD
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+=======
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 
 [[package]]
 name = "num-derive"
@@ -3260,7 +3442,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
+<<<<<<< HEAD
  "sha2 0.10.9",
+=======
+ "sha2",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -3347,7 +3533,11 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
+<<<<<<< HEAD
  "der 0.7.10",
+=======
+ "der",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "spki",
 ]
 
@@ -3434,9 +3624,15 @@ dependencies = [
 
 [[package]]
 name = "proptest"
+<<<<<<< HEAD
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+=======
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
@@ -3445,6 +3641,13 @@ dependencies = [
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift 0.4.0",
+=======
+ "lazy_static",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "regex-syntax 0.8.10",
  "rusty-fork",
  "tempfile",
@@ -3524,7 +3727,11 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
+<<<<<<< HEAD
  "rustc-hash 2.1.2",
+=======
+ "rustc-hash 2.1.1",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -3545,7 +3752,11 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
+<<<<<<< HEAD
  "rustc-hash 2.1.2",
+=======
+ "rustc-hash 2.1.1",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -3616,6 +3827,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3637,6 +3849,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "rand_chacha"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3647,6 +3860,8 @@ dependencies = [
 ]
 
 [[package]]
+=======
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3665,6 +3880,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3682,6 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "rand_xorshift"
+<<<<<<< HEAD
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
@@ -3943,9 +4160,15 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
+<<<<<<< HEAD
 version = "0.5.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23a3127ee32baec36af75b4107082d9bd823501ec14a4e016be4b6b37faa74ae"
+=======
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "hmac",
  "subtle",
@@ -4010,9 +4233,15 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
+<<<<<<< HEAD
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+=======
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 
 [[package]]
 name = "rustc_version"
@@ -4024,6 +4253,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "rustcrypto-ff"
 version = "0.14.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4045,6 +4275,8 @@ dependencies = [
 ]
 
 [[package]]
+=======
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4241,6 +4473,15 @@ dependencies = [
  "ctutils",
  "der 0.8.0",
  "hybrid-array",
+=======
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "subtle",
  "zeroize",
 ]
@@ -4428,8 +4669,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
+<<<<<<< HEAD
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+=======
+ "cpufeatures",
+ "digest",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -4439,6 +4685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
+<<<<<<< HEAD
  "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
@@ -4452,6 +4699,10 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.2",
+=======
+ "cpufeatures",
+ "digest",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -4506,11 +4757,16 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+<<<<<<< HEAD
  "digest 0.10.7",
+=======
+ "digest",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rand_core 0.6.4",
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "signature"
 version = "3.0.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4525,6 +4781,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+=======
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 
 [[package]]
 name = "simple_asn1"
@@ -4592,7 +4854,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "built",
  "clap",
@@ -4618,7 +4884,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos-account"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "colored 3.1.1",
  "snarkvm",
@@ -4626,7 +4896,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos-cli"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "aleo-std",
  "anstyle",
@@ -4643,6 +4917,10 @@ dependencies = [
  "parking_lot",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
+=======
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rayon",
  "rpassword",
  "self_update",
@@ -4669,7 +4947,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos-display"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "anyhow",
  "crossterm",
@@ -4682,7 +4964,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4725,7 +5011,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-bft"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4753,6 +5043,13 @@ dependencies = [
  "rand_distr",
  "rayon",
  "sha2 0.10.9",
+=======
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_distr",
+ "rayon",
+ "sha2",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "smol_str 0.3.2",
  "snarkos-account",
  "snarkos-node-bft",
@@ -4779,7 +5076,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-bft-events"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "anyhow",
  "bytes",
@@ -4789,6 +5090,9 @@ dependencies = [
  "rand_chacha 0.10.0",
  "serde",
  "snarkos-node-bft-events",
+=======
+ "serde",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "snarkos-node-sync-locators",
  "snarkos-node-tcp",
  "snarkvm",
@@ -4800,7 +5104,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-bft-ledger-service"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4819,7 +5127,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-bft-storage-service"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4833,7 +5145,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-cdn"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "anyhow",
  "bincode",
@@ -4855,7 +5171,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-consensus"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4881,7 +5201,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-metrics"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "built",
  "locktick",
@@ -4895,7 +5219,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-network"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "anyhow",
  "built",
@@ -4913,7 +5241,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-rest"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4949,7 +5281,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-router"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4963,6 +5299,9 @@ dependencies = [
  "peak_alloc",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
+=======
+ "rand 0.8.5",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rayon",
  "snarkos-account",
  "snarkos-node-bft-ledger-service",
@@ -4985,7 +5324,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-router-messages"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "bytes",
  "proptest",
@@ -5001,7 +5344,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-sync"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "anyhow",
  "futures",
@@ -5027,7 +5374,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-sync-communication-service"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "async-trait",
  "tokio",
@@ -5035,7 +5386,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-sync-locators"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5046,7 +5401,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-tcp"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5064,7 +5423,11 @@ dependencies = [
 
 [[package]]
 name = "snarkos-utilities"
+<<<<<<< HEAD
 version = "4.6.0"
+=======
+version = "4.5.1"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "anyhow",
  "locktick",
@@ -5115,6 +5478,12 @@ dependencies = [
  "rayon",
  "serde",
  "sha2 0.10.9",
+=======
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "sha2",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "smallvec",
  "snarkvm-algorithms-cuda",
  "snarkvm-curves",
@@ -5567,6 +5936,10 @@ dependencies = [
  "parking_lot",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
+=======
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rayon",
  "snarkvm-circuit",
  "snarkvm-console",
@@ -5631,6 +6004,10 @@ dependencies = [
  "proptest",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
+=======
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rand_distr",
  "rayon",
  "serde_json",
@@ -5741,6 +6118,10 @@ dependencies = [
  "parking_lot",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
+=======
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rayon",
  "serde_json",
  "snarkvm-algorithms",
@@ -5762,6 +6143,10 @@ dependencies = [
  "parking_lot",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
+=======
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rayon",
  "snarkvm-circuit",
  "snarkvm-console",
@@ -5861,6 +6246,11 @@ dependencies = [
  "reqwest",
  "serde_json",
  "sha2 0.10.9",
+=======
+ "rand 0.8.5",
+ "serde_json",
+ "sha2",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "snarkvm-curves",
  "snarkvm-utilities",
  "thiserror 2.0.18",
@@ -5950,6 +6340,10 @@ dependencies = [
  "parking_lot",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
+=======
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rayon",
  "serde_json",
  "snarkvm-algorithms",
@@ -5974,6 +6368,10 @@ dependencies = [
  "paste",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
+=======
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rayon",
  "serde_json",
  "snarkvm-algorithms",
@@ -6011,6 +6409,10 @@ dependencies = [
  "num_cpus",
  "rand 0.10.1",
  "rand_xorshift 0.5.0",
+=======
+ "rand 0.8.5",
+ "rand_xorshift",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rayon",
  "serde",
  "serde_json",
@@ -6078,7 +6480,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
+<<<<<<< HEAD
  "der 0.7.10",
+=======
+ "der",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -6340,7 +6746,11 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
+<<<<<<< HEAD
  "sha2 0.10.9",
+=======
+ "sha2",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "signal-hook",
  "siphasher",
  "terminfo",
@@ -6937,9 +7347,15 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
+<<<<<<< HEAD
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+=======
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 
 [[package]]
 name = "unicode-truncate"
@@ -7167,6 +7583,18 @@ checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+=======
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -7291,7 +7719,11 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
+<<<<<<< HEAD
  "sha2 0.10.9",
+=======
+ "sha2",
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "thiserror 1.0.69",
  "uuid",
 ]
@@ -7835,18 +8267,30 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+<<<<<<< HEAD
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+=======
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
+<<<<<<< HEAD
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+=======
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+>>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5076,7 +5076,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -5099,7 +5099,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5127,7 +5127,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "blst",
  "cc",
@@ -5138,7 +5138,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5152,7 +5152,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -5162,7 +5162,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -5172,7 +5172,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -5182,7 +5182,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5202,12 +5202,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -5218,7 +5218,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5232,7 +5232,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -5247,7 +5247,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5260,7 +5260,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -5269,7 +5269,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5279,7 +5279,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5291,7 +5291,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5303,7 +5303,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5314,7 +5314,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5326,7 +5326,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -5339,7 +5339,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -5350,7 +5350,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -5366,7 +5366,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "aleo-std",
  "locktick",
@@ -5380,7 +5380,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -5400,7 +5400,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "anyhow",
  "bech32",
@@ -5418,7 +5418,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -5439,7 +5439,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -5454,7 +5454,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5465,7 +5465,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -5473,7 +5473,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5483,7 +5483,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5494,7 +5494,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5505,7 +5505,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5516,7 +5516,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5527,7 +5527,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "rand 0.10.1",
  "rustc_version",
@@ -5540,7 +5540,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5557,7 +5557,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5589,7 +5589,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "anyhow",
  "rand 0.10.1",
@@ -5601,7 +5601,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5624,7 +5624,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5643,7 +5643,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -5656,7 +5656,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5669,7 +5669,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5682,7 +5682,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5693,7 +5693,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5708,7 +5708,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5721,7 +5721,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -5730,7 +5730,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5751,7 +5751,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5774,7 +5774,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5791,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -5820,7 +5820,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5838,7 +5838,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "metrics",
 ]
@@ -5846,7 +5846,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5869,7 +5869,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-slipstream-plugin-interface"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "anyhow",
  "tracing",
@@ -5878,7 +5878,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-slipstream-plugin-manager"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "anyhow",
  "json5",
@@ -5894,7 +5894,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5929,7 +5929,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-error"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-environment",
@@ -5940,7 +5940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "aleo-std",
  "colored 3.1.1",
@@ -5967,7 +5967,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "enum-iterator",
  "indexmap 2.14.0",
@@ -5988,7 +5988,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "bincode",
  "serde_json",
@@ -6001,7 +6001,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6024,7 +6024,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=d83dc74732b8b273d222ad412426338e51da823b#d83dc74732b8b273d222ad412426338e51da823b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -168,7 +168,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -243,9 +243,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -253,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -662,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -684,9 +684,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -737,7 +737,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1054,36 +1054,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl"
-version = "0.4.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fc3b6dd0b87ba36e565715bf9a2ced221311db47bd18011676f24a6066edbc"
-dependencies = [
- "curl-sys",
- "libc",
- "openssl-probe 0.1.6",
- "openssl-sys",
- "schannel",
- "socket2 0.6.3",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.87+curl-8.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a460380f0ef783703dcbe909107f39c162adeac050d73c850055118b5b6327"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,9 +1308,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.16"
+version = "0.17.0-rc.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91bbdd377139884fafcad8dc43a760a3e1e681aa26db910257fa6535b70e1829"
+checksum = "dc4bf51f0534ed6e59a0f2f26272b64ba55c470133f8424c2adfd1c4d59d9988"
 dependencies = [
  "der 0.8.0",
  "digest 0.11.2",
@@ -1383,9 +1353,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.30"
+version = "0.14.0-rc.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7a0bfd012613a7bcfe02cbfccf2b846e9ef9e1bccb641c48d461253cfb034d"
+checksum = "b148a81cede8f4023248f980cffdf7611c46f2add469c6980e815b7c5b764ba5"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -1495,7 +1465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2526,6 +2496,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2542,9 +2523,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-rc.8"
+version = "0.14.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2c6c227649d5ec80eaae541f1736232641a0bcdb3062a52b34edb42054158"
+checksum = "1b382cbfd43caf55991a93850ce538aa1aa67bb264af367d22dfe7937c4e997d"
 dependencies = [
  "cpubits",
  "ecdsa",
@@ -2917,7 +2898,7 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "openssl-sys",
  "schannel",
  "security-framework",
@@ -3085,9 +3066,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
-version = "5.3.3"
+version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
 dependencies = [
  "is-wsl",
  "libc",
@@ -3096,9 +3077,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -3122,21 +3103,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -3315,7 +3290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3623,9 +3598,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
 ]
@@ -4013,9 +3988,9 @@ dependencies = [
 
 [[package]]
 name = "rtoolbox"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327b72899159dfae8060c51a1f6aebe955245bcd9cc4997eed0f623caea022e4"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -4092,7 +4067,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4117,7 +4092,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -4151,7 +4126,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4162,9 +4137,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4739,6 +4714,7 @@ dependencies = [
  "snarkos-node-tcp",
  "snarkos-utilities",
  "snarkvm",
+ "snarkvm-slipstream-plugin-manager",
  "time",
  "tokio",
  "tokio-stream",
@@ -4962,6 +4938,7 @@ dependencies = [
  "snarkos-node-router",
  "snarkos-node-sync",
  "snarkvm",
+ "snarkvm-slipstream-plugin-manager",
  "time",
  "tokio",
  "tower",
@@ -5099,7 +5076,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -5122,7 +5099,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5150,7 +5127,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "blst",
  "cc",
@@ -5161,7 +5138,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5175,7 +5152,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -5185,7 +5162,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -5195,7 +5172,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -5205,7 +5182,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5225,12 +5202,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -5241,7 +5218,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5255,7 +5232,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -5270,7 +5247,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5283,7 +5260,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -5292,7 +5269,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5302,7 +5279,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5314,7 +5291,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5326,7 +5303,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5337,7 +5314,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5349,7 +5326,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -5362,7 +5339,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -5373,7 +5350,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -5389,7 +5366,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "locktick",
@@ -5403,7 +5380,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -5423,7 +5400,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -5441,7 +5418,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -5462,7 +5439,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -5477,7 +5454,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5488,7 +5465,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -5496,7 +5473,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5506,7 +5483,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5517,7 +5494,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5528,7 +5505,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5539,7 +5516,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5550,7 +5527,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "rand 0.10.1",
  "rustc_version",
@@ -5563,7 +5540,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5580,7 +5557,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5612,7 +5589,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "anyhow",
  "rand 0.10.1",
@@ -5624,7 +5601,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5647,7 +5624,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5666,7 +5643,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -5679,7 +5656,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5692,7 +5669,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5705,7 +5682,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5716,7 +5693,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5731,7 +5708,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5744,7 +5721,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -5753,7 +5730,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5768,12 +5745,13 @@ dependencies = [
  "serde_json",
  "snarkvm-algorithms",
  "snarkvm-console",
+ "snarkvm-utilities",
 ]
 
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5796,7 +5774,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5813,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -5832,6 +5810,7 @@ dependencies = [
  "snarkvm-ledger-committee",
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-puzzle",
+ "snarkvm-slipstream-plugin-manager",
  "snarkvm-synthesizer-program",
  "snarkvm-synthesizer-snark",
  "snarkvm-utilities",
@@ -5841,7 +5820,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5859,7 +5838,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "metrics",
 ]
@@ -5867,19 +5846,19 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "anyhow",
  "cfg-if",
  "colored 3.1.1",
- "curl",
  "hex",
  "lazy_static",
  "locktick",
  "parking_lot",
  "paste",
  "rand 0.10.1",
+ "reqwest",
  "serde_json",
  "sha2 0.10.9",
  "snarkvm-curves",
@@ -5888,9 +5867,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "snarkvm-slipstream-plugin-interface"
+version = "4.6.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+dependencies = [
+ "anyhow",
+ "tracing",
+]
+
+[[package]]
+name = "snarkvm-slipstream-plugin-manager"
+version = "4.6.0"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
+dependencies = [
+ "anyhow",
+ "json5",
+ "libloading",
+ "parking_lot",
+ "serde_json",
+ "snarkvm-slipstream-plugin-interface",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "snarkvm-synthesizer"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5925,7 +5929,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-error"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-environment",
@@ -5936,7 +5940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "colored 3.1.1",
@@ -5963,7 +5967,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "enum-iterator",
  "indexmap 2.14.0",
@@ -5984,7 +5988,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "bincode",
  "serde_json",
@@ -5997,7 +6001,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6020,7 +6024,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=stream_plugin_testing#d83dc74732b8b273d222ad412426338e51da823b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -6044,7 +6048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6281,7 +6285,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6365,14 +6369,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "test-log-macros"
-version = "0.2.19"
+name = "test-log-core"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be35209fd0781c5401458ab66e4f98accf63553e8fae7425503e92fdd319783b"
+checksum = "37d4d41320b48bc4a211a9021678fcc0c99569b594ea31c93735b8e517102b4c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9beb9249a81e430dffd42400a49019bcf548444f1968ff23080a625de0d4d320"
+dependencies = [
+ "syn 2.0.117",
+ "test-log-core",
 ]
 
 [[package]]
@@ -6547,9 +6561,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -6668,7 +6682,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -6893,9 +6907,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -7043,9 +7057,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",
@@ -7116,11 +7130,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -7129,7 +7143,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -7243,18 +7257,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7374,7 +7388,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7692,9 +7706,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"
@@ -7704,6 +7718,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4720,7 +4720,6 @@ dependencies = [
  "snarkos-node-tcp",
  "snarkos-utilities",
  "snarkvm",
- "snarkvm-slipstream-plugin-manager",
  "time",
  "tokio",
  "tokio-stream",
@@ -4945,7 +4944,6 @@ dependencies = [
  "snarkos-node-router",
  "snarkos-node-sync",
  "snarkvm",
- "snarkvm-slipstream-plugin-manager",
  "time",
  "tokio",
  "tower",
@@ -5083,7 +5081,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -5097,6 +5095,8 @@ dependencies = [
  "snarkvm-ledger",
  "snarkvm-metrics",
  "snarkvm-parameters",
+ "snarkvm-slipstream-plugin-interface",
+ "snarkvm-slipstream-plugin-manager",
  "snarkvm-synthesizer",
  "snarkvm-utilities",
  "ureq",
@@ -5106,7 +5106,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5134,7 +5134,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "blst",
  "cc",
@@ -5145,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5159,7 +5159,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -5169,7 +5169,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -5179,7 +5179,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -5189,7 +5189,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5209,12 +5209,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -5225,7 +5225,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5239,7 +5239,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -5254,7 +5254,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5267,7 +5267,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -5276,7 +5276,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5286,7 +5286,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5298,7 +5298,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5310,7 +5310,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5321,7 +5321,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5333,7 +5333,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -5346,7 +5346,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -5357,7 +5357,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -5373,7 +5373,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "aleo-std",
  "locktick",
@@ -5387,7 +5387,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -5407,7 +5407,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "anyhow",
  "bech32",
@@ -5425,7 +5425,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -5446,7 +5446,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -5461,7 +5461,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5472,7 +5472,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -5480,7 +5480,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5490,7 +5490,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5501,7 +5501,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5512,7 +5512,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5523,7 +5523,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5534,7 +5534,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "rand 0.10.1",
  "rustc_version",
@@ -5547,7 +5547,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5564,7 +5564,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5596,7 +5596,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "anyhow",
  "rand 0.10.1",
@@ -5608,7 +5608,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5631,7 +5631,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5650,7 +5650,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -5663,7 +5663,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5676,7 +5676,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5689,7 +5689,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5700,7 +5700,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5715,7 +5715,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5728,7 +5728,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -5737,7 +5737,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5758,7 +5758,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5781,7 +5781,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5798,7 +5798,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -5827,7 +5827,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5845,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "metrics",
 ]
@@ -5853,7 +5853,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5876,7 +5876,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-slipstream-plugin-interface"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "anyhow",
 ]
@@ -5884,7 +5884,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-slipstream-plugin-manager"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "anyhow",
  "json5",
@@ -5898,7 +5898,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5933,7 +5933,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-error"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-environment",
@@ -5944,7 +5944,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "aleo-std",
  "colored 3.1.1",
@@ -5971,7 +5971,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "enum-iterator",
  "indexmap 2.14.0",
@@ -5992,7 +5992,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "bincode",
  "serde_json",
@@ -6005,7 +6005,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6028,7 +6028,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=5f6b502578cc#5f6b502578ccc14661bfd768207e6d7376ddd7fc"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5083,7 +5083,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -5108,7 +5108,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5136,7 +5136,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "blst",
  "cc",
@@ -5147,7 +5147,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5161,7 +5161,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -5171,7 +5171,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -5181,7 +5181,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -5191,7 +5191,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5211,12 +5211,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -5227,7 +5227,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5241,7 +5241,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -5256,7 +5256,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5269,7 +5269,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -5278,7 +5278,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5288,7 +5288,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5300,7 +5300,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5312,7 +5312,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5323,7 +5323,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5335,7 +5335,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -5348,7 +5348,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -5359,7 +5359,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -5375,7 +5375,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "aleo-std",
  "locktick",
@@ -5389,7 +5389,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -5409,7 +5409,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "anyhow",
  "bech32",
@@ -5427,7 +5427,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -5448,7 +5448,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -5463,7 +5463,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5474,7 +5474,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -5482,7 +5482,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5492,7 +5492,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5503,7 +5503,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5514,7 +5514,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5525,7 +5525,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5536,7 +5536,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "rand 0.10.1",
  "rustc_version",
@@ -5549,7 +5549,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5566,7 +5566,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5598,7 +5598,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "anyhow",
  "rand 0.10.1",
@@ -5610,7 +5610,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5633,7 +5633,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5652,7 +5652,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -5665,7 +5665,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5678,7 +5678,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5691,7 +5691,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5702,7 +5702,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5717,7 +5717,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5730,7 +5730,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -5739,7 +5739,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5760,7 +5760,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5783,7 +5783,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5800,7 +5800,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -5829,7 +5829,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5847,7 +5847,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "metrics",
 ]
@@ -5855,7 +5855,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5878,7 +5878,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-slipstream-plugin-interface"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "anyhow",
 ]
@@ -5886,7 +5886,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-slipstream-plugin-manager"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "anyhow",
  "json5",
@@ -5900,7 +5900,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5935,7 +5935,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-error"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-environment",
@@ -5946,7 +5946,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "aleo-std",
  "colored 3.1.1",
@@ -5973,7 +5973,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "enum-iterator",
  "indexmap 2.14.0",
@@ -5994,7 +5994,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "bincode",
  "serde_json",
@@ -6007,7 +6007,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6030,7 +6030,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=10845556178ac#10845556178ac63c488b7ded9e04a3125f468cf9"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=60322dd#60322dd106822d4769a0c4b146699a804e5e08c3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,15 +357,9 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-<<<<<<< HEAD
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
-=======
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 
 [[package]]
 name = "base64"
@@ -469,11 +463,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
-<<<<<<< HEAD
  "digest 0.10.7",
-=======
- "digest",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -497,7 +487,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "block-buffer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,8 +496,6 @@ dependencies = [
 ]
 
 [[package]]
-=======
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "blst"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,7 +618,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-<<<<<<< HEAD
 name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,8 +629,6 @@ dependencies = [
 ]
 
 [[package]]
-=======
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,29 +702,20 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-<<<<<<< HEAD
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-=======
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "cc",
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
-=======
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,15 +823,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-<<<<<<< HEAD
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
-=======
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,15 +899,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-<<<<<<< HEAD
 name = "cpubits"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
 
 [[package]]
-=======
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,7 +914,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,8 +923,6 @@ dependencies = [
 ]
 
 [[package]]
-=======
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,7 +1000,6 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-<<<<<<< HEAD
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
@@ -1050,22 +1015,15 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-<<<<<<< HEAD
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-=======
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "generic-array",
  "typenum",
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "crypto-common"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,8 +1034,6 @@ dependencies = [
 ]
 
 [[package]]
-=======
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,7 +1044,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,15 +1060,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
-<<<<<<< HEAD
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
-=======
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1200,7 +1149,6 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
-<<<<<<< HEAD
  "const-oid 0.9.6",
  "zeroize",
 ]
@@ -1277,19 +1225,12 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
-<<<<<<< HEAD
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
-=======
- "block-buffer",
- "const-oid",
- "crypto-common",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "subtle",
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "digest"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,8 +1243,6 @@ dependencies = [
 ]
 
 [[package]]
-=======
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,17 +1318,6 @@ dependencies = [
  "rfc6979",
  "signature 3.0.0-rc.10",
  "zeroize",
-=======
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest",
- "elliptic-curve",
- "rfc6979",
- "signature",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -1399,11 +1327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
-<<<<<<< HEAD
  "signature 2.2.0",
-=======
- "signature",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -1415,13 +1339,8 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
-<<<<<<< HEAD
  "sha2 0.10.9",
  "signature 2.2.0",
-=======
- "sha2",
- "signature",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "subtle",
  "zeroize",
 ]
@@ -1446,19 +1365,6 @@ dependencies = [
  "rand_core 0.10.1",
  "rustcrypto-ff",
  "rustcrypto-group",
-=======
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest",
- "ff",
- "generic-array",
- "group",
- "rand_core 0.6.4",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "sec1",
  "subtle",
  "zeroize",
@@ -1588,19 +1494,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
-<<<<<<< HEAD
-=======
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,22 +1717,12 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-<<<<<<< HEAD
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-=======
-version = "0.14.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
-dependencies = [
- "typenum",
- "version_check",
- "zeroize",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -1941,20 +1824,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
-=======
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,19 +1942,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-<<<<<<< HEAD
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.2",
-=======
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -2177,7 +2038,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
-<<<<<<< HEAD
 name = "hybrid-array"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2189,8 +2049,6 @@ dependencies = [
 ]
 
 [[package]]
-=======
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2523,15 +2381,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-<<<<<<< HEAD
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-=======
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "memchr",
  "serde",
@@ -2639,12 +2491,6 @@ checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
-=======
-version = "0.3.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
-dependencies = [
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2685,16 +2531,6 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sha2 0.11.0",
-=======
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
-dependencies = [
- "cfg-if",
- "ecdsa",
- "elliptic-curve",
- "sha2",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -2804,15 +2640,9 @@ dependencies = [
 
 [[package]]
 name = "line-clipping"
-<<<<<<< HEAD
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
-=======
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -3023,15 +2853,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-<<<<<<< HEAD
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
-=======
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "libc",
  "log",
@@ -3163,15 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-<<<<<<< HEAD
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-=======
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 
 [[package]]
 name = "num-derive"
@@ -3442,11 +3260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
-<<<<<<< HEAD
  "sha2 0.10.9",
-=======
- "sha2",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -3533,11 +3347,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
-<<<<<<< HEAD
  "der 0.7.10",
-=======
- "der",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "spki",
 ]
 
@@ -3624,15 +3434,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-<<<<<<< HEAD
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
-=======
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
@@ -3641,13 +3445,6 @@ dependencies = [
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift 0.4.0",
-=======
- "lazy_static",
- "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_xorshift",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "regex-syntax 0.8.10",
  "rusty-fork",
  "tempfile",
@@ -3727,11 +3524,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
-<<<<<<< HEAD
  "rustc-hash 2.1.2",
-=======
- "rustc-hash 2.1.1",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -3752,11 +3545,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
-<<<<<<< HEAD
  "rustc-hash 2.1.2",
-=======
- "rustc-hash 2.1.1",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -3827,7 +3616,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3849,7 +3637,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "rand_chacha"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3860,8 +3647,6 @@ dependencies = [
 ]
 
 [[package]]
-=======
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3880,7 +3665,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3898,7 +3682,6 @@ dependencies = [
 
 [[package]]
 name = "rand_xorshift"
-<<<<<<< HEAD
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
@@ -4160,15 +3943,9 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-<<<<<<< HEAD
 version = "0.5.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23a3127ee32baec36af75b4107082d9bd823501ec14a4e016be4b6b37faa74ae"
-=======
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "hmac",
  "subtle",
@@ -4233,15 +4010,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-<<<<<<< HEAD
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-=======
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 
 [[package]]
 name = "rustc_version"
@@ -4253,7 +4024,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "rustcrypto-ff"
 version = "0.14.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4275,8 +4045,6 @@ dependencies = [
 ]
 
 [[package]]
-=======
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4473,15 +4241,6 @@ dependencies = [
  "ctutils",
  "der 0.8.0",
  "hybrid-array",
-=======
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "subtle",
  "zeroize",
 ]
@@ -4669,13 +4428,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
-<<<<<<< HEAD
  "cpufeatures 0.2.17",
  "digest 0.10.7",
-=======
- "cpufeatures",
- "digest",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -4685,7 +4439,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
-<<<<<<< HEAD
  "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
@@ -4699,10 +4452,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.2",
-=======
- "cpufeatures",
- "digest",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -4757,16 +4506,11 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
-<<<<<<< HEAD
  "digest 0.10.7",
-=======
- "digest",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rand_core 0.6.4",
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "signature"
 version = "3.0.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4781,12 +4525,6 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-=======
-name = "simd-adler32"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 
 [[package]]
 name = "simple_asn1"
@@ -4854,11 +4592,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "built",
  "clap",
@@ -4884,11 +4618,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos-account"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "colored 3.1.1",
  "snarkvm",
@@ -4896,11 +4626,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos-cli"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "aleo-std",
  "anstyle",
@@ -4917,10 +4643,6 @@ dependencies = [
  "parking_lot",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
-=======
- "rand 0.8.5",
- "rand_chacha 0.3.1",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rayon",
  "rpassword",
  "self_update",
@@ -4947,11 +4669,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos-display"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "anyhow",
  "crossterm",
@@ -4964,11 +4682,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5011,11 +4725,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-bft"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5043,13 +4753,6 @@ dependencies = [
  "rand_distr",
  "rayon",
  "sha2 0.10.9",
-=======
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_distr",
- "rayon",
- "sha2",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "smol_str 0.3.2",
  "snarkos-account",
  "snarkos-node-bft",
@@ -5076,11 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-bft-events"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "anyhow",
  "bytes",
@@ -5090,9 +4789,6 @@ dependencies = [
  "rand_chacha 0.10.0",
  "serde",
  "snarkos-node-bft-events",
-=======
- "serde",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "snarkos-node-sync-locators",
  "snarkos-node-tcp",
  "snarkvm",
@@ -5104,11 +4800,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-bft-ledger-service"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5127,11 +4819,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-bft-storage-service"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5145,11 +4833,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-cdn"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "anyhow",
  "bincode",
@@ -5171,11 +4855,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-consensus"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5201,11 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-metrics"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "built",
  "locktick",
@@ -5219,11 +4895,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-network"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "anyhow",
  "built",
@@ -5241,11 +4913,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-rest"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5281,11 +4949,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-router"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5299,9 +4963,6 @@ dependencies = [
  "peak_alloc",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
-=======
- "rand 0.8.5",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rayon",
  "snarkos-account",
  "snarkos-node-bft-ledger-service",
@@ -5324,11 +4985,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-router-messages"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "bytes",
  "proptest",
@@ -5344,11 +5001,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-sync"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "anyhow",
  "futures",
@@ -5374,11 +5027,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-sync-communication-service"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "async-trait",
  "tokio",
@@ -5386,11 +5035,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-sync-locators"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5401,11 +5046,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos-node-tcp"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5423,11 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "snarkos-utilities"
-<<<<<<< HEAD
 version = "4.6.0"
-=======
-version = "4.5.1"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "anyhow",
  "locktick",
@@ -5478,12 +5115,6 @@ dependencies = [
  "rayon",
  "serde",
  "sha2 0.10.9",
-=======
- "rand 0.8.5",
- "rayon",
- "serde",
- "sha2",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "smallvec",
  "snarkvm-algorithms-cuda",
  "snarkvm-curves",
@@ -5936,10 +5567,6 @@ dependencies = [
  "parking_lot",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
-=======
- "rand 0.8.5",
- "rand_chacha 0.3.1",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rayon",
  "snarkvm-circuit",
  "snarkvm-console",
@@ -6004,10 +5631,6 @@ dependencies = [
  "proptest",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
-=======
- "rand 0.8.5",
- "rand_chacha 0.3.1",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rand_distr",
  "rayon",
  "serde_json",
@@ -6118,10 +5741,6 @@ dependencies = [
  "parking_lot",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
-=======
- "rand 0.8.5",
- "rand_chacha 0.3.1",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rayon",
  "serde_json",
  "snarkvm-algorithms",
@@ -6143,10 +5762,6 @@ dependencies = [
  "parking_lot",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
-=======
- "rand 0.8.5",
- "rand_chacha 0.3.1",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rayon",
  "snarkvm-circuit",
  "snarkvm-console",
@@ -6246,11 +5861,6 @@ dependencies = [
  "reqwest",
  "serde_json",
  "sha2 0.10.9",
-=======
- "rand 0.8.5",
- "serde_json",
- "sha2",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "snarkvm-curves",
  "snarkvm-utilities",
  "thiserror 2.0.18",
@@ -6340,10 +5950,6 @@ dependencies = [
  "parking_lot",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
-=======
- "rand 0.8.5",
- "rand_chacha 0.3.1",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rayon",
  "serde_json",
  "snarkvm-algorithms",
@@ -6368,10 +5974,6 @@ dependencies = [
  "paste",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
-=======
- "rand 0.8.5",
- "rand_chacha 0.3.1",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rayon",
  "serde_json",
  "snarkvm-algorithms",
@@ -6409,10 +6011,6 @@ dependencies = [
  "num_cpus",
  "rand 0.10.1",
  "rand_xorshift 0.5.0",
-=======
- "rand 0.8.5",
- "rand_xorshift",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "rayon",
  "serde",
  "serde_json",
@@ -6480,11 +6078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
-<<<<<<< HEAD
  "der 0.7.10",
-=======
- "der",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -6746,11 +6340,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
-<<<<<<< HEAD
  "sha2 0.10.9",
-=======
- "sha2",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "signal-hook",
  "siphasher",
  "terminfo",
@@ -7347,15 +6937,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-<<<<<<< HEAD
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
-=======
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 
 [[package]]
 name = "unicode-truncate"
@@ -7583,18 +7167,6 @@ checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-=======
-version = "0.4.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
-dependencies = [
- "cfg-if",
- "futures-util",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 ]
 
 [[package]]
@@ -7719,11 +7291,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
-<<<<<<< HEAD
  "sha2 0.10.9",
-=======
- "sha2",
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
  "thiserror 1.0.69",
  "uuid",
 ]
@@ -8267,30 +7835,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-<<<<<<< HEAD
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
-=======
-version = "0.8.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-<<<<<<< HEAD
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
-=======
-version = "0.8.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
->>>>>>> 7cc3b687f (Updated snarkvm with arc around pluginmanager)
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4925,6 +4925,7 @@ dependencies = [
  "indexmap 2.14.0",
  "jsonwebtoken",
  "locktick",
+ "lru",
  "once_cell",
  "parking_lot",
  "rand 0.10.1",
@@ -5076,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -5099,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5127,7 +5128,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "blst",
  "cc",
@@ -5138,7 +5139,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5152,7 +5153,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -5162,7 +5163,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -5172,7 +5173,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -5182,7 +5183,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5202,12 +5203,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -5218,7 +5219,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5232,7 +5233,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -5247,7 +5248,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5260,7 +5261,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -5269,7 +5270,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5279,7 +5280,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5291,7 +5292,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5303,7 +5304,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5314,7 +5315,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5326,7 +5327,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -5339,7 +5340,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -5350,7 +5351,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -5366,7 +5367,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "aleo-std",
  "locktick",
@@ -5380,7 +5381,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -5400,7 +5401,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -5418,7 +5419,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -5439,7 +5440,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -5454,7 +5455,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5465,7 +5466,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -5473,7 +5474,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5483,7 +5484,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5494,7 +5495,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5505,7 +5506,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5516,7 +5517,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5527,7 +5528,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "rand 0.10.1",
  "rustc_version",
@@ -5540,7 +5541,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5557,7 +5558,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5589,7 +5590,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "anyhow",
  "rand 0.10.1",
@@ -5601,7 +5602,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5624,7 +5625,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5643,7 +5644,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -5656,7 +5657,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5669,7 +5670,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5682,7 +5683,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5693,7 +5694,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5708,7 +5709,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5721,7 +5722,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -5730,7 +5731,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5751,7 +5752,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5774,7 +5775,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5791,7 +5792,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -5820,7 +5821,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5838,7 +5839,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "metrics",
 ]
@@ -5846,7 +5847,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5869,7 +5870,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-slipstream-plugin-interface"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "anyhow",
  "tracing",
@@ -5878,7 +5879,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-slipstream-plugin-manager"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "anyhow",
  "json5",
@@ -5894,7 +5895,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5929,7 +5930,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-error"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-environment",
@@ -5940,7 +5941,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "aleo-std",
  "colored 3.1.1",
@@ -5967,7 +5968,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "enum-iterator",
  "indexmap 2.14.0",
@@ -5988,7 +5989,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "bincode",
  "serde_json",
@@ -6001,7 +6002,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6024,7 +6025,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e#951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=159f04ce49a29674e0fe63530e0212a71d58417f#159f04ce49a29674e0fe63530e0212a71d58417f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "10845556178ac"
+rev = "60322dd"
 #version = "=4.6.0"
 default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,13 @@ default-features = false
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "0d50724d180f02cc9973cbb07c1cb8ec0c10212a"
+rev = "68e72e6c68a87425e8a406e078dae1cea46f2bc1"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "0d50724d180f02cc9973cbb07c1cb8ec0c10212a"
+rev = "68e72e6c68a87425e8a406e078dae1cea46f2bc1"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,14 +47,14 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-# Latest stream_plugin_testing commit
-rev = "951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+# Latest staking commit
+rev = "159f04ce49a29674e0fe63530e0212a71d58417f"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-# Latest stream_plugin_testing commit
-rev = "951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
+# Latest staking commit
+rev = "159f04ce49a29674e0fe63530e0212a71d58417f"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,12 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
-#version = "=4.6.0"
+branch = "stream_plugin_testing"
 default-features = false
+
+[workspace.dependencies.snarkvm-slipstream-plugin-manager]
+git = "https://github.com/ProvableHQ/snarkVM.git"
+branch = "stream_plugin_testing"
 
 [workspace.dependencies.anyhow]
 version = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,13 @@ default-features = false
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "1eeb80dac6e9333ccffbeb5be57c6ed9438ed4bb"
+rev = "3e09bd1c6f8bcd39310836dbbe0a853c0431fcf7"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "1eeb80dac6e9333ccffbeb5be57c6ed9438ed4bb"
+rev = "3e09bd1c6f8bcd39310836dbbe0a853c0431fcf7"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,15 +47,10 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "5f6b502578cc"
+rev = "10845556178ac"
 #version = "=4.6.0"
 default-features = false
 
-[workspace.dependencies.snarkvm-slipstream-plugin-manager]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "5f6b502578cc"
-#version = "=4.6.0"
-default-features = false
 
 [workspace.dependencies.anyhow]
 version = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,13 +48,13 @@ default-features = false
 [workspace.dependencies.snarkvm]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "41023939401d9a2f5667cd1e0c211c582b269c95"
+rev = "37b18a3bd4bdb0a02145df4d39a550dce1cf53bf"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "41023939401d9a2f5667cd1e0c211c582b269c95"
+rev = "37b18a3bd4bdb0a02145df4d39a550dce1cf53bf"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,13 @@ default-features = false
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "3e09bd1c6f8bcd39310836dbbe0a853c0431fcf7"
+rev = "2811e1a524ff23a5e937ac4c1e8453520569b789"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "3e09bd1c6f8bcd39310836dbbe0a853c0431fcf7"
+rev = "2811e1a524ff23a5e937ac4c1e8453520569b789"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,13 @@ default-features = false
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "147b33914743874c26f9285a2ef5baf3cf478f56"
+rev = "1eeb80dac6e9333ccffbeb5be57c6ed9438ed4bb"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "147b33914743874c26f9285a2ef5baf3cf478f56"
+rev = "1eeb80dac6e9333ccffbeb5be57c6ed9438ed4bb"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,12 +48,14 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-branch = "stream_plugin_testing"
+# Latest stream_plugin_testing commit
+rev = "8edbf9fc4a7bd0092ffa63b7a816ad9a76494440"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-branch = "stream_plugin_testing"
+# Latest stream_plugin_testing commit
+rev = "8edbf9fc4a7bd0092ffa63b7a816ad9a76494440"
 
 [workspace.dependencies.anyhow]
 version = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ default-features = false
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
 rev = "0d50724d180f02cc9973cbb07c1cb8ec0c10212a"
+default-features = false
 
 [workspace.dependencies.anyhow]
 version = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,13 +48,13 @@ default-features = false
 [workspace.dependencies.snarkvm]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "dbcc803158311d7c4ae88a387b426b3e96b1c63d"
+rev = "7fb6b76886c6a6daf359de380b4a5be2b923e11e"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "dbcc803158311d7c4ae88a387b426b3e96b1c63d"
+rev = "7fb6b76886c6a6daf359de380b4a5be2b923e11e"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,13 +48,13 @@ default-features = false
 [workspace.dependencies.snarkvm]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "7fb6b76886c6a6daf359de380b4a5be2b923e11e"
+rev = "790bc32d54619db93ac35f3f2d0fae333e1082d6"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "7fb6b76886c6a6daf359de380b4a5be2b923e11e"
+rev = "790bc32d54619db93ac35f3f2d0fae333e1082d6"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,13 +48,13 @@ default-features = false
 [workspace.dependencies.snarkvm]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "530d5cb2ab85f1c1cfa7c9b534bba300ab4dac7c"
+rev = "2756fc535d2df62c12e34d12918f1a368ba459f8"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "530d5cb2ab85f1c1cfa7c9b534bba300ab4dac7c"
+rev = "2756fc535d2df62c12e34d12918f1a368ba459f8"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,13 @@ default-features = false
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "9617445a4e6f5c120f96dcf33ddb9df09cbf80e9"
+rev = "06cf3a7fd4ab16526920a4095c8c7069cfa82a17"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "9617445a4e6f5c120f96dcf33ddb9df09cbf80e9"
+rev = "06cf3a7fd4ab16526920a4095c8c7069cfa82a17"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,16 +46,17 @@ version = "1.0.1"
 default-features = false
 
 [workspace.dependencies.snarkvm]
-#path = "../snarkVM"
-git = "https://github.com/ProvableHQ/snarkVM.git"
+path = "../snarkVM"
+#git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "2811e1a524ff23a5e937ac4c1e8453520569b789"
+#rev = "41023939401d9a2f5667cd1e0c211c582b269c95"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
-git = "https://github.com/ProvableHQ/snarkVM.git"
+path = "../snarkVM/plugins/slipstream_plugin_manager"
+#git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "2811e1a524ff23a5e937ac4c1e8453520569b789"
+#rev = "41023939401d9a2f5667cd1e0c211c582b269c95"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,13 +48,13 @@ default-features = false
 [workspace.dependencies.snarkvm]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "37b18a3bd4bdb0a02145df4d39a550dce1cf53bf"
+rev = "1e8b0a8ed663336e6bc0a828d72194433a9c402b"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "37b18a3bd4bdb0a02145df4d39a550dce1cf53bf"
+rev = "1e8b0a8ed663336e6bc0a828d72194433a9c402b"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,8 +271,8 @@ path = "snarkos/main.rs"
 
 [features]
 default = [ "snarkos-cli/metrics", "snarkos-node-metrics", "snarkos-node/metrics", "snarkos-node-cdn/metrics" ]
-history = [ "snarkos-node/history" ]
-history-staking-rewards = [ "snarkos-node/history-staking-rewards" ]
+history = [ "snarkos-node/history", "snarkos-cli/history" ]
+history-staking-rewards = [ "snarkos-node/history-staking-rewards", "snarkos-cli/history-staking-rewards" ]
 telemetry = [ "snarkos-node/telemetry" ]
 cuda = [
   "snarkos-account/cuda",
@@ -304,6 +304,7 @@ serial = [
   "snarkos-node-consensus/serial",
   "snarkos-node-metrics/serial",
   "snarkos-node-rest/serial",
+
   "snarkos-node-router/serial",
   "snarkos-node-sync/serial",
   "snarkvm/serial"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,13 +48,13 @@ default-features = false
 [workspace.dependencies.snarkvm]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "2756fc535d2df62c12e34d12918f1a368ba459f8"
+rev = "d83dc74732b8b273d222ad412426338e51da823b"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "2756fc535d2df62c12e34d12918f1a368ba459f8"
+rev = "d83dc74732b8b273d222ad412426338e51da823b"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,13 @@ default-features = false
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "8edbf9fc4a7bd0092ffa63b7a816ad9a76494440"
+rev = "0d50724d180f02cc9973cbb07c1cb8ec0c10212a"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "8edbf9fc4a7bd0092ffa63b7a816ad9a76494440"
+rev = "0d50724d180f02cc9973cbb07c1cb8ec0c10212a"
 
 [workspace.dependencies.anyhow]
 version = "1.0"
@@ -273,6 +273,7 @@ path = "snarkos/main.rs"
 default = [ "snarkos-cli/metrics", "snarkos-node-metrics", "snarkos-node/metrics", "snarkos-node-cdn/metrics" ]
 history = [ "snarkos-node/history", "snarkos-cli/history" ]
 history-staking-rewards = [ "snarkos-node/history-staking-rewards", "snarkos-cli/history-staking-rewards" ]
+slipstream-plugins = [ "snarkos-node/slipstream-plugins", "snarkos-cli/slipstream-plugins" ]
 telemetry = [ "snarkos-node/telemetry" ]
 cuda = [
   "snarkos-account/cuda",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,13 @@ default-features = false
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "06cf3a7fd4ab16526920a4095c8c7069cfa82a17"
+rev = "147b33914743874c26f9285a2ef5baf3cf478f56"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "06cf3a7fd4ab16526920a4095c8c7069cfa82a17"
+rev = "147b33914743874c26f9285a2ef5baf3cf478f56"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,17 +46,15 @@ version = "1.0.1"
 default-features = false
 
 [workspace.dependencies.snarkvm]
-path = "../snarkVM"
-#git = "https://github.com/ProvableHQ/snarkVM.git"
+git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-#rev = "41023939401d9a2f5667cd1e0c211c582b269c95"
+rev = "41023939401d9a2f5667cd1e0c211c582b269c95"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
-path = "../snarkVM/plugins/slipstream_plugin_manager"
-#git = "https://github.com/ProvableHQ/snarkVM.git"
+git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-#rev = "41023939401d9a2f5667cd1e0c211c582b269c95"
+rev = "41023939401d9a2f5667cd1e0c211c582b269c95"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,13 @@ default-features = false
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "c2057121188564a656ebd341a55b0ba97ed2b0f4"
+rev = "9617445a4e6f5c120f96dcf33ddb9df09cbf80e9"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "c2057121188564a656ebd341a55b0ba97ed2b0f4"
+rev = "9617445a4e6f5c120f96dcf33ddb9df09cbf80e9"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,13 +48,13 @@ default-features = false
 [workspace.dependencies.snarkvm]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "790bc32d54619db93ac35f3f2d0fae333e1082d6"
+rev = "530d5cb2ab85f1c1cfa7c9b534bba300ab4dac7c"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "790bc32d54619db93ac35f3f2d0fae333e1082d6"
+rev = "530d5cb2ab85f1c1cfa7c9b534bba300ab4dac7c"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,13 +47,13 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-# Latest staking commit
+# Latest staging commit
 rev = "159f04ce49a29674e0fe63530e0212a71d58417f"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
-# Latest staking commit
+# Latest staging commit
 rev = "159f04ce49a29674e0fe63530e0212a71d58417f"
 default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,13 @@ default-features = false
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "68e72e6c68a87425e8a406e078dae1cea46f2bc1"
+rev = "c2057121188564a656ebd341a55b0ba97ed2b0f4"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "68e72e6c68a87425e8a406e078dae1cea46f2bc1"
+rev = "c2057121188564a656ebd341a55b0ba97ed2b0f4"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,13 +48,13 @@ default-features = false
 [workspace.dependencies.snarkvm]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "1e8b0a8ed663336e6bc0a828d72194433a9c402b"
+rev = "dbcc803158311d7c4ae88a387b426b3e96b1c63d"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "1e8b0a8ed663336e6bc0a828d72194433a9c402b"
+rev = "dbcc803158311d7c4ae88a387b426b3e96b1c63d"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,8 +271,8 @@ path = "snarkos/main.rs"
 
 [features]
 default = [ "snarkos-cli/metrics", "snarkos-node-metrics", "snarkos-node/metrics", "snarkos-node-cdn/metrics" ]
-history = [ "snarkos-node/history", "snarkos-cli/history" ]
-history-staking-rewards = [ "snarkos-node/history-staking-rewards", "snarkos-cli/history-staking-rewards" ]
+history = [ "snarkos-node/history" ]
+history-staking-rewards = [ "snarkos-node/history-staking-rewards" ]
 slipstream-plugins = [ "snarkos-node/slipstream-plugins", "snarkos-cli/slipstream-plugins" ]
 telemetry = [ "snarkos-node/telemetry" ]
 cuda = [
@@ -305,7 +305,6 @@ serial = [
   "snarkos-node-consensus/serial",
   "snarkos-node-metrics/serial",
   "snarkos-node-rest/serial",
-
   "snarkos-node-router/serial",
   "snarkos-node-sync/serial",
   "snarkvm/serial"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,13 +48,13 @@ default-features = false
 [workspace.dependencies.snarkvm]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "d83dc74732b8b273d222ad412426338e51da823b"
+rev = "951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 default-features = false
 
 [workspace.dependencies.snarkvm-slipstream-plugin-manager]
 git = "https://github.com/ProvableHQ/snarkVM.git"
 # Latest stream_plugin_testing commit
-rev = "d83dc74732b8b273d222ad412426338e51da823b"
+rev = "951cb1bc5ea305747cad56ef7ef2b5f1d0dfe01e"
 default-features = false
 
 [workspace.dependencies.anyhow]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,6 +21,7 @@ default = [ ]
 async = [ ]
 history = [ "snarkos-node/history" ]
 history-staking-rewards = [ "snarkos-node/history-staking-rewards" ]
+slipstream-plugins = [ "snarkos-node/slipstream-plugins" ]
 locktick = [
   "dep:locktick",
   "snarkos-display/locktick",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,8 +19,6 @@ edition = "2024"
 [features]
 default = [ ]
 async = [ ]
-history = [ "snarkos-node/history" ]
-history-staking-rewards = [ "snarkos-node/history-staking-rewards" ]
 slipstream-plugins = [ "snarkos-node/slipstream-plugins" ]
 locktick = [
   "dep:locktick",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,6 +19,8 @@ edition = "2024"
 [features]
 default = [ ]
 async = [ ]
+history = [ "snarkos-node/history" ]
+history-staking-rewards = [ "snarkos-node/history-staking-rewards" ]
 locktick = [
   "dep:locktick",
   "snarkos-display/locktick",

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -297,6 +297,12 @@ pub struct Start {
     /// If the flag is set, the node will attempt to automatically migrate the node data to the new format.
     #[clap(long)]
     pub auto_migrate_node_data: bool,
+
+    /// Paths to Slipstream plugin config files (JSON5). May be repeated for multiple plugins.
+    /// Requires the node to be compiled with --features history or --features history-staking-rewards.
+    #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+    #[clap(long = "slipstream-config", value_name = "PATH", verbatim_doc_comment)]
+    pub slipstream_configs: Vec<PathBuf>,
 }
 
 impl Start {
@@ -844,11 +850,17 @@ impl Start {
         // Register the signal handler.
         let signal_handler = SignalHandler::new();
 
+        // Collect slipstream plugin config paths (empty slice when feature is disabled).
+        #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+        let slipstream_configs: &[PathBuf] = &self.slipstream_configs;
+        #[cfg(not(any(feature = "history", feature = "history-staking-rewards")))]
+        let slipstream_configs: &[PathBuf] = &[];
+
         // Initialize the node.
         let node = match node_type {
-            NodeType::Validator => Node::new_validator(node_ip, self.bft, rest_ip, self.rest_rps, account, &trusted_peers, &trusted_validators, genesis, cdn, storage_mode, node_data_dir, self.trusted_peers_only, self.auto_db_checkpoints.clone(), dev_txs, self.dev, signal_handler.clone()).await,
+            NodeType::Validator => Node::new_validator(node_ip, self.bft, rest_ip, self.rest_rps, account, &trusted_peers, &trusted_validators, genesis, cdn, storage_mode, node_data_dir, self.trusted_peers_only, self.auto_db_checkpoints.clone(), dev_txs, self.dev, slipstream_configs, signal_handler.clone()).await,
             NodeType::Prover => Node::new_prover(node_ip, account, &trusted_peers, genesis, node_data_dir, self.trusted_peers_only, self.dev, signal_handler.clone()).await,
-            NodeType::Client => Node::new_client(node_ip, rest_ip, self.rest_rps, account, &trusted_peers, genesis, cdn, storage_mode, node_data_dir, self.trusted_peers_only, self.auto_db_checkpoints.clone(), self.dev, signal_handler.clone()).await,
+            NodeType::Client => Node::new_client(node_ip, rest_ip, self.rest_rps, account, &trusted_peers, genesis, cdn, storage_mode, node_data_dir, self.trusted_peers_only, self.auto_db_checkpoints.clone(), self.dev, slipstream_configs, signal_handler.clone()).await,
             NodeType::BootstrapClient => Node::new_bootstrap_client(node_ip, account, *genesis.header(), self.dev).await,
         }?;
 

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -299,8 +299,8 @@ pub struct Start {
     pub auto_migrate_node_data: bool,
 
     /// Paths to Slipstream plugin config files (JSON5). May be repeated for multiple plugins.
-    /// Requires the node to be compiled with --features history or --features history-staking-rewards.
-    #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+    /// Requires the node to be compiled with --features slipstream-plugins.
+    #[cfg(feature = "slipstream-plugins")]
     #[clap(long = "slipstream-config", value_name = "PATH", verbatim_doc_comment)]
     pub slipstream_configs: Vec<PathBuf>,
 }
@@ -851,9 +851,9 @@ impl Start {
         let signal_handler = SignalHandler::new();
 
         // Collect slipstream plugin config paths (empty slice when feature is disabled).
-        #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+        #[cfg(feature = "slipstream-plugins")]
         let slipstream_configs: &[PathBuf] = &self.slipstream_configs;
-        #[cfg(not(any(feature = "history", feature = "history-staking-rewards")))]
+        #[cfg(not(feature = "slipstream-plugins"))]
         let slipstream_configs: &[PathBuf] = &[];
 
         // Initialize the node.

--- a/docs/slipstream_plugins.md
+++ b/docs/slipstream_plugins.md
@@ -1,0 +1,198 @@
+# Slipstream Plugins
+
+Slipstream is a plugin system that lets operators stream canonical mapping updates and staking
+rewards from snarkOS nodes to external services (databases, metrics pipelines, etc.) in
+real time, without modifying node code.
+
+---
+
+## Overview
+
+Slipstream plugins are dynamically loaded shared libraries (`.so` / `.dylib` / `.dll`) that
+implement the `SlipstreamPlugin` trait from `snarkvm-slipstream-plugin-interface`. The plugin
+manager inside `snarkVM`'s `FinalizeStore` calls plugin hooks every time canonical finalize runs.
+
+Plugins can subscribe to:
+
+- **Mapping updates** — every key/value write that occurs during canonical finalize.
+- **Staking rewards** — per-staker reward notifications (requires `history-staking-rewards` feature).
+
+Only **Validator** and **Client** nodes finalize blocks and therefore support plugins.
+Prover nodes do not.
+
+---
+
+## Building a Plugin
+
+Use `snarkvm-slipstream-plugin-interface` as a dependency and implement the `SlipstreamPlugin`
+trait. Compile your crate as a `cdylib`:
+
+```toml
+# Cargo.toml
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+snarkvm-slipstream-plugin-interface = { git = "https://github.com/ProvableHQ/snarkVM.git", branch = "stream_plugin_testing" }
+```
+
+Export the constructor with the exact symbol name `_create_plugin`:
+
+```rust
+#[no_mangle]
+pub extern "C" fn _create_plugin() -> *mut dyn SlipstreamPlugin {
+    Box::into_raw(Box::new(MyPlugin::new()))
+}
+```
+
+See `slipstream-plugin-postgres` in the snarkVM repository for a complete reference
+implementation.
+
+---
+
+## Plugin Config File (JSON5)
+
+Each plugin is configured via a JSON5 file. The required field is `libpath`, which can be
+absolute or relative to the config file's directory.
+
+```json5
+{
+  // Required: path to the compiled .so / .dylib
+  libpath: "./libslipstream_postgres_example.so",
+
+  // Optional: override the plugin name reported by name()
+  name: "postgres",
+
+  // Plugin-specific fields (passed verbatim to on_load)
+  connection_string: "postgres://user:pass@localhost/aleo",
+  batch_size: 100,
+}
+```
+
+---
+
+## Starting a Node with Plugins
+
+Compile snarkOS with the `history` feature (or `history-staking-rewards` for staking data):
+
+```bash
+cargo build --features history -p snarkos
+```
+
+Pass one or more `--slipstream-config` flags at startup:
+
+```bash
+# Single plugin
+snarkos start --client \
+  --slipstream-config ~/.aleo/plugins/postgres/plugin.json5
+
+# Multiple plugins
+snarkos start --validator \
+  --slipstream-config ~/.aleo/plugins/postgres/plugin.json5 \
+  --slipstream-config ~/.aleo/plugins/metrics/plugin.json5
+```
+
+Plugins are loaded synchronously before the REST server starts. If any plugin fails to load,
+the node exits with an error.
+
+---
+
+## Runtime Management via REST API
+
+All endpoints require a valid JWT token (`Authorization: Bearer <token>`).
+
+### List loaded plugins
+
+```
+GET /{network}/slipstream/plugins
+```
+
+Response (200):
+```json
+["postgres", "metrics"]
+```
+
+### Load a plugin at runtime
+
+```
+POST /{network}/slipstream/plugins
+Content-Type: application/json
+
+{ "config_file": "/path/to/plugin.json5" }
+```
+
+Response (200):
+```json
+{ "loaded": "postgres" }
+```
+
+Returns **422 Unprocessable Entity** if a plugin with that name is already loaded.
+
+### Unload a plugin
+
+```
+DELETE /{network}/slipstream/plugins/{name}
+```
+
+Response (200):
+```json
+{ "unloaded": true }
+```
+
+Returns **404 Not Found** if no plugin with that name is loaded.
+
+### Reload a plugin (unload + load from new config)
+
+```
+PUT /{network}/slipstream/plugins/{name}
+Content-Type: application/json
+
+{ "config_file": "/path/to/new_plugin.json5" }
+```
+
+Response (200):
+```json
+{ "reloaded": true }
+```
+
+Returns **404 Not Found** if no plugin with that name is currently loaded.
+
+---
+
+## Example: curl Commands
+
+```bash
+JWT="<your-jwt-token>"
+BASE="http://localhost:3030/mainnet"
+
+# List
+curl -H "Authorization: Bearer $JWT" "$BASE/slipstream/plugins"
+
+# Load
+curl -X POST -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"config_file":"/path/to/plugin.json5"}' \
+  "$BASE/slipstream/plugins"
+
+# Unload
+curl -X DELETE -H "Authorization: Bearer $JWT" \
+  "$BASE/slipstream/plugins/postgres"
+
+# Reload
+curl -X PUT -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json" \
+  -d '{"config_file":"/path/to/new_plugin.json5"}' \
+  "$BASE/slipstream/plugins/postgres"
+```
+
+---
+
+## Notes
+
+- Plugins are loaded in startup order and unloaded in reverse order on shutdown.
+- The `on_unload` method is called on every plugin during graceful shutdown.
+- Plugin errors during `notify_mapping_update` / `notify_staking_reward` are logged as warnings
+  and never propagated to the node — a misbehaving plugin cannot crash the node.
+- The plugin manager uses a `std::sync::RwLock`; `notify_*` calls acquire a read lock, while
+  load/unload/reload operations acquire the write lock. Avoid long-running operations inside
+  plugin callbacks.

--- a/docs/slipstream_plugins.md
+++ b/docs/slipstream_plugins.md
@@ -73,10 +73,15 @@ absolute or relative to the config file's directory.
 
 ## Starting a Node with Plugins
 
-Compile snarkOS with the `history` feature (or `history-staking-rewards` for staking data):
+Compile snarkOS with the `slipstream-plugins` feature. Add `history` if you need mapping update
+history, or `history-staking-rewards` if you also want staking reward notifications:
 
 ```bash
-cargo build --features history -p snarkos
+# Mapping updates only
+cargo build --features slipstream-plugins
+
+# Mapping updates + staking rewards
+cargo build --features slipstream-plugins,history-staking-rewards
 ```
 
 Pass one or more `--slipstream-config` flags at startup:
@@ -141,21 +146,10 @@ Response (200):
 
 Returns **404 Not Found** if no plugin with that name is loaded.
 
-### Reload a plugin (unload + load from new config)
+### Reload a plugin (not yet implemented)
 
-```
-PUT /{network}/slipstream/plugins/{name}
-Content-Type: application/json
-
-{ "config_file": "/path/to/new_plugin.json5" }
-```
-
-Response (200):
-```json
-{ "reloaded": true }
-```
-
-Returns **404 Not Found** if no plugin with that name is currently loaded.
+`PUT /{network}/slipstream/plugins/{name}` is not currently available. To update a plugin's
+config during runtime, unload it with DELETE and reload it with POST. Otherwise, stop the snarkos service, update the config, and restart it, pointing at the new config.
 
 ---
 
@@ -176,12 +170,6 @@ curl -X POST -H "Authorization: Bearer $JWT" \
 
 # Unload
 curl -X DELETE -H "Authorization: Bearer $JWT" \
-  "$BASE/slipstream/plugins/postgres"
-
-# Reload
-curl -X PUT -H "Authorization: Bearer $JWT" \
-  -H "Content-Type: application/json" \
-  -d '{"config_file":"/path/to/new_plugin.json5"}' \
   "$BASE/slipstream/plugins/postgres"
 ```
 

--- a/docs/slipstream_plugins.md
+++ b/docs/slipstream_plugins.md
@@ -99,6 +99,12 @@ the node exits with an error.
 
 ## Runtime Management via REST API
 
+> **Authentication required.** All slipstream management endpoints are protected by JWT
+> authentication. Every request must include an `Authorization: Bearer <token>` header.
+> The token is printed to stdout at node startup and written to
+> `<node_data_dir>/jwt_secret_<address>.txt`. To disable auth entirely, start the node
+> with `--nojwt` (not recommended in production).
+
 ### List loaded plugins
 
 ```
@@ -150,7 +156,7 @@ config during runtime, unload it with DELETE and reload it with POST. Otherwise,
 
 ```bash
 BASE="http://localhost:3030/mainnet"
-TOKEN="<your-jwt-token>"   # printed at startup or found in <data_dir>/jwt_secret_<address>.txt
+TOKEN="<your-jwt-token>"   # printed at startup or found in <data_dir>/jwt_secret_<address>.txt (e.g. `~/.aleo/storage/jwt_secrect_{address}.txt`)
 
 # List
 curl -H "Authorization: Bearer $TOKEN" "$BASE/slipstream/plugins"

--- a/docs/slipstream_plugins.md
+++ b/docs/slipstream_plugins.md
@@ -99,8 +99,6 @@ the node exits with an error.
 
 ## Runtime Management via REST API
 
-All endpoints require a valid JWT token (`Authorization: Bearer <token>`).
-
 ### List loaded plugins
 
 ```
@@ -151,21 +149,19 @@ config during runtime, unload it with DELETE and reload it with POST. Otherwise,
 ## Example: curl Commands
 
 ```bash
-JWT="<your-jwt-token>"
 BASE="http://localhost:3030/mainnet"
 
 # List
-curl -H "Authorization: Bearer $JWT" "$BASE/slipstream/plugins"
+curl "$BASE/slipstream/plugins"
 
 # Load
-curl -X POST -H "Authorization: Bearer $JWT" \
+curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"config_file":"/path/to/plugin.json5"}' \
   "$BASE/slipstream/plugins"
 
 # Unload
-curl -X DELETE -H "Authorization: Bearer $JWT" \
-  "$BASE/slipstream/plugins/postgres"
+curl -X DELETE "$BASE/slipstream/plugins/postgres"
 ```
 
 ---

--- a/docs/slipstream_plugins.md
+++ b/docs/slipstream_plugins.md
@@ -150,18 +150,20 @@ config during runtime, unload it with DELETE and reload it with POST. Otherwise,
 
 ```bash
 BASE="http://localhost:3030/mainnet"
+TOKEN="<your-jwt-token>"   # printed at startup or found in <data_dir>/jwt_secret_<address>.txt
 
 # List
-curl "$BASE/slipstream/plugins"
+curl -H "Authorization: Bearer $TOKEN" "$BASE/slipstream/plugins"
 
 # Load
 curl -X POST \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"config_file":"/path/to/plugin.json5"}' \
   "$BASE/slipstream/plugins"
 
 # Unload
-curl -X DELETE "$BASE/slipstream/plugins/postgres"
+curl -X DELETE -H "Authorization: Bearer $TOKEN" "$BASE/slipstream/plugins/postgres"
 ```
 
 ---

--- a/docs/slipstream_plugins.md
+++ b/docs/slipstream_plugins.md
@@ -15,7 +15,7 @@ manager inside `snarkVM`'s `FinalizeStore` calls plugin hooks every time canonic
 Plugins can subscribe to:
 
 - **Mapping updates** — every key/value write that occurs during canonical finalize.
-- **Staking rewards** — per-staker reward notifications (requires `history-staking-rewards` feature).
+- **Staking rewards** — per-staker reward notifications
 
 Only **Validator** and **Client** nodes finalize blocks and therefore support plugins.
 Prover nodes do not.
@@ -73,15 +73,10 @@ absolute or relative to the config file's directory.
 
 ## Starting a Node with Plugins
 
-Compile snarkOS with the `slipstream-plugins` feature. Add `history` if you need mapping update
-history, or `history-staking-rewards` if you also want staking reward notifications:
+Compile snarkOS with the `slipstream-plugins` feature
 
 ```bash
-# Mapping updates only
 cargo build --features slipstream-plugins
-
-# Mapping updates + staking rewards
-cargo build --features slipstream-plugins,history-staking-rewards
 ```
 
 Pass one or more `--slipstream-config` flags at startup:

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -40,7 +40,7 @@ metrics = [
 ]
 history = [ "snarkos-node-rest/history", "snarkvm/history" ]
 history-staking-rewards = [ "snarkos-node-rest/history-staking-rewards", "snarkvm/history-staking-rewards" ]
-slipstream-plugins = [ "dep:snarkvm-slipstream-plugin-manager", "snarkos-node-rest/slipstream-plugins", "snarkvm/slipstream-plugins" ]
+slipstream-plugins = [ "snarkos-node-rest/slipstream-plugins", "snarkvm/slipstream-plugins" ]
 telemetry = [ "snarkos-node-bft/telemetry", "snarkos-node-consensus/telemetry", "snarkos-node-rest/telemetry" ]
 cuda = [
   "snarkvm/cuda",
@@ -137,10 +137,6 @@ workspace = true
 
 [dependencies.snarkvm]
 workspace = true
-
-[dependencies.snarkvm-slipstream-plugin-manager]
-workspace = true
-optional = true
 
 [dependencies.time]
 workspace = true

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -38,8 +38,9 @@ metrics = [
   "snarkos-node-router/metrics",
   "snarkos-node-tcp/metrics"
 ]
-history = [ "dep:snarkvm-slipstream-plugin-manager", "snarkos-node-rest/history", "snarkvm/history" ]
-history-staking-rewards = [ "dep:snarkvm-slipstream-plugin-manager", "snarkos-node-rest/history-staking-rewards", "snarkvm/history-staking-rewards" ]
+history = [ "snarkos-node-rest/history", "snarkvm/history" ]
+history-staking-rewards = [ "snarkos-node-rest/history-staking-rewards", "snarkvm/history-staking-rewards" ]
+slipstream-plugins = [ "dep:snarkvm-slipstream-plugin-manager", "snarkos-node-rest/slipstream-plugins", "snarkvm/slipstream-plugins" ]
 telemetry = [ "snarkos-node-bft/telemetry", "snarkos-node-consensus/telemetry", "snarkos-node-rest/telemetry" ]
 cuda = [
   "snarkvm/cuda",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -38,8 +38,8 @@ metrics = [
   "snarkos-node-router/metrics",
   "snarkos-node-tcp/metrics"
 ]
-history = [ "snarkos-node-rest/history" ]
-history-staking-rewards = [ "snarkos-node-rest/history-staking-rewards" ]
+history = [ "dep:snarkvm-slipstream-plugin-manager", "snarkos-node-rest/history", "snarkvm/history" ]
+history-staking-rewards = [ "dep:snarkvm-slipstream-plugin-manager", "snarkos-node-rest/history-staking-rewards", "snarkvm/history-staking-rewards" ]
 telemetry = [ "snarkos-node-bft/telemetry", "snarkos-node-consensus/telemetry", "snarkos-node-rest/telemetry" ]
 cuda = [
   "snarkvm/cuda",
@@ -136,6 +136,10 @@ workspace = true
 
 [dependencies.snarkvm]
 workspace = true
+
+[dependencies.snarkvm-slipstream-plugin-manager]
+workspace = true
+optional = true
 
 [dependencies.time]
 workspace = true

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -20,6 +20,7 @@ edition = "2024"
 default = [ ]
 history = [ "dep:snarkvm-slipstream-plugin-manager", "snarkvm/history" ]
 history-staking-rewards = [ "dep:snarkvm-slipstream-plugin-manager", "snarkvm/history-staking-rewards" ]
+slipstream-plugins = [ "dep:snarkvm-slipstream-plugin-manager", "snarkvm/slipstream-plugins" ]
 telemetry = [ "snarkos-node-consensus/telemetry" ]
 cuda = [ "snarkvm/cuda", "snarkos-node-consensus/cuda", "snarkos-node-router/cuda" ]
 locktick = [

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -18,9 +18,9 @@ edition = "2024"
 
 [features]
 default = [ ]
-history = [ "dep:snarkvm-slipstream-plugin-manager", "snarkvm/history" ]
-history-staking-rewards = [ "dep:snarkvm-slipstream-plugin-manager", "snarkvm/history-staking-rewards" ]
-slipstream-plugins = [ "dep:snarkvm-slipstream-plugin-manager", "snarkvm/slipstream-plugins" ]
+history = [ "snarkvm/history" ]
+history-staking-rewards = [ "snarkvm/history-staking-rewards" ]
+slipstream-plugins = [ "snarkvm/slipstream-plugins" ]
 telemetry = [ "snarkos-node-consensus/telemetry" ]
 cuda = [ "snarkvm/cuda", "snarkos-node-consensus/cuda", "snarkos-node-router/cuda" ]
 locktick = [
@@ -99,10 +99,6 @@ workspace = true
 
 [dependencies.snarkvm]
 workspace = true
-
-[dependencies.snarkvm-slipstream-plugin-manager]
-workspace = true
-optional = true
 
 [dependencies.rand]
 workspace = true

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -18,8 +18,8 @@ edition = "2024"
 
 [features]
 default = [ ]
-history = [ "snarkvm/history" ]
-history-staking-rewards = [ "snarkvm/history-staking-rewards" ]
+history = [ "dep:snarkvm-slipstream-plugin-manager", "snarkvm/history" ]
+history-staking-rewards = [ "dep:snarkvm-slipstream-plugin-manager", "snarkvm/history-staking-rewards" ]
 telemetry = [ "snarkos-node-consensus/telemetry" ]
 cuda = [ "snarkvm/cuda", "snarkos-node-consensus/cuda", "snarkos-node-router/cuda" ]
 locktick = [
@@ -95,6 +95,10 @@ workspace = true
 
 [dependencies.snarkvm]
 workspace = true
+
+[dependencies.snarkvm-slipstream-plugin-manager]
+workspace = true
+optional = true
 
 [dependencies.rand]
 workspace = true

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -167,13 +167,25 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
                 .expect("Couldn't set up rate limiting for the REST server!"),
         );
 
-        let routes = axum::Router::new()
-
-            // All the endpoints before the call to `route_layer` are protected with JWT auth.
+        // Build the auth-protected routes. #[cfg] cannot appear inside a method chain, so we
+        // build this router as a named binding and conditionally extend it before applying the layer.
+        let auth_routes = axum::Router::new()
             .route("/node/address", get(Self::get_node_address))
             .route("/program/{id}/mapping/{name}", get(Self::get_mapping_values))
-            .route("/db_backup", post(Self::db_backup))
-            .route_layer(middleware::from_fn(auth_middleware))
+            .route("/db_backup", post(Self::db_backup));
+
+        // Slipstream plugin management endpoints require auth.
+        #[cfg(feature = "slipstream-plugins")]
+        let auth_routes = auth_routes
+            .route("/slipstream/plugins", get(Self::slipstream_list_plugins).post(Self::slipstream_load_plugin))
+            .route(
+                "/slipstream/plugins/{name}",
+                // TODO: PUT (reload) is not yet implemented.
+                axum::routing::delete(Self::slipstream_unload_plugin),
+            );
+
+        let routes = axum::Router::new()
+            .merge(auth_routes.route_layer(middleware::from_fn(auth_middleware)))
 
              // Get ../consensus_version
             .route("/consensus_version", get(Self::get_consensus_version))
@@ -266,17 +278,6 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         // If the `history` feature is enabled, enable the additional endpoint.
         #[cfg(feature = "history")]
         let routes = routes.route("/program/{id}/mapping/{name}/{key}/history/{height}", get(Self::get_history));
-
-        // If the `slipstream-plugins` feature is enabled,
-        // enable the Slipstream plugin management endpoints (no auth required).
-        #[cfg(feature = "slipstream-plugins")]
-        let routes = routes
-            .route("/slipstream/plugins", get(Self::slipstream_list_plugins).post(Self::slipstream_load_plugin))
-            .route(
-                "/slipstream/plugins/{name}",
-                // TODO: PUT (reload) is not yet implemented.
-                axum::routing::delete(Self::slipstream_unload_plugin),
-            );
 
         // If the `history-staking-rewards` feature is enabled, enable the additional endpoint.
         #[cfg(feature = "history-staking-rewards")]

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -137,7 +137,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     fn build_routes(&self, rest_rps: u32) -> axum::Router {
         let cors = CorsLayer::new()
             .allow_origin(Any)
-            .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE, Method::OPTIONS])
+            .allow_methods([Method::GET, Method::POST, Method::DELETE, Method::OPTIONS])
             .allow_headers([CONTENT_TYPE]);
 
         // Prepare the rate limiting setup.
@@ -267,7 +267,8 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route("/slipstream/plugins", get(Self::slipstream_list_plugins).post(Self::slipstream_load_plugin))
             .route(
                 "/slipstream/plugins/{name}",
-                axum::routing::delete(Self::slipstream_unload_plugin).put(Self::slipstream_reload_plugin),
+                // TODO: PUT (reload) is not yet implemented.
+                axum::routing::delete(Self::slipstream_unload_plugin),
             );
 
         // If the `history-staking-rewards` feature is enabled, enable the additional endpoint.

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -166,15 +166,6 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route("/program/{id}/mapping/{name}", get(Self::get_mapping_values))
             .route("/db_backup", post(Self::db_backup));
 
-        // If the `history` or `history-staking-rewards` feature is enabled, enable the Slipstream plugin management endpoints.
-        #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
-        let routes = routes
-            .route("/slipstream/plugins", get(Self::slipstream_list_plugins).post(Self::slipstream_load_plugin))
-            .route(
-                "/slipstream/plugins/{name}",
-                axum::routing::delete(Self::slipstream_unload_plugin).put(Self::slipstream_reload_plugin),
-            );
-
         let routes = routes.route_layer(middleware::from_fn(auth_middleware))
 
              // Get ../consensus_version
@@ -268,6 +259,16 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         // If the `history` feature is enabled, enable the additional endpoint.
         #[cfg(feature = "history")]
         let routes = routes.route("/program/{id}/mapping/{name}/{key}/history/{height}", get(Self::get_history));
+
+        // If the `slipstream-plugins` feature is enabled,
+        // enable the Slipstream plugin management endpoints (no auth required).
+        #[cfg(feature = "slipstream-plugins")]
+        let routes = routes
+            .route("/slipstream/plugins", get(Self::slipstream_list_plugins).post(Self::slipstream_load_plugin))
+            .route(
+                "/slipstream/plugins/{name}",
+                axum::routing::delete(Self::slipstream_unload_plugin).put(Self::slipstream_reload_plugin),
+            );
 
         // If the `history-staking-rewards` feature is enabled, enable the additional endpoint.
         #[cfg(feature = "history-staking-rewards")]

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -137,7 +137,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     fn build_routes(&self, rest_rps: u32) -> axum::Router {
         let cors = CorsLayer::new()
             .allow_origin(Any)
-            .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+            .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE, Method::OPTIONS])
             .allow_headers([CONTENT_TYPE]);
 
         // Prepare the rate limiting setup.
@@ -164,8 +164,19 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             // All the endpoints before the call to `route_layer` are protected with JWT auth.
             .route("/node/address", get(Self::get_node_address))
             .route("/program/{id}/mapping/{name}", get(Self::get_mapping_values))
-            .route("/db_backup", post(Self::db_backup))
-            .route_layer(middleware::from_fn(auth_middleware))
+            .route("/db_backup", post(Self::db_backup));
+
+        // If the `history` or `history-staking-rewards` feature is enabled, enable the Slipstream plugin management endpoints.
+        #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+        let routes = routes
+            .route("/slipstream/plugins", get(Self::slipstream_list_plugins).post(Self::slipstream_load_plugin))
+            .route(
+                "/slipstream/plugins/{name}",
+                axum::routing::delete(Self::slipstream_unload_plugin)
+                    .put(Self::slipstream_reload_plugin),
+            );
+
+        let routes = routes.route_layer(middleware::from_fn(auth_middleware))
 
              // Get ../consensus_version
             .route("/consensus_version", get(Self::get_consensus_version))

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -164,9 +164,8 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             // All the endpoints before the call to `route_layer` are protected with JWT auth.
             .route("/node/address", get(Self::get_node_address))
             .route("/program/{id}/mapping/{name}", get(Self::get_mapping_values))
-            .route("/db_backup", post(Self::db_backup));
-
-        let routes = routes.route_layer(middleware::from_fn(auth_middleware))
+            .route("/db_backup", post(Self::db_backup))
+            .route_layer(middleware::from_fn(auth_middleware))
 
              // Get ../consensus_version
             .route("/consensus_version", get(Self::get_consensus_version))

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -172,8 +172,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route("/slipstream/plugins", get(Self::slipstream_list_plugins).post(Self::slipstream_load_plugin))
             .route(
                 "/slipstream/plugins/{name}",
-                axum::routing::delete(Self::slipstream_unload_plugin)
-                    .put(Self::slipstream_reload_plugin),
+                axum::routing::delete(Self::slipstream_unload_plugin).put(Self::slipstream_reload_plugin),
             );
 
         let routes = routes.route_layer(middleware::from_fn(auth_middleware))

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -172,7 +172,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
                 .expect("Couldn't set up rate limiting for the REST server!"),
         );
 
-        // Build the auth-protected routes. #[cfg] cannot appear inside a method chain, so we
+        // Build the JWT auth-protected endpoints. #[cfg] cannot appear inside a method chain, so we
         // build this router as a named binding and conditionally extend it before applying the layer.
         let auth_routes = axum::Router::new()
             .route("/node/address", get(Self::get_node_address))
@@ -191,6 +191,8 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
 
         let routes = axum::Router::new()
             .merge(auth_routes.route_layer(middleware::from_fn(auth_middleware)))
+
+            // All endpoints declared after here are not protected
 
              // Get ../consensus_version
             .route("/consensus_version", get(Self::get_consensus_version))

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -1185,43 +1185,5 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok((StatusCode::OK, ErasedJson::pretty(serde_json::json!({ "unloaded": true }))))
     }
 
-    /// PUT /{network}/slipstream/plugins/{name}
-    #[cfg(feature = "slipstream-plugins")]
-    pub(crate) async fn slipstream_reload_plugin(
-        State(rest): State<Self>,
-        Path(name): Path<String>,
-        Json(body): Json<serde_json::Value>,
-    ) -> Result<impl axum::response::IntoResponse, RestError> {
-        use snarkvm_slipstream_plugin_manager::slipstream_manager::SlipstreamPluginManagerError;
-
-        let config_file = body
-            .get("config_file")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| RestError::bad_request(anyhow!("Missing required field: config_file")))?
-            .to_owned();
-        let manager = rest
-            .ledger
-            .vm()
-            .finalize_store()
-            .slipstream_plugin_manager()
-            .ok_or_else(|| RestError::service_unavailable(anyhow!("No Slipstream plugin manager is installed")))?;
-        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-            let mut mgr = manager.write().map_err(|e| anyhow!("Plugin manager lock poisoned: {e}"))?;
-            mgr.reload_plugin(&name, &config_file).map_err(|e: SlipstreamPluginManagerError| match e {
-                SlipstreamPluginManagerError::PluginNotLoaded(_) => anyhow!("404: {e}"),
-                other => anyhow!("{other}"),
-            })
-        })
-        .await
-        .map_err(|e| RestError::internal_server_error(anyhow!("Task join error: {e}")))?
-        .map_err(|e| {
-            let msg = e.to_string();
-            if msg.starts_with("404: ") {
-                RestError::not_found(anyhow!("{}", &msg[5..]))
-            } else {
-                RestError::internal_server_error(e)
-            }
-        })?;
-        Ok((StatusCode::OK, ErasedJson::pretty(serde_json::json!({ "reloaded": true }))))
-    }
+    // TODO: PUT /{network}/slipstream/plugins/{name} (reload) is not yet implemented.
 }

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -1135,8 +1135,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .slipstream_plugin_manager()
             .ok_or_else(|| RestError::service_unavailable(anyhow!("No Slipstream plugin manager is installed")))?;
         let name = tokio::task::spawn_blocking(move || -> anyhow::Result<String> {
-            let mut mgr =
-                manager.write().map_err(|e| anyhow!("Plugin manager lock poisoned: {e}"))?;
+            let mut mgr = manager.write().map_err(|e| anyhow!("Plugin manager lock poisoned: {e}"))?;
             mgr.load_plugin(&config_file).map_err(|e: SlipstreamPluginManagerError| match e {
                 SlipstreamPluginManagerError::PluginAlreadyLoaded(_) => anyhow!("409: {e}"),
                 other => anyhow!("{other}"),
@@ -1170,8 +1169,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .slipstream_plugin_manager()
             .ok_or_else(|| RestError::service_unavailable(anyhow!("No Slipstream plugin manager is installed")))?;
         tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-            let mut mgr =
-                manager.write().map_err(|e| anyhow!("Plugin manager lock poisoned: {e}"))?;
+            let mut mgr = manager.write().map_err(|e| anyhow!("Plugin manager lock poisoned: {e}"))?;
             mgr.unload_plugin(&name).map_err(|e: SlipstreamPluginManagerError| match e {
                 SlipstreamPluginManagerError::PluginNotLoaded(_) => anyhow!("404: {e}"),
                 other => anyhow!("{other}"),
@@ -1211,8 +1209,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .slipstream_plugin_manager()
             .ok_or_else(|| RestError::service_unavailable(anyhow!("No Slipstream plugin manager is installed")))?;
         tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-            let mut mgr =
-                manager.write().map_err(|e| anyhow!("Plugin manager lock poisoned: {e}"))?;
+            let mut mgr = manager.write().map_err(|e| anyhow!("Plugin manager lock poisoned: {e}"))?;
             mgr.reload_plugin(&name, &config_file).map_err(|e: SlipstreamPluginManagerError| match e {
                 SlipstreamPluginManagerError::PluginNotLoaded(_) => anyhow!("404: {e}"),
                 other => anyhow!("{other}"),

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -1134,22 +1134,19 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .finalize_store()
             .slipstream_plugin_manager()
             .ok_or_else(|| RestError::service_unavailable(anyhow!("No Slipstream plugin manager is installed")))?;
-        let name = tokio::task::spawn_blocking(move || -> anyhow::Result<String> {
-            let mut mgr = manager.write().map_err(|e| anyhow!("Plugin manager lock poisoned: {e}"))?;
-            mgr.load_plugin(&config_file).map_err(|e: SlipstreamPluginManagerError| match e {
-                SlipstreamPluginManagerError::PluginAlreadyLoaded(_) => anyhow!("409: {e}"),
-                other => anyhow!("{other}"),
-            })
+        let name = tokio::task::spawn_blocking(move || -> Result<String, SlipstreamPluginManagerError> {
+            let mut mgr = manager
+                .write()
+                .map_err(|_| SlipstreamPluginManagerError::PluginLoadError("Plugin manager lock poisoned".to_string()))?;
+            mgr.load_plugin(&config_file)
         })
         .await
         .map_err(|e| RestError::internal_server_error(anyhow!("Task join error: {e}")))?
-        .map_err(|e| {
-            let msg = e.to_string();
-            if msg.starts_with("409: ") {
-                RestError::unprocessable_entity(anyhow!("{}", &msg[5..]))
-            } else {
-                RestError::internal_server_error(e)
+        .map_err(|e| match e {
+            SlipstreamPluginManagerError::PluginAlreadyLoaded(_) => {
+                RestError::unprocessable_entity(anyhow!("{e}"))
             }
+            other => RestError::internal_server_error(anyhow!("{other}")),
         })?;
         Ok((StatusCode::OK, ErasedJson::pretty(serde_json::json!({ "loaded": name }))))
     }

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -1095,7 +1095,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     }
 
     /// GET /{network}/slipstream/plugins
-    #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+    #[cfg(feature = "slipstream-plugins")]
     pub(crate) async fn slipstream_list_plugins(
         State(rest): State<Self>,
     ) -> Result<impl axum::response::IntoResponse, RestError> {
@@ -1116,7 +1116,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     }
 
     /// POST /{network}/slipstream/plugins
-    #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+    #[cfg(feature = "slipstream-plugins")]
     pub(crate) async fn slipstream_load_plugin(
         State(rest): State<Self>,
         Json(body): Json<serde_json::Value>,
@@ -1155,7 +1155,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     }
 
     /// DELETE /{network}/slipstream/plugins/{name}
-    #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+    #[cfg(feature = "slipstream-plugins")]
     pub(crate) async fn slipstream_unload_plugin(
         State(rest): State<Self>,
         Path(name): Path<String>,
@@ -1189,7 +1189,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     }
 
     /// PUT /{network}/slipstream/plugins/{name}
-    #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+    #[cfg(feature = "slipstream-plugins")]
     pub(crate) async fn slipstream_reload_plugin(
         State(rest): State<Self>,
         Path(name): Path<String>,

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -1101,14 +1101,12 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     ) -> Result<impl axum::response::IntoResponse, RestError> {
         use snarkvm_slipstream_plugin_manager::slipstream_manager::SlipstreamPluginManagerError;
 
-        let manager = rest
-            .ledger
-            .vm()
-            .finalize_store()
-            .slipstream_plugin_manager()
+        let mgr_arc = rest.ledger.vm().finalize_store().slipstream_plugin_manager();
+        let mgr_guard = mgr_arc.read();
+        let manager = mgr_guard
+            .as_ref()
             .ok_or_else(|| RestError::service_unavailable(anyhow!("No Slipstream plugin manager is installed")))?;
         let plugins = manager
-            .read()
             .list_plugins()
             .map_err(|e: SlipstreamPluginManagerError| RestError::internal_server_error(anyhow!(e)))?;
         Ok((StatusCode::OK, ErasedJson::pretty(plugins)))
@@ -1127,14 +1125,13 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .and_then(|v| v.as_str())
             .ok_or_else(|| RestError::bad_request(anyhow!("Missing required field: config_file")))?
             .to_owned();
-        let manager = rest
-            .ledger
-            .vm()
-            .finalize_store()
-            .slipstream_plugin_manager()
-            .ok_or_else(|| RestError::service_unavailable(anyhow!("No Slipstream plugin manager is installed")))?;
+        let mgr_arc = rest.ledger.vm().finalize_store().slipstream_plugin_manager();
+        if mgr_arc.read().is_none() {
+            return Err(RestError::service_unavailable(anyhow!("No Slipstream plugin manager is installed")));
+        }
         let name = tokio::task::spawn_blocking(move || -> Result<String, SlipstreamPluginManagerError> {
-            manager.write().load_plugin(&config_file)
+            // Safety: manager is set exactly once and never cleared; verified Some above.
+            mgr_arc.write().as_mut().expect("plugin manager verified present").load_plugin(&config_file)
         })
         .await
         .map_err(|e| RestError::internal_server_error(anyhow!("Task join error: {e}")))?
@@ -1155,14 +1152,13 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     ) -> Result<impl axum::response::IntoResponse, RestError> {
         use snarkvm_slipstream_plugin_manager::slipstream_manager::SlipstreamPluginManagerError;
 
-        let manager = rest
-            .ledger
-            .vm()
-            .finalize_store()
-            .slipstream_plugin_manager()
-            .ok_or_else(|| RestError::service_unavailable(anyhow!("No Slipstream plugin manager is installed")))?;
+        let mgr_arc = rest.ledger.vm().finalize_store().slipstream_plugin_manager();
+        if mgr_arc.read().is_none() {
+            return Err(RestError::service_unavailable(anyhow!("No Slipstream plugin manager is installed")));
+        }
         tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-            manager.write().unload_plugin(&name).map_err(|e: SlipstreamPluginManagerError| match e {
+            // Safety: manager is set exactly once and never cleared; verified Some above.
+            mgr_arc.write().as_mut().expect("plugin manager verified present").unload_plugin(&name).map_err(|e: SlipstreamPluginManagerError| match e {
                 SlipstreamPluginManagerError::PluginNotLoaded(_) => anyhow!("404: {e}"),
                 other => anyhow!("{other}"),
             })

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -1200,7 +1200,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     pub(crate) async fn slipstream_list_plugins(
         State(rest): State<Self>,
     ) -> Result<impl axum::response::IntoResponse, RestError> {
-        use snarkvm_slipstream_plugin_manager::slipstream_manager::SlipstreamPluginManagerError;
+        use snarkvm::slipstream_plugin_manager::slipstream_manager::SlipstreamPluginManagerError;
 
         let mgr_arc = rest.ledger.vm().finalize_store().slipstream_plugin_manager();
         let mgr_guard = mgr_arc.read();
@@ -1219,7 +1219,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         State(rest): State<Self>,
         Json(body): Json<serde_json::Value>,
     ) -> Result<impl axum::response::IntoResponse, RestError> {
-        use snarkvm_slipstream_plugin_manager::slipstream_manager::SlipstreamPluginManagerError;
+        use snarkvm::slipstream_plugin_manager::slipstream_manager::SlipstreamPluginManagerError;
 
         let config_file = body
             .get("config_file")
@@ -1249,7 +1249,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         State(rest): State<Self>,
         Path(name): Path<String>,
     ) -> Result<impl axum::response::IntoResponse, RestError> {
-        use snarkvm_slipstream_plugin_manager::slipstream_manager::SlipstreamPluginManagerError;
+        use snarkvm::slipstream_plugin_manager::slipstream_manager::SlipstreamPluginManagerError;
 
         let mgr_arc = rest.ledger.vm().finalize_store().slipstream_plugin_manager();
         if mgr_arc.read().is_none() {

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -1136,9 +1136,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         .await
         .map_err(|e| RestError::internal_server_error(anyhow!("Task join error: {e}")))?
         .map_err(|e| match e {
-            SlipstreamPluginManagerError::PluginAlreadyLoaded(_) => {
-                RestError::unprocessable_entity(anyhow!("{e}"))
-            }
+            SlipstreamPluginManagerError::PluginAlreadyLoaded(_) => RestError::unprocessable_entity(anyhow!("{e}")),
             other => RestError::internal_server_error(anyhow!("{other}")),
         })?;
         Ok((StatusCode::OK, ErasedJson::pretty(serde_json::json!({ "loaded": name }))))
@@ -1158,10 +1156,12 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         }
         tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
             // Safety: manager is set exactly once and never cleared; verified Some above.
-            mgr_arc.write().as_mut().expect("plugin manager verified present").unload_plugin(&name).map_err(|e: SlipstreamPluginManagerError| match e {
-                SlipstreamPluginManagerError::PluginNotLoaded(_) => anyhow!("404: {e}"),
-                other => anyhow!("{other}"),
-            })
+            mgr_arc.write().as_mut().expect("plugin manager verified present").unload_plugin(&name).map_err(
+                |e: SlipstreamPluginManagerError| match e {
+                    SlipstreamPluginManagerError::PluginNotLoaded(_) => anyhow!("404: {e}"),
+                    other => anyhow!("{other}"),
+                },
+            )
         })
         .await
         .map_err(|e| RestError::internal_server_error(anyhow!("Task join error: {e}")))?

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -1109,7 +1109,6 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .ok_or_else(|| RestError::service_unavailable(anyhow!("No Slipstream plugin manager is installed")))?;
         let plugins = manager
             .read()
-            .map_err(|e| RestError::internal_server_error(anyhow!("Plugin manager lock poisoned: {e}")))?
             .list_plugins()
             .map_err(|e: SlipstreamPluginManagerError| RestError::internal_server_error(anyhow!(e)))?;
         Ok((StatusCode::OK, ErasedJson::pretty(plugins)))
@@ -1135,10 +1134,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .slipstream_plugin_manager()
             .ok_or_else(|| RestError::service_unavailable(anyhow!("No Slipstream plugin manager is installed")))?;
         let name = tokio::task::spawn_blocking(move || -> Result<String, SlipstreamPluginManagerError> {
-            let mut mgr = manager
-                .write()
-                .map_err(|_| SlipstreamPluginManagerError::PluginLoadError("Plugin manager lock poisoned".to_string()))?;
-            mgr.load_plugin(&config_file)
+            manager.write().load_plugin(&config_file)
         })
         .await
         .map_err(|e| RestError::internal_server_error(anyhow!("Task join error: {e}")))?
@@ -1166,8 +1162,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .slipstream_plugin_manager()
             .ok_or_else(|| RestError::service_unavailable(anyhow!("No Slipstream plugin manager is installed")))?;
         tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-            let mut mgr = manager.write().map_err(|e| anyhow!("Plugin manager lock poisoned: {e}"))?;
-            mgr.unload_plugin(&name).map_err(|e: SlipstreamPluginManagerError| match e {
+            manager.write().unload_plugin(&name).map_err(|e: SlipstreamPluginManagerError| match e {
                 SlipstreamPluginManagerError::PluginNotLoaded(_) => anyhow!("404: {e}"),
                 other => anyhow!("{other}"),
             })

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -1134,25 +1134,24 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .finalize_store()
             .slipstream_plugin_manager()
             .ok_or_else(|| RestError::service_unavailable(anyhow!("No Slipstream plugin manager is installed")))?;
-        let name =
-            tokio::task::spawn_blocking(move || manager.write().map_err(|e| anyhow!("Plugin manager lock poisoned: {e}")).and_then(|mut mgr| {
-                mgr.load_plugin(&config_file).map_err(|e: SlipstreamPluginManagerError| match e {
-                    SlipstreamPluginManagerError::PluginAlreadyLoaded(_) => {
-                        anyhow!("409: {e}")
-                    }
-                    other => anyhow!("{other}"),
-                })
-            }))
-            .await
-            .map_err(|e| RestError::internal_server_error(anyhow!("Task join error: {e}")))?
-            .map_err(|e| {
-                let msg = e.to_string();
-                if msg.starts_with("409: ") {
-                    RestError::unprocessable_entity(anyhow!("{}", &msg[5..]))
-                } else {
-                    RestError::internal_server_error(e)
-                }
-            })?;
+        let name = tokio::task::spawn_blocking(move || -> anyhow::Result<String> {
+            let mut mgr =
+                manager.write().map_err(|e| anyhow!("Plugin manager lock poisoned: {e}"))?;
+            mgr.load_plugin(&config_file).map_err(|e: SlipstreamPluginManagerError| match e {
+                SlipstreamPluginManagerError::PluginAlreadyLoaded(_) => anyhow!("409: {e}"),
+                other => anyhow!("{other}"),
+            })
+        })
+        .await
+        .map_err(|e| RestError::internal_server_error(anyhow!("Task join error: {e}")))?
+        .map_err(|e| {
+            let msg = e.to_string();
+            if msg.starts_with("409: ") {
+                RestError::unprocessable_entity(anyhow!("{}", &msg[5..]))
+            } else {
+                RestError::internal_server_error(e)
+            }
+        })?;
         Ok((StatusCode::OK, ErasedJson::pretty(serde_json::json!({ "loaded": name }))))
     }
 
@@ -1170,12 +1169,14 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .finalize_store()
             .slipstream_plugin_manager()
             .ok_or_else(|| RestError::service_unavailable(anyhow!("No Slipstream plugin manager is installed")))?;
-        tokio::task::spawn_blocking(move || manager.write().map_err(|e| anyhow!("Plugin manager lock poisoned: {e}")).and_then(|mut mgr| {
+        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+            let mut mgr =
+                manager.write().map_err(|e| anyhow!("Plugin manager lock poisoned: {e}"))?;
             mgr.unload_plugin(&name).map_err(|e: SlipstreamPluginManagerError| match e {
                 SlipstreamPluginManagerError::PluginNotLoaded(_) => anyhow!("404: {e}"),
                 other => anyhow!("{other}"),
             })
-        }))
+        })
         .await
         .map_err(|e| RestError::internal_server_error(anyhow!("Task join error: {e}")))?
         .map_err(|e| {
@@ -1209,12 +1210,14 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .finalize_store()
             .slipstream_plugin_manager()
             .ok_or_else(|| RestError::service_unavailable(anyhow!("No Slipstream plugin manager is installed")))?;
-        tokio::task::spawn_blocking(move || manager.write().map_err(|e| anyhow!("Plugin manager lock poisoned: {e}")).and_then(|mut mgr| {
+        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+            let mut mgr =
+                manager.write().map_err(|e| anyhow!("Plugin manager lock poisoned: {e}"))?;
             mgr.reload_plugin(&name, &config_file).map_err(|e: SlipstreamPluginManagerError| match e {
                 SlipstreamPluginManagerError::PluginNotLoaded(_) => anyhow!("404: {e}"),
                 other => anyhow!("{other}"),
             })
-        }))
+        })
         .await
         .map_err(|e| RestError::internal_server_error(anyhow!("Task join error: {e}")))?
         .map_err(|e| {

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -1268,8 +1268,8 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         .map_err(|e| RestError::internal_server_error(anyhow!("Task join error: {e}")))?
         .map_err(|e| {
             let msg = e.to_string();
-            if msg.starts_with("404: ") {
-                RestError::not_found(anyhow!("{}", &msg[5..]))
+            if let Some(stripped) = msg.strip_prefix("404: ") {
+                RestError::not_found(anyhow!("{}", stripped))
             } else {
                 RestError::internal_server_error(e)
             }

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -1093,4 +1093,138 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             None => Err(RestError::service_unavailable(anyhow!("Route isn't available for this node type"))),
         }
     }
+
+    /// GET /{network}/slipstream/plugins
+    #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+    pub(crate) async fn slipstream_list_plugins(
+        State(rest): State<Self>,
+    ) -> Result<impl axum::response::IntoResponse, RestError> {
+        use snarkvm_slipstream_plugin_manager::slipstream_manager::SlipstreamPluginManagerError;
+
+        let manager = rest
+            .ledger
+            .vm()
+            .finalize_store()
+            .slipstream_plugin_manager()
+            .ok_or_else(|| RestError::service_unavailable(anyhow!("No Slipstream plugin manager is installed")))?;
+        let plugins = manager
+            .read()
+            .map_err(|e| RestError::internal_server_error(anyhow!("Plugin manager lock poisoned: {e}")))?
+            .list_plugins()
+            .map_err(|e: SlipstreamPluginManagerError| RestError::internal_server_error(anyhow!(e)))?;
+        Ok((StatusCode::OK, ErasedJson::pretty(plugins)))
+    }
+
+    /// POST /{network}/slipstream/plugins
+    #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+    pub(crate) async fn slipstream_load_plugin(
+        State(rest): State<Self>,
+        Json(body): Json<serde_json::Value>,
+    ) -> Result<impl axum::response::IntoResponse, RestError> {
+        use snarkvm_slipstream_plugin_manager::slipstream_manager::SlipstreamPluginManagerError;
+
+        let config_file = body
+            .get("config_file")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| RestError::bad_request(anyhow!("Missing required field: config_file")))?
+            .to_owned();
+        let manager = rest
+            .ledger
+            .vm()
+            .finalize_store()
+            .slipstream_plugin_manager()
+            .ok_or_else(|| RestError::service_unavailable(anyhow!("No Slipstream plugin manager is installed")))?;
+        let name =
+            tokio::task::spawn_blocking(move || manager.write().map_err(|e| anyhow!("Plugin manager lock poisoned: {e}")).and_then(|mut mgr| {
+                mgr.load_plugin(&config_file).map_err(|e: SlipstreamPluginManagerError| match e {
+                    SlipstreamPluginManagerError::PluginAlreadyLoaded(_) => {
+                        anyhow!("409: {e}")
+                    }
+                    other => anyhow!("{other}"),
+                })
+            }))
+            .await
+            .map_err(|e| RestError::internal_server_error(anyhow!("Task join error: {e}")))?
+            .map_err(|e| {
+                let msg = e.to_string();
+                if msg.starts_with("409: ") {
+                    RestError::unprocessable_entity(anyhow!("{}", &msg[5..]))
+                } else {
+                    RestError::internal_server_error(e)
+                }
+            })?;
+        Ok((StatusCode::OK, ErasedJson::pretty(serde_json::json!({ "loaded": name }))))
+    }
+
+    /// DELETE /{network}/slipstream/plugins/{name}
+    #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+    pub(crate) async fn slipstream_unload_plugin(
+        State(rest): State<Self>,
+        Path(name): Path<String>,
+    ) -> Result<impl axum::response::IntoResponse, RestError> {
+        use snarkvm_slipstream_plugin_manager::slipstream_manager::SlipstreamPluginManagerError;
+
+        let manager = rest
+            .ledger
+            .vm()
+            .finalize_store()
+            .slipstream_plugin_manager()
+            .ok_or_else(|| RestError::service_unavailable(anyhow!("No Slipstream plugin manager is installed")))?;
+        tokio::task::spawn_blocking(move || manager.write().map_err(|e| anyhow!("Plugin manager lock poisoned: {e}")).and_then(|mut mgr| {
+            mgr.unload_plugin(&name).map_err(|e: SlipstreamPluginManagerError| match e {
+                SlipstreamPluginManagerError::PluginNotLoaded(_) => anyhow!("404: {e}"),
+                other => anyhow!("{other}"),
+            })
+        }))
+        .await
+        .map_err(|e| RestError::internal_server_error(anyhow!("Task join error: {e}")))?
+        .map_err(|e| {
+            let msg = e.to_string();
+            if msg.starts_with("404: ") {
+                RestError::not_found(anyhow!("{}", &msg[5..]))
+            } else {
+                RestError::internal_server_error(e)
+            }
+        })?;
+        Ok((StatusCode::OK, ErasedJson::pretty(serde_json::json!({ "unloaded": true }))))
+    }
+
+    /// PUT /{network}/slipstream/plugins/{name}
+    #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+    pub(crate) async fn slipstream_reload_plugin(
+        State(rest): State<Self>,
+        Path(name): Path<String>,
+        Json(body): Json<serde_json::Value>,
+    ) -> Result<impl axum::response::IntoResponse, RestError> {
+        use snarkvm_slipstream_plugin_manager::slipstream_manager::SlipstreamPluginManagerError;
+
+        let config_file = body
+            .get("config_file")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| RestError::bad_request(anyhow!("Missing required field: config_file")))?
+            .to_owned();
+        let manager = rest
+            .ledger
+            .vm()
+            .finalize_store()
+            .slipstream_plugin_manager()
+            .ok_or_else(|| RestError::service_unavailable(anyhow!("No Slipstream plugin manager is installed")))?;
+        tokio::task::spawn_blocking(move || manager.write().map_err(|e| anyhow!("Plugin manager lock poisoned: {e}")).and_then(|mut mgr| {
+            mgr.reload_plugin(&name, &config_file).map_err(|e: SlipstreamPluginManagerError| match e {
+                SlipstreamPluginManagerError::PluginNotLoaded(_) => anyhow!("404: {e}"),
+                other => anyhow!("{other}"),
+            })
+        }))
+        .await
+        .map_err(|e| RestError::internal_server_error(anyhow!("Task join error: {e}")))?
+        .map_err(|e| {
+            let msg = e.to_string();
+            if msg.starts_with("404: ") {
+                RestError::not_found(anyhow!("{}", &msg[5..]))
+            } else {
+                RestError::internal_server_error(e)
+            }
+        })?;
+        Ok((StatusCode::OK, ErasedJson::pretty(serde_json::json!({ "reloaded": true }))))
+    }
 }

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -128,9 +128,6 @@ pub struct Client<N: Network, C: ConsensusStorage<N>> {
     ping: Arc<Ping<N>>,
     /// The signal handling logic.
     signal_handler: Arc<SignalHandler>,
-    /// The Slipstream plugin service (present when plugins are loaded).
-    #[cfg(feature = "slipstream-plugins")]
-    slipstream_service: Arc<Mutex<Option<snarkvm_slipstream_plugin_manager::slipstream_service::SlipstreamPluginService>>>,
 }
 
 impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
@@ -159,19 +156,16 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
         }
         .with_context(|| "Failed to initialize the ledger")?;
 
-        // Initialize the Slipstream plugin service (if any config files were provided).
+        // Initialize the Slipstream plugin manager (if any config files were provided).
         #[cfg(feature = "slipstream-plugins")]
-        let slipstream_service = if !slipstream_configs.is_empty() {
-            let service =
-                snarkvm_slipstream_plugin_manager::slipstream_service::SlipstreamPluginService::new(slipstream_configs)
-                    .context("Failed to initialize Slipstream plugin service")?;
-            ledger.vm().finalize_store().set_slipstream_plugin_manager(service.plugin_manager());
+        if !slipstream_configs.is_empty() {
+            let manager =
+                snarkvm_slipstream_plugin_manager::SlipstreamPluginManager::from_config_files(slipstream_configs)
+                    .context("Failed to initialize Slipstream plugin manager")?;
+            ledger.vm().finalize_store().set_slipstream_plugin_manager(manager);
             let num_plugins = slipstream_configs.len();
             tracing::info!(target: "slipstream", "Slipstream plugin manager registered ({num_plugins} plugin(s))");
-            Some(service)
-        } else {
-            None
-        };
+        }
 
         // Initialize the ledger service.
         let ledger_service = Arc::new(CoreLedgerService::<N, C>::new(ledger.clone(), signal_handler.clone()));
@@ -213,8 +207,6 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
             num_verifying_executions: Default::default(),
             handles: Default::default(),
             signal_handler: signal_handler.clone(),
-            #[cfg(feature = "slipstream-plugins")]
-            slipstream_service: Arc::new(Mutex::new(slipstream_service)),
         };
 
         // Perform sync with CDN (if enabled).
@@ -566,8 +558,8 @@ impl<N: Network, C: ConsensusStorage<N>> NodeInterface<N> for Client<N, C> {
 
         // Shut down the Slipstream plugin service.
         #[cfg(feature = "slipstream-plugins")]
-        if let Some(service) = self.slipstream_service.lock().take() {
-            service.join();
+        if let Some(manager) = self.ledger.vm().finalize_store().slipstream_plugin_manager().write().as_mut() {
+            manager.unload();
         }
 
         // Abort the tasks.

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -160,7 +160,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
         #[cfg(feature = "slipstream-plugins")]
         if !_slipstream_configs.is_empty() {
             let manager =
-                snarkvm_slipstream_plugin_manager::SlipstreamPluginManager::from_config_files(_slipstream_configs)
+                snarkvm::slipstream_plugin_manager::SlipstreamPluginManager::from_config_files(_slipstream_configs)
                     .context("Failed to initialize Slipstream plugin manager")?;
             ledger.vm().finalize_store().set_slipstream_plugin_manager(manager);
             let num_plugins = _slipstream_configs.len();

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -129,7 +129,7 @@ pub struct Client<N: Network, C: ConsensusStorage<N>> {
     /// The signal handling logic.
     signal_handler: Arc<SignalHandler>,
     /// The Slipstream plugin service (present when plugins are loaded).
-    #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+    #[cfg(feature = "slipstream-plugins")]
     slipstream_service: Arc<Mutex<Option<snarkvm_slipstream_plugin_manager::slipstream_service::SlipstreamPluginService>>>,
 }
 
@@ -160,13 +160,14 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
         .with_context(|| "Failed to initialize the ledger")?;
 
         // Initialize the Slipstream plugin service (if any config files were provided).
-        #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+        #[cfg(feature = "slipstream-plugins")]
         let slipstream_service = if !slipstream_configs.is_empty() {
             let service =
                 snarkvm_slipstream_plugin_manager::slipstream_service::SlipstreamPluginService::new(slipstream_configs)
                     .context("Failed to initialize Slipstream plugin service")?;
             ledger.vm().finalize_store().set_slipstream_plugin_manager(service.plugin_manager());
-            tracing::info!("Loaded {} Slipstream plugin(s)", slipstream_configs.len());
+            let num_plugins = slipstream_configs.len();
+            tracing::info!(target: "slipstream", "Slipstream plugin manager registered ({num_plugins} plugin(s))");
             Some(service)
         } else {
             None
@@ -212,7 +213,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
             num_verifying_executions: Default::default(),
             handles: Default::default(),
             signal_handler: signal_handler.clone(),
-            #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+            #[cfg(feature = "slipstream-plugins")]
             slipstream_service: Arc::new(Mutex::new(slipstream_service)),
         };
 
@@ -564,7 +565,7 @@ impl<N: Network, C: ConsensusStorage<N>> NodeInterface<N> for Client<N, C> {
         trace!("Shutting down the node...");
 
         // Shut down the Slipstream plugin service.
-        #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+        #[cfg(feature = "slipstream-plugins")]
         if let Some(service) = self.slipstream_service.lock().take() {
             service.join();
         }

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -144,7 +144,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
         node_data_dir: NodeDataDir,
         trusted_peers_only: bool,
         dev: Option<u16>,
-        slipstream_configs: &[std::path::PathBuf],
+        _slipstream_configs: &[std::path::PathBuf],
         signal_handler: Arc<SignalHandler>,
     ) -> Result<Self> {
         // Initialize the ledger.
@@ -158,12 +158,12 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
 
         // Initialize the Slipstream plugin manager (if any config files were provided).
         #[cfg(feature = "slipstream-plugins")]
-        if !slipstream_configs.is_empty() {
+        if !_slipstream_configs.is_empty() {
             let manager =
-                snarkvm_slipstream_plugin_manager::SlipstreamPluginManager::from_config_files(slipstream_configs)
+                snarkvm_slipstream_plugin_manager::SlipstreamPluginManager::from_config_files(_slipstream_configs)
                     .context("Failed to initialize Slipstream plugin manager")?;
             ledger.vm().finalize_store().set_slipstream_plugin_manager(manager);
-            let num_plugins = slipstream_configs.len();
+            let num_plugins = _slipstream_configs.len();
             tracing::info!(target: "slipstream", "Slipstream plugin manager registered ({num_plugins} plugin(s))");
         }
 

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -128,6 +128,9 @@ pub struct Client<N: Network, C: ConsensusStorage<N>> {
     ping: Arc<Ping<N>>,
     /// The signal handling logic.
     signal_handler: Arc<SignalHandler>,
+    /// The Slipstream plugin service (present when plugins are loaded).
+    #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+    slipstream_service: Arc<Mutex<Option<snarkvm_slipstream_plugin_manager::slipstream_service::SlipstreamPluginService>>>,
 }
 
 impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
@@ -144,6 +147,7 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
         node_data_dir: NodeDataDir,
         trusted_peers_only: bool,
         dev: Option<u16>,
+        slipstream_configs: &[std::path::PathBuf],
         signal_handler: Arc<SignalHandler>,
     ) -> Result<Self> {
         // Initialize the ledger.
@@ -154,6 +158,19 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
             spawn_blocking!(Ledger::<N, C>::load(genesis, storage_mode))
         }
         .with_context(|| "Failed to initialize the ledger")?;
+
+        // Initialize the Slipstream plugin service (if any config files were provided).
+        #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+        let slipstream_service = if !slipstream_configs.is_empty() {
+            let service =
+                snarkvm_slipstream_plugin_manager::slipstream_service::SlipstreamPluginService::new(slipstream_configs)
+                    .context("Failed to initialize Slipstream plugin service")?;
+            ledger.vm().finalize_store().set_slipstream_plugin_manager(service.plugin_manager());
+            tracing::info!("Loaded {} Slipstream plugin(s)", slipstream_configs.len());
+            Some(service)
+        } else {
+            None
+        };
 
         // Initialize the ledger service.
         let ledger_service = Arc::new(CoreLedgerService::<N, C>::new(ledger.clone(), signal_handler.clone()));
@@ -195,6 +212,8 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
             num_verifying_executions: Default::default(),
             handles: Default::default(),
             signal_handler: signal_handler.clone(),
+            #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+            slipstream_service: Arc::new(Mutex::new(slipstream_service)),
         };
 
         // Perform sync with CDN (if enabled).
@@ -543,6 +562,12 @@ impl<N: Network, C: ConsensusStorage<N>> NodeInterface<N> for Client<N, C> {
 
         // Shut down the node.
         trace!("Shutting down the node...");
+
+        // Shut down the Slipstream plugin service.
+        #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+        if let Some(service) = self.slipstream_service.lock().take() {
+            service.join();
+        }
 
         // Abort the tasks.
         trace!("Shutting down the client...");

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -98,6 +98,7 @@ impl<N: Network> Node<N> {
         auto_db_checkpoints: Option<PathBuf>,
         dev_txs: bool,
         dev: Option<u16>,
+        slipstream_configs: &[PathBuf],
         signal_handler: Arc<SignalHandler>,
     ) -> Result<Self> {
         let validator = Arc::new(
@@ -116,6 +117,7 @@ impl<N: Network> Node<N> {
                 trusted_peers_only,
                 dev_txs,
                 dev,
+                slipstream_configs,
                 signal_handler,
             )
             .await?,
@@ -173,6 +175,7 @@ impl<N: Network> Node<N> {
         trusted_peers_only: bool,
         auto_db_checkpoints: Option<PathBuf>,
         dev: Option<u16>,
+        slipstream_configs: &[PathBuf],
         signal_handler: Arc<SignalHandler>,
     ) -> Result<Self> {
         let client = Arc::new(
@@ -188,6 +191,7 @@ impl<N: Network> Node<N> {
                 node_data_dir,
                 trusted_peers_only,
                 dev,
+                slipstream_configs,
                 signal_handler,
             )
             .await?,

--- a/node/src/prover/mod.rs
+++ b/node/src/prover/mod.rs
@@ -200,7 +200,7 @@ impl<N: Network, C: ConsensusStorage<N>> Prover<N, C> {
             // If the node is not connected to any peers, then skip this iteration.
             if self.router.number_of_connected_peers() == 0 {
                 debug!("Skipping an iteration of the puzzle (no connected peers)");
-                tokio::time::sleep(Duration::from_secs(N::ANCHOR_TIME as u64)).await;
+                tokio::time::sleep(Duration::from_secs(N::REWARD_ANCHOR_TIME as u64)).await;
                 continue;
             }
 

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -74,7 +74,7 @@ pub struct Validator<N: Network, C: ConsensusStorage<N>> {
     /// Keeps track of sending pings.
     ping: Arc<Ping<N>>,
     /// The Slipstream plugin service (present when plugins are loaded).
-    #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+    #[cfg(feature = "slipstream-plugins")]
     slipstream_service: Arc<Mutex<Option<snarkvm_slipstream_plugin_manager::slipstream_service::SlipstreamPluginService>>>,
 }
 
@@ -108,13 +108,14 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
         .with_context(|| "Failed to initialize the ledger")?;
 
         // Initialize the Slipstream plugin service (if any config files were provided).
-        #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+        #[cfg(feature = "slipstream-plugins")]
         let slipstream_service = if !slipstream_configs.is_empty() {
             let service =
                 snarkvm_slipstream_plugin_manager::slipstream_service::SlipstreamPluginService::new(slipstream_configs)
                     .context("Failed to initialize Slipstream plugin service")?;
             ledger.vm().finalize_store().set_slipstream_plugin_manager(service.plugin_manager());
-            tracing::info!("Loaded {} Slipstream plugin(s)", slipstream_configs.len());
+            let num_plugins = slipstream_configs.len();
+            tracing::info!(target: "slipstream", "Slipstream plugin manager registered ({num_plugins} plugin(s))");
             Some(service)
         } else {
             None
@@ -166,7 +167,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
             sync: sync.clone(),
             ping,
             handles: Default::default(),
-            #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+            #[cfg(feature = "slipstream-plugins")]
             slipstream_service: Arc::new(Mutex::new(slipstream_service)),
         };
 
@@ -489,7 +490,7 @@ impl<N: Network, C: ConsensusStorage<N>> NodeInterface<N> for Validator<N, C> {
         trace!("Shutting down the node...");
 
         // Shut down the Slipstream plugin service.
-        #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+        #[cfg(feature = "slipstream-plugins")]
         if let Some(service) = self.slipstream_service.lock().take() {
             service.join();
         }

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -486,7 +486,7 @@ impl<N: Network, C: ConsensusStorage<N>> NodeInterface<N> for Validator<N, C> {
         if let Some(manager) = self.ledger.vm().finalize_store().slipstream_plugin_manager().write().as_mut() {
             manager.unload();
         }
-        
+
         // Shut down the REST instance.
         if let Some(rest) = &self.rest {
             trace!("Shutting down the REST server...");

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -73,9 +73,6 @@ pub struct Validator<N: Network, C: ConsensusStorage<N>> {
     pub(crate) handles: Arc<Mutex<Vec<JoinHandle<()>>>>,
     /// Keeps track of sending pings.
     ping: Arc<Ping<N>>,
-    /// The Slipstream plugin service (present when plugins are loaded).
-    #[cfg(feature = "slipstream-plugins")]
-    slipstream_service: Arc<Mutex<Option<snarkvm_slipstream_plugin_manager::slipstream_service::SlipstreamPluginService>>>,
 }
 
 impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
@@ -107,19 +104,16 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
         }
         .with_context(|| "Failed to initialize the ledger")?;
 
-        // Initialize the Slipstream plugin service (if any config files were provided).
+        // Initialize the Slipstream plugin manager (if any config files were provided).
         #[cfg(feature = "slipstream-plugins")]
-        let slipstream_service = if !slipstream_configs.is_empty() {
-            let service =
-                snarkvm_slipstream_plugin_manager::slipstream_service::SlipstreamPluginService::new(slipstream_configs)
-                    .context("Failed to initialize Slipstream plugin service")?;
-            ledger.vm().finalize_store().set_slipstream_plugin_manager(service.plugin_manager());
+        if !slipstream_configs.is_empty() {
+            let manager =
+                snarkvm_slipstream_plugin_manager::SlipstreamPluginManager::from_config_files(slipstream_configs)
+                    .context("Failed to initialize Slipstream plugin manager")?;
+            ledger.vm().finalize_store().set_slipstream_plugin_manager(manager);
             let num_plugins = slipstream_configs.len();
             tracing::info!(target: "slipstream", "Slipstream plugin manager registered ({num_plugins} plugin(s))");
-            Some(service)
-        } else {
-            None
-        };
+        }
 
         // Initialize the ledger service.
         let ledger_service = Arc::new(CoreLedgerService::new(ledger.clone(), signal_handler.clone()));
@@ -167,8 +161,6 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
             sync: sync.clone(),
             ping,
             handles: Default::default(),
-            #[cfg(feature = "slipstream-plugins")]
-            slipstream_service: Arc::new(Mutex::new(slipstream_service)),
         };
 
         // Perform sync with CDN (if enabled).
@@ -489,10 +481,10 @@ impl<N: Network, C: ConsensusStorage<N>> NodeInterface<N> for Validator<N, C> {
         // Shut down the node.
         trace!("Shutting down the node...");
 
-        // Shut down the Slipstream plugin service.
+        // Shut down the Slipstream plugin manager.
         #[cfg(feature = "slipstream-plugins")]
-        if let Some(service) = self.slipstream_service.lock().take() {
-            service.join();
+        if let Some(manager) = self.ledger.vm().finalize_store().slipstream_plugin_manager().write().as_mut() {
+            manager.unload();
         }
 
         // Abort the tasks.

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -108,7 +108,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
         #[cfg(feature = "slipstream-plugins")]
         if !_slipstream_configs.is_empty() {
             let manager =
-                snarkvm_slipstream_plugin_manager::SlipstreamPluginManager::from_config_files(_slipstream_configs)
+                snarkvm::slipstream_plugin_manager::SlipstreamPluginManager::from_config_files(_slipstream_configs)
                     .context("Failed to initialize Slipstream plugin manager")?;
             ledger.vm().finalize_store().set_slipstream_plugin_manager(manager);
             let num_plugins = _slipstream_configs.len();

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -92,7 +92,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
         trusted_peers_only: bool,
         dev_txs: bool,
         dev: Option<u16>,
-        slipstream_configs: &[std::path::PathBuf],
+        _slipstream_configs: &[std::path::PathBuf],
         signal_handler: Arc<SignalHandler>,
     ) -> Result<Self> {
         // Initialize the ledger.
@@ -106,12 +106,12 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
 
         // Initialize the Slipstream plugin manager (if any config files were provided).
         #[cfg(feature = "slipstream-plugins")]
-        if !slipstream_configs.is_empty() {
+        if !_slipstream_configs.is_empty() {
             let manager =
-                snarkvm_slipstream_plugin_manager::SlipstreamPluginManager::from_config_files(slipstream_configs)
+                snarkvm_slipstream_plugin_manager::SlipstreamPluginManager::from_config_files(_slipstream_configs)
                     .context("Failed to initialize Slipstream plugin manager")?;
             ledger.vm().finalize_store().set_slipstream_plugin_manager(manager);
-            let num_plugins = slipstream_configs.len();
+            let num_plugins = _slipstream_configs.len();
             tracing::info!(target: "slipstream", "Slipstream plugin manager registered ({num_plugins} plugin(s))");
         }
 

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -73,6 +73,9 @@ pub struct Validator<N: Network, C: ConsensusStorage<N>> {
     pub(crate) handles: Arc<Mutex<Vec<JoinHandle<()>>>>,
     /// Keeps track of sending pings.
     ping: Arc<Ping<N>>,
+    /// The Slipstream plugin service (present when plugins are loaded).
+    #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+    slipstream_service: Arc<Mutex<Option<snarkvm_slipstream_plugin_manager::slipstream_service::SlipstreamPluginService>>>,
 }
 
 impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
@@ -92,6 +95,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
         trusted_peers_only: bool,
         dev_txs: bool,
         dev: Option<u16>,
+        slipstream_configs: &[std::path::PathBuf],
         signal_handler: Arc<SignalHandler>,
     ) -> Result<Self> {
         // Initialize the ledger.
@@ -102,6 +106,19 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
             spawn_blocking!(Ledger::<N, C>::load(genesis, storage_mode))
         }
         .with_context(|| "Failed to initialize the ledger")?;
+
+        // Initialize the Slipstream plugin service (if any config files were provided).
+        #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+        let slipstream_service = if !slipstream_configs.is_empty() {
+            let service =
+                snarkvm_slipstream_plugin_manager::slipstream_service::SlipstreamPluginService::new(slipstream_configs)
+                    .context("Failed to initialize Slipstream plugin service")?;
+            ledger.vm().finalize_store().set_slipstream_plugin_manager(service.plugin_manager());
+            tracing::info!("Loaded {} Slipstream plugin(s)", slipstream_configs.len());
+            Some(service)
+        } else {
+            None
+        };
 
         // Initialize the ledger service.
         let ledger_service = Arc::new(CoreLedgerService::new(ledger.clone(), signal_handler.clone()));
@@ -149,6 +166,8 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
             sync: sync.clone(),
             ping,
             handles: Default::default(),
+            #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+            slipstream_service: Arc::new(Mutex::new(slipstream_service)),
         };
 
         // Perform sync with CDN (if enabled).
@@ -469,6 +488,12 @@ impl<N: Network, C: ConsensusStorage<N>> NodeInterface<N> for Validator<N, C> {
         // Shut down the node.
         trace!("Shutting down the node...");
 
+        // Shut down the Slipstream plugin service.
+        #[cfg(any(feature = "history", feature = "history-staking-rewards"))]
+        if let Some(service) = self.slipstream_service.lock().take() {
+            service.join();
+        }
+
         // Abort the tasks.
         trace!("Shutting down the validator...");
         self.handles.lock().iter().for_each(|handle| handle.abort());
@@ -539,6 +564,7 @@ mod tests {
             false,
             dev_txs,
             None,
+            &[],
             SignalHandler::new(),
         )
         .await

--- a/node/tests/common/node.rs
+++ b/node/tests/common/node.rs
@@ -75,7 +75,7 @@ pub async fn validator() -> Validator<CurrentNetwork, ConsensusMemory<CurrentNet
         false, // This test requires validators to connect to peers.
         false, // No dev traffic in production mode.
         None,
-        &[], // No Slipstream plugins.
+        &[],  // No Slipstream plugins.
         None, // No dev committee hotswap in production mode.
         SignalHandler::new(None),
     )

--- a/node/tests/common/node.rs
+++ b/node/tests/common/node.rs
@@ -37,6 +37,7 @@ pub async fn client() -> Client<CurrentNetwork, ConsensusMemory<CurrentNetwork>>
         NodeDataDir::new_test(None),
         false, // Connect to untrusted peers.
         None,
+        &[], // No Slipstream plugins.
         SignalHandler::new(),
     )
     .await
@@ -74,6 +75,7 @@ pub async fn validator() -> Validator<CurrentNetwork, ConsensusMemory<CurrentNet
         false, // This test requires validators to connect to peers.
         false, // No dev traffic in production mode.
         None,
+        &[], // No Slipstream plugins.
         SignalHandler::new(),
     )
     .await


### PR DESCRIPTION
# Summary                                                                                                                                                                 
   
   Wires the new [Slipstream plugin system](https://github.com/ProvableHQ/snarkVM/pull/3190) into snarkOS so that node operators can load one or more streaming plugins at startup and manage them at runtime via authenticated REST endpoints. Validator and Client nodes both support plugins; Prover nodes do not (they do not finalize blocks).                                                                                                                                                                                                 
   
  ---                                                                                                                                                                     
  # Changes                                                                                                                                                                                                                                                                                                                   

 ### Cargo / feature wiring
  - All Slipstream functionality is gated behind --features slipstream-plugins. Nodes compiled without the feature are unaffected. The flag propagates through the workspace: snarkos → snarkos-cli → snarkos-node → snarkos-node-rest → snarkvm.           
  - Cargo.toml — Added snarkvm-slipstream-plugin-manager as a new workspace dependency                                                                                                                                                                 
  - node/Cargo.toml — Added snarkvm-slipstream-plugin-manager as an optional dep, propagate new `slipstream-plugins` feature flag to enable it alongside the corresponding snarkvm features.                                                                                                                                         
  - node/rest/Cargo.toml — Same optional dep + feature wiring.                                                                                                            
  - cli/Cargo.toml — Added slipstream-plugins features forwarding to snarkos-node.
                                                                                                                                                                          
  ### CLI                                                                                                                                                                     
  - cli/src/commands/start.rs — Added --slipstream-config PATH flag (repeatable; feature-gated). Empty slice is passed when the feature is disabled so the call site is always uniform.                                                                                                                                                         
                                                                                                                                                                        
  ### Node layer                                                                                                                                                              
  - node/src/node.rs — Threaded slipstream_configs: &[PathBuf] through new_validator and new_client.                                                                    
  - node/src/validator/mod.rs / node/src/client/mod.rs — After Ledger::load, if plugin configs are provided, a SlipstreamPluginManager is initialized and injected into the FinalizeStore                                                                                                       
                                                                                                                                                                        
 ### REST API                                                                                                                                                                
  - node/rest/src/lib.rs — Registered three slipstream routes. Added DELETE to CORS allowed methods.     
  - node/rest/src/routes.rs — Implemented three handlers:                                                                                                                  
                                                        
  | Method | Path                                     | Description                              |
|--------|------------------------------------------|------------------------------------------|
| GET    | /{network}/slipstream/plugins            | List loaded plugins                      |
| POST   | /{network}/slipstream/plugins            | Load a plugin from a config file         |
| DELETE | /{network}/slipstream/plugins/{name}     | Unload a plugin by name                  |       

 PUT (reload) is not yet implemented and is left as a TODO.                                                            
   
  ### Error mapping: PluginNotLoaded → 404, PluginAlreadyLoaded → 422, all others → 500.                                                                                      
                                                                                                                                                                        
  ### Tests / docs                                                                                                                                                            
  - node/tests/common/node.rs — Updated client() and validator() test helpers to pass &[] for the new parameter.                                                        
  - docs/slipstream_plugins.md — New operator guide covering: what Slipstream is, plugin ABI and build instructions, JSON5 config format, startup flags, full REST API reference, and curl examples. (NOTE: Couldn't think of a better place to put it so happy to move elsewhere)
                                                                                                                                                                          
  ---                                                                                                                                                                   
  # Usage                                                                                                                                                                   
                                                                                                                                                                        
  #### Build with plugin support
  cargo build --release --features slipstream-plugins                                                                                                                               
   
  #### Start a client node with two plugins                                                                                                                                  
  snarkos start --client  \                                                                                                                                              
    --slipstream-config ~/.aleo/plugins/postgres/plugin.json5 \                                                                                                           
    --slipstream-config ~/.aleo/plugins/metrics/plugin.json5                                                                                                              
                                                                                                                                                                          
  #### List loaded plugins                                                                                                                                                   
  curl http://localhost:3030/mainnet/slipstream/plugins                                                                                                 
                                                                                                                                                                          
  #### Load a new plugin at runtime                                                                                                                                              
  curl -X POST -H "Content-Type: application/json" \                                                                                                                               
    -d '{"config_file":"/path/to/plugin.json5"}' \                                                                                                                        
    http://localhost:3030/mainnet/slipstream/plugins
    
    
 #### Delete/Unload a new plugin at runtime                                                                                                                                              
  curl -X DELETE  \                                                                                                                                                                                                                                        
    http://localhost:3030/mainnet/slipstream/plugins/{plugin_name}                                                                                                                    
                                                                                                                                                                          
  ---                                                                                                                                                                     
  # Notes                                                                                                                                                                   
                                                                                                                                                                        
  - All plugin-related code is gated on #[cfg(feature = "slipstream-plugins")], so builds without these features are unaffected.
  - Plugin manager lock errors (poisoned RwLock) surface as 500 errors; plugin call errors during finalize are logged as warnings and never propagated to the node.       