### PR TITLE
Prevent old block responses from causing a gateway disconnect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -788,7 +788,7 @@ workflows:
           filters:
             branches:
               only:
-                - feat/vk-migration
+                - prevent_block_response_race_disconnect
                 - canary
                 - testnet
                 - mainnet
@@ -798,7 +798,7 @@ workflows:
           filters:
             branches:
               only:
-                - feat/vk-migration
+                - prevent_block_response_race_disconnect
                 - canary
                 - testnet
                 - mainnet

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -677,7 +677,7 @@ impl<N: Network> Gateway<N> {
                         }
                         Err(err) => {
                             warn!("Unable to process block response from '{peer_ip}' - {err}");
-                            Err(err.into())
+                            Ok(true)
                         }
                     }
                 } else {


### PR DESCRIPTION
## Motivation

A mainnet validator lost quorum multiple times today. The following log was observed:
```
[MemoryPool] Disconnecting from '34.186.58.65:5000' - The sync request was removed because we already advanced —
```

## Test Plan

- CI, which is running chaotic devnets with ledger resets of quorum minority, should be sufficient
- Reviewers please evaluate the surrounding logic, `fn inbound` and `fn insert_block_response`