### PR TITLE
Prevent old block responses from causing a gateway disconnect

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -660,7 +660,7 @@ impl<N: Network> Gateway<N> {
                         }
                         Err(err) => {
                             warn!("Unable to process block response from '{peer_ip}' - {err}");
-                            Err(err.into())
+                            Ok(true)
                         }
                     }
                 } else {


### PR DESCRIPTION
## Motivation

Duplicate of https://github.com/ProvableHQ/snarkOS/pull/4176
See the reasoning and test plan in that PR README.
