### PR TITLE
[Feature] Batch Triggers

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -13,4 +13,6 @@ ignore = [
   "RUSTSEC-2026-0002",
   # TODO remove once we migrate away from bincode, or it becomes maintained again.
   "RUSTSEC-2025-0141",
+  # TODO remove once termwiz/terminfo update to phf 0.13+, which drops the rand 0.8 dependency.
+  "RUSTSEC-2026-0097",
 ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -797,7 +797,7 @@ workflows:
           filters:
             branches:
               only:
-                - ci/reenable-check-logs
+                - fix/batch-triggers
                 - canary
                 - testnet
                 - mainnet
@@ -807,7 +807,7 @@ workflows:
           filters:
             branches:
               only:
-                - ci/reenable-check-logs
+                - fix/batch-triggers
                 - canary
                 - testnet
                 - mainnet

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "itoa",
  "matchit 0.8.4",
@@ -2127,9 +2127,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a79f2aff40c18ab8615ddc5caa9eb5b96314aef18fe5823090f204ad988e813"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "subtle",
  "typenum",
@@ -2161,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2176,7 +2176,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2189,7 +2188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -2205,7 +2204,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2233,7 +2232,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2253,7 +2252,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -2292,12 +2291,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -2305,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2318,9 +2318,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2332,15 +2332,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2352,15 +2352,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2575,9 +2575,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2649,9 +2649,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libgit2-sys"
@@ -2746,9 +2746,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -3430,12 +3430,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3459,9 +3453,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -4018,7 +4012,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
@@ -4062,7 +4056,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -4172,9 +4166,9 @@ dependencies = [
 
 [[package]]
 name = "rustcrypto-ff"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5db129183b2c139d7d87d08be57cba626c715789db17aec65c8866bfd767d1f"
+checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
 dependencies = [
  "rand_core 0.10.0",
  "subtle",
@@ -4182,9 +4176,9 @@ dependencies = [
 
 [[package]]
 name = "rustcrypto-group"
-version = "0.14.0-rc.0"
+version = "0.14.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c4b1463f274a3ff6fb2f44da43e576cb9424367bd96f185ead87b52fe00523"
+checksum = "369f9b61aa45933c062c9f6b5c3c50ab710687eca83dd3802653b140b43f85ed"
 dependencies = [
  "rand_core 0.10.0",
  "rustcrypto-ff",
@@ -4380,9 +4374,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46b9a5ab87780a3189a1d704766579517a04ad59de653b7aad7d38e8a15f7dc"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
  "ctutils",
@@ -4432,7 +4426,7 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d832c086ece0dacc29fb2947bb4219b8f6e12fe9e40b7108f9e57c4224e47b5c"
 dependencies = [
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "indicatif",
  "log",
  "quick-xml",
@@ -4516,9 +4510,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -5218,7 +5212,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -5241,7 +5235,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5269,7 +5263,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "blst",
  "cc",
@@ -5280,7 +5274,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5294,7 +5288,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -5304,7 +5298,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -5314,7 +5308,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -5324,7 +5318,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -5344,12 +5338,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -5360,7 +5354,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5374,7 +5368,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -5389,7 +5383,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5402,7 +5396,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -5411,7 +5405,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5421,7 +5415,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5433,7 +5427,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5445,7 +5439,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5456,7 +5450,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5468,7 +5462,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -5481,7 +5475,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -5492,7 +5486,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -5508,7 +5502,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "aleo-std",
  "locktick",
@@ -5522,7 +5516,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -5542,7 +5536,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "anyhow",
  "bech32",
@@ -5560,7 +5554,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -5581,7 +5575,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -5596,7 +5590,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5607,7 +5601,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -5615,7 +5609,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5625,7 +5619,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5636,7 +5630,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5647,7 +5641,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5658,7 +5652,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5669,7 +5663,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "rand 0.10.0",
  "rustc_version",
@@ -5682,7 +5676,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5699,7 +5693,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5731,7 +5725,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "anyhow",
  "rand 0.10.0",
@@ -5743,7 +5737,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -5766,7 +5760,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
@@ -5785,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -5798,7 +5792,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "indexmap 2.13.0",
  "rayon",
@@ -5811,7 +5805,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "indexmap 2.13.0",
  "rayon",
@@ -5824,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5835,7 +5829,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "indexmap 2.13.0",
  "rayon",
@@ -5850,7 +5844,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5863,7 +5857,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -5872,7 +5866,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5892,7 +5886,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5915,7 +5909,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5932,7 +5926,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -5960,7 +5954,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5978,7 +5972,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "metrics",
 ]
@@ -5986,7 +5980,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6009,7 +6003,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6044,7 +6038,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-error"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-environment",
@@ -6055,7 +6049,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "aleo-std",
  "colored 3.1.1",
@@ -6082,7 +6076,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "enum-iterator",
  "indexmap 2.13.0",
@@ -6103,7 +6097,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "bincode",
  "serde_json",
@@ -6116,7 +6110,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6139,7 +6133,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.6.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?branch=fix%2Fprop-tests#b270ffa64eb2a11f4b612cb61b296a1fa7803749"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -6630,9 +6624,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -6772,18 +6766,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
 dependencies = [
  "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -6800,7 +6794,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -7238,9 +7232,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7251,9 +7245,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.65"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7261,9 +7255,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote 1.0.45",
  "wasm-bindgen-macro-support",
@@ -7271,9 +7265,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -7284,9 +7278,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -7327,9 +7321,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.92"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7896,9 +7890,9 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -7907,9 +7901,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -7939,18 +7933,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -7980,9 +7974,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -7991,9 +7985,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -8002,9 +7996,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -168,7 +168,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -737,7 +737,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1495,7 +1495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4092,7 +4092,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4151,7 +4151,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6044,7 +6044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6281,7 +6281,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7374,7 +7374,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core 0.5.6",
  "bytes",
@@ -390,7 +390,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
 dependencies = [
- "axum 0.8.8",
+ "axum 0.8.9",
  "axum-core 0.5.6",
  "bytes",
  "futures-util",
@@ -522,9 +522,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake2"
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -694,7 +694,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -780,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "colorchoice"
@@ -932,7 +932,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -1040,7 +1040,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -1077,7 +1077,7 @@ dependencies = [
  "ctutils",
  "hybrid-array",
  "num-traits",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "subtle",
  "zeroize",
 ]
@@ -1099,7 +1099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1114,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
  "subtle",
@@ -1451,16 +1451,16 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.29"
+version = "0.14.0-rc.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84043d573efd4ac9d2d125817979a379204bf7e328b25a4a30487e8d100e618"
+checksum = "7d7a0bfd012613a7bcfe02cbfccf2b846e9ef9e1bccb641c48d461253cfb034d"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "crypto-common 0.2.1",
  "digest 0.11.2",
  "hybrid-array",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rustcrypto-ff",
  "rustcrypto-group",
  "sec1",
@@ -1587,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fiat-crypto"
@@ -1690,9 +1690,12 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "fs_extra"
@@ -1864,7 +1867,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1881,7 +1884,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -1911,7 +1914,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.4",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -1929,7 +1932,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1972,6 +1975,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hdrhistogram"
@@ -2183,15 +2192,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2417,12 +2425,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "rayon",
  "serde",
  "serde_core",
@@ -2575,9 +2583,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2649,9 +2657,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libgit2-sys"
@@ -2683,9 +2691,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
@@ -2707,9 +2715,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.25"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "libc",
@@ -2723,7 +2731,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2785,9 +2793,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -2879,7 +2887,7 @@ dependencies = [
  "base64 0.21.7",
  "hyper 0.14.32",
  "hyper-tls 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "ipnet",
  "metrics",
  "metrics-util",
@@ -3003,7 +3011,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3016,7 +3024,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3168,11 +3176,11 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3206,9 +3214,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
@@ -3441,9 +3449,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -3528,9 +3536,9 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift 0.4.0",
  "regex-syntax 0.8.10",
@@ -3631,7 +3639,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -3697,9 +3705,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3707,13 +3715,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3743,7 +3751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3766,9 +3774,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -3777,7 +3785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.10.0",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -3795,7 +3803,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60aa6af80be32871323012e02e6e65f8a7cc7890931ae421d217ad8fe0df2ccf"
 dependencies = [
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3818,7 +3826,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
@@ -3870,7 +3878,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.16.1",
  "indoc",
  "instability",
@@ -3889,14 +3897,14 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -3918,7 +3926,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4129,12 +4137,12 @@ dependencies = [
 
 [[package]]
 name = "rtoolbox"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+checksum = "327b72899159dfae8060c51a1f6aebe955245bcd9cc4997eed0f623caea022e4"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4170,7 +4178,7 @@ version = "0.14.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
 dependencies = [
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -4180,7 +4188,7 @@ version = "0.14.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "369f9b61aa45933c062c9f6b5c3c50ab710687eca83dd3802653b140b43f85ed"
 dependencies = [
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rustcrypto-ff",
  "subtle",
 ]
@@ -4191,7 +4199,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4204,7 +4212,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -4213,9 +4221,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4278,9 +4286,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4392,7 +4400,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4443,9 +4451,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seq-macro"
@@ -4489,7 +4497,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -4539,7 +4547,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -4656,7 +4664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
 dependencies = [
  "digest 0.11.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4775,12 +4783,12 @@ dependencies = [
  "colored 3.1.1",
  "console-subscriber",
  "crossterm",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "locktick",
  "nix 0.30.1",
  "num_cpus",
  "parking_lot",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rayon",
  "rpassword",
@@ -4831,14 +4839,14 @@ dependencies = [
  "deadline",
  "futures-util",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "locktick",
  "lru",
  "num_cpus",
  "parking_lot",
  "paste",
  "pea2pea",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "reqwest 0.12.28",
  "serde_json",
@@ -4869,14 +4877,14 @@ dependencies = [
  "anyhow",
  "async-recursion",
  "async-trait",
- "axum 0.8.8",
+ "axum 0.8.9",
  "axum-extra",
  "bytes",
  "clap",
  "colored 3.1.1",
  "deadline",
  "futures",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools",
  "locktick",
  "lru",
@@ -4886,7 +4894,7 @@ dependencies = [
  "paste",
  "pea2pea",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rand_distr",
  "rayon",
@@ -4921,9 +4929,9 @@ version = "4.6.0"
 dependencies = [
  "anyhow",
  "bytes",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "serde",
  "snarkos-node-bft-events",
@@ -4942,10 +4950,10 @@ version = "4.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "locktick",
  "parking_lot",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rayon",
  "snarkos-node-metrics",
  "snarkos-utilities",
@@ -4961,7 +4969,7 @@ version = "4.6.0"
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "locktick",
  "lru",
  "parking_lot",
@@ -4998,7 +5006,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "colored 3.1.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools",
  "locktick",
  "lru",
@@ -5055,17 +5063,17 @@ version = "4.6.0"
 dependencies = [
  "aleo-std",
  "anyhow",
- "axum 0.8.8",
+ "axum 0.8.9",
  "axum-extra",
  "base64 0.22.1",
  "built",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "jsonwebtoken",
  "locktick",
  "once_cell",
  "parking_lot",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rayon",
  "serde",
  "serde_json",
@@ -5098,7 +5106,7 @@ dependencies = [
  "locktick",
  "parking_lot",
  "peak_alloc",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rayon",
  "snarkos-account",
@@ -5142,11 +5150,11 @@ version = "4.6.0"
 dependencies = [
  "anyhow",
  "futures",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools",
  "locktick",
  "parking_lot",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "snarkos-node-bft-ledger-service",
  "snarkos-node-metrics",
@@ -5174,7 +5182,7 @@ name = "snarkos-node-sync-locators"
 version = "4.6.0"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "snarkvm",
  "tracing",
@@ -5216,7 +5224,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00
 dependencies = [
  "anyhow",
  "dotenvy",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde_json",
  "snarkvm-algorithms",
  "snarkvm-circuit",
@@ -5244,10 +5252,10 @@ dependencies = [
  "fxhash",
  "hashbrown 0.15.5",
  "hex",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools",
  "num-traits",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rayon",
  "serde",
  "sha2 0.10.9",
@@ -5321,7 +5329,7 @@ version = "4.6.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools",
  "nom",
  "num-traits",
@@ -5520,7 +5528,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00
 dependencies = [
  "anyhow",
  "enum-iterator",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "lazy_static",
  "paste",
  "serde",
@@ -5543,7 +5551,7 @@ dependencies = [
  "itertools",
  "nom",
  "num-traits",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "snarkvm-curves",
  "snarkvm-fields",
@@ -5559,7 +5567,7 @@ dependencies = [
  "enum-iterator",
  "enum_index",
  "enum_index_derive",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "num-derive",
  "num-traits",
  "seq-macro",
@@ -5665,7 +5673,7 @@ name = "snarkvm-curves"
 version = "4.6.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
- "rand 0.10.0",
+ "rand 0.10.1",
  "rustc_version",
  "serde",
  "snarkvm-fields",
@@ -5682,7 +5690,7 @@ dependencies = [
  "anyhow",
  "itertools",
  "num-traits",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rayon",
  "serde",
  "snarkvm-utilities",
@@ -5697,11 +5705,11 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "locktick",
  "lru",
  "parking_lot",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rayon",
  "snarkvm-circuit",
@@ -5728,7 +5736,7 @@ version = "4.6.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "anyhow",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde_json",
  "snarkvm-console",
  "snarkvm-ledger-narwhal-subdag",
@@ -5740,7 +5748,7 @@ version = "4.6.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools",
  "rayon",
  "serde_json",
@@ -5763,9 +5771,9 @@ version = "4.6.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rand_distr",
  "rayon",
@@ -5794,7 +5802,7 @@ name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.6.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -5807,7 +5815,7 @@ name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.6.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -5831,7 +5839,7 @@ name = "snarkvm-ledger-narwhal-subdag"
 version = "4.6.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -5871,11 +5879,11 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "locktick",
  "lru",
  "parking_lot",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rayon",
  "serde_json",
@@ -5891,11 +5899,11 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "colored 3.1.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "locktick",
  "lru",
  "parking_lot",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rayon",
  "snarkvm-circuit",
@@ -5931,7 +5939,7 @@ dependencies = [
  "aleo-std-storage",
  "anyhow",
  "bincode",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "locktick",
  "parking_lot",
  "rayon",
@@ -5992,7 +6000,7 @@ dependencies = [
  "locktick",
  "parking_lot",
  "paste",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde_json",
  "sha2 0.10.9",
  "snarkvm-curves",
@@ -6007,12 +6015,12 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools",
  "locktick",
  "lru",
  "parking_lot",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rayon",
  "serde_json",
  "snarkvm-algorithms",
@@ -6053,11 +6061,11 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00
 dependencies = [
  "aleo-std",
  "colored 3.1.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools",
  "locktick",
  "parking_lot",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rayon",
  "serde_json",
@@ -6079,9 +6087,9 @@ version = "4.6.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=8c5ef1f5849cf12e2e00b2b4ca5cea152db48402#8c5ef1f5849cf12e2e00b2b4ca5cea152db48402"
 dependencies = [
  "enum-iterator",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "paste",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rayon",
  "serde_json",
@@ -6118,7 +6126,7 @@ dependencies = [
  "colored 3.1.1",
  "num-bigint",
  "num_cpus",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_xorshift 0.5.0",
  "rayon",
  "serde",
@@ -6358,7 +6366,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -6421,7 +6429,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -6649,9 +6657,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -6667,9 +6675,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -6746,7 +6754,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -6766,9 +6774,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.1",
 ]
@@ -6851,7 +6859,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -6891,7 +6899,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84e6672c7510df74859726427edea641674dad1aeeb30057b87335b1ba23b843"
 dependencies = [
- "axum 0.8.8",
+ "axum 0.8.9",
  "forwarded-header-value",
  "governor",
  "http 1.4.0",
@@ -7232,9 +7240,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7245,9 +7253,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7255,9 +7263,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote 1.0.45",
  "wasm-bindgen-macro-support",
@@ -7265,9 +7273,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -7278,9 +7286,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -7302,7 +7310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -7313,17 +7321,17 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7822,7 +7830,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -7852,8 +7860,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -7872,7 +7880,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -7884,9 +7892,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
@@ -8016,7 +8024,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memchr",
  "thiserror 2.0.18",
  "time",

--- a/node/bft/README.md
+++ b/node/bft/README.md
@@ -31,6 +31,17 @@ f + 1 vertices that vote for the anchor, or 2f + 1 vertices that do not, or a ti
 ```
 Note that in this quote `2f + 1` should really be `n - f`.
 
+#### Batch Proposal
+
+Batch proposals are driven by a dedicated **batch proposal task** that runs in a loop and is the only place that calls `propose_batch()`. This keeps proposal on a single execution path and avoids concurrent proposal attempts.
+
+The task waits for one of two events before attempting to propose:
+
+1. **Ready notification** — When the primary advances to a new round (e.g. after a certificate is committed or in the Narwhal case when storage increments the round), it signals readiness by notifying the batch proposal task (`is_ready_notify`). The task wakes up and, if the node is synced, calls `propose_batch()`.
+2. **Maximum delay timeout** — If no notification occurs within the configured maximum batch delay, the task wakes up anyway and tries to propose. This provides a fallback so that rounds still progress even when no round-advancement event has occurred.
+
+The primary tracks the latest proposed **(round, timestamp)** in `latest_proposed_batch`. This state is used to: avoid proposing the same round twice; rate-limit the primary's own proposals (via a dedicated check against the previous proposal timestamp); and decide whether to advance when a certificate is received. Peer proposal timestamps are validated separately so that the primary does not accept batches proposed too soon after a peer's previous proposal.
+
 ### Ledger Advancement
 
 The BFT module also advances the ledger as new certificates are added to the DAG. There are two different ways the ledger can advance.

--- a/node/bft/README.md
+++ b/node/bft/README.md
@@ -35,10 +35,11 @@ Note that in this quote `2f + 1` should really be `n - f`.
 
 Batch proposals are driven by a dedicated **batch proposal task** that runs in a loop and is the only place that calls `propose_batch()`. This keeps proposal on a single execution path and avoids concurrent proposal attempts.
 
-The task waits for one of two events before attempting to propose:
+Each iteration of the inner loop waits for the first of these to fire before calling `propose_batch()`:
 
-1. **Ready notification** — When the primary advances to a new round (e.g. after a certificate is committed or in the Narwhal case when storage increments the round), it signals readiness by notifying the batch proposal task (`is_ready_notify`). The task wakes up and, if the node is synced, calls `propose_batch()`.
-2. **Maximum delay timeout** — If no notification occurs within the configured maximum batch delay, the task wakes up anyway and tries to propose. This provides a fallback so that rounds still progress even when no round-advancement event has occurred.
+1. **Ready notification** (`is_ready_notify`) — When the primary advances to a new round (e.g. after a certificate is committed, or in the Narwhal case when storage increments the round), it signals readiness via `is_ready_notify`. The task wakes up and, if the node is synced, calls `propose_batch()`.
+2. **Delay timeout** — If not sufficient time has elapsed, the task sets a timer for `MAX_BATCH_DELAY − elapsed`.
+3. **Sync completion** If the node is currently syncing, it waits for the state to change to `Synced`. This lets the task wake up as soon as sync finishes without polling.
 
 The primary tracks the latest proposed **(round, timestamp)** in `latest_proposed_batch`. This state is used to: avoid proposing the same round twice; rate-limit the primary's own proposals (via a dedicated check against the previous proposal timestamp); and decide whether to advance when a certificate is received. Peer proposal timestamps are validated separately so that the primary does not accept batches proposed too soon after a peer's previous proposal.
 

--- a/node/bft/README.md
+++ b/node/bft/README.md
@@ -10,38 +10,44 @@ The `snarkos-node-bft` crate provides a node implementation for a BFT-based memo
 
 The primary is the coordinator, responsible for advancing rounds and broadcasting the anchor.
 
-#### Triggering Round Advancement
+#### Round Advancement
 
-Each round runs until one of two conditions is met:
-1. The coinbase target has been reached, or
-2. The round has reached its timeout (currently set to 10 seconds)
+A round advances once a quorum (`n - f`) of validators have submitted certificates for that round
+and the following round-type-specific conditions are met:
 
-#### Advancing Rounds
+- **Even rounds**: the elected leader's certificate is present among the quorum, confirming the
+  leader was reachable. If the leader's certificate is absent, the node waits up to
+  `MAX_LEADER_CERTIFICATE_DELAY` before advancing without it.
+- **Odd rounds**: at least `f + 1` certificates from the current round reference the previous
+  even round's leader certificate (availability threshold), or `n - f` do not (non-leader
+  quorum). If neither threshold is reached, the node again falls back to the timeout.
 
-As described in the paper [Bullshark: The Partially Synchronous Version](https://arxiv.org/abs/2209.05633),
-the BFT generally advances rounds when `n − f` vertices are delivered, however:
-```
-The problem in advancing rounds whenever n − f vertices are delivered is that parties
-might not vote for the anchor even if the party that broadcast it is just slightly slower
-than the fastest n − f parties. To deal with this, the BFT integrates timeouts into
-the DAG construction. If the first n − f vertices a party p gets in an even-numbered round r 
-do not include the anchor of round r, then p sets a timer and waits for the anchor
-until the timer expires. Similarly, in an odd-numbered round, parties wait for either
-f + 1 vertices that vote for the anchor, or 2f + 1 vertices that do not, or a timeout.
-```
-Note that in this quote `2f + 1` should really be `n - f`.
+In both cases the timeout is `MAX_LEADER_CERTIFICATE_DELAY` (currently 5 seconds), reset at the
+start of each round. This follows the [Bullshark](https://arxiv.org/abs/2209.05633) protocol.
 
 #### Batch Proposal
 
-Batch proposals are driven by a dedicated **batch proposal task** that runs in a loop and is the only place that calls `propose_batch()`. This keeps proposal on a single execution path and avoids concurrent proposal attempts.
+Batch proposals are driven by a dedicated **`ProposalTask`** that runs in a loop and is the only place that calls `Primary::propose_batch()`.
+This keeps proposal on a single execution path and avoids concurrent proposal attempts. Each loop iteration covers one full round and proceeds through three stages:
 
-Each iteration of the inner loop waits for the first of these to fire before calling `propose_batch()`:
+**Stage 1 — Wait until ready to propose**
 
-1. **Ready notification** (`is_ready_notify`) — When the primary advances to a new round (e.g. after a certificate is committed, or in the Narwhal case when storage increments the round), it signals readiness via `is_ready_notify`. The task wakes up and, if the node is synced, calls `propose_batch()`.
-2. **Delay timeout** — If not sufficient time has elapsed, the task sets a timer for `MAX_BATCH_DELAY − elapsed`.
-3. **Sync completion** If the node is currently syncing, it waits for the state to change to `Synced`. This lets the task wake up as soon as sync finishes without polling.
+The task blocks until all of the following conditions are satisfied:
+1. The node is synced. If it is currently syncing, the task waits via `wait_for_synced_if_syncing()` before continuing.
+2. `MIN_BATCH_DELAY` has elapsed since the start of the round, enforcing a minimum inter-proposal interval.
+3. One of two events fires:
+   - **Ready signal** — `ProposalTask::signal()` is called from `try_increment_to_the_next_round()` when the primary successfully advances to a new round (e.g. after a leader certificate is committed). This is delivered via a `watch` channel.
+   - **`MAX_BATCH_DELAY` timeout** — If no signal arrives within `MAX_BATCH_DELAY` of the round start, the task proceeds anyway. This handles the case where the elected leader's certificate never arrives.
 
-The primary tracks the latest proposed **(round, timestamp)** in `latest_proposed_batch`. This state is used to: avoid proposing the same round twice; rate-limit the primary's own proposals (via a dedicated check against the previous proposal timestamp); and decide whether to advance when a certificate is received. Peer proposal timestamps are validated separately so that the primary does not accept batches proposed too soon after a peer's previous proposal.
+A short `CREATE_BATCH_INTERVAL` heartbeat keeps the round-change check alive while waiting.
+
+**Stage 2 — Propose**
+
+The task calls `propose_batch()` in a loop until it returns `Ok(true)` (batch submitted). On `Ok(false)` or a transient error it retries every `CREATE_BATCH_INTERVAL`. If the round advances during retries, the task restarts from Stage 1.
+
+**Stage 3 — Wait for signatures**
+
+Once the batch is broadcast, the task periodically calls `propose_batch()` every `MAX_BATCH_DELAY` to rebroadcast to any validators that have not yet signed. It exits this stage as soon as the round advances (detected either via the ready signal or by polling `current_round()`).
 
 ### Ledger Advancement
 

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -607,16 +607,24 @@ impl<N: Network> BFT<N> {
         // Determine the list of all previous leader certificates since the last committed round.
         // The order of the leader certificates is from **newest** to **oldest**.
         let mut leader_certificates = vec![leader_certificate.clone()];
+        // Whether the consensus callback should be skipped (true when the round is already committed).
+        // When `latest_leader_round == last_committed_round` the round was already committed by a
+        // concurrent call that beat us to the lock, or by a prior session whose DAG state was
+        // reconstructed without populating `recently_committed`.  In both cases we still re-run
+        // DFS + GC to ensure `recently_committed` and `gc_round` are populated, but we must NOT
+        // send a duplicate subdag to the consensus callback.
+        let skip_consensus;
         {
             // Read-lock the DAG.
             // We need to hold the lock, so we do not later fail to re-acquire it.
             let dag = self.dag.read();
 
             // Re-check under the lock: another call may have committed this round while we were waiting.
-            if latest_leader_round <= dag.last_committed_round() {
+            if latest_leader_round < dag.last_committed_round() {
                 trace!("Skipping already-committed leader round {latest_leader_round}");
                 return Ok(());
             }
+            skip_consensus = latest_leader_round == dag.last_committed_round();
 
             #[cfg(debug_assertions)]
             trace!("Attempting to commit leader certificate for round {}...", latest_leader_round);
@@ -749,25 +757,28 @@ impl<N: Network> BFT<N> {
                 "BFT failed to commit - the subdag anchor round {anchor_round} does not match the leader round {leader_round}",
             );
 
-            // Trigger consensus.
-            if let Some(consensus_sender) = self.consensus_sender.get() {
-                // Initialize a callback sender and receiver.
-                let (callback_sender, callback_receiver) = oneshot::channel();
-                // Send the subdag and transmissions to consensus.
-                consensus_sender.tx_consensus_subdag.send((subdag, transmissions, callback_sender)).await?;
-                // Await the callback to continue.
-                match callback_receiver.await {
-                    Ok(Ok(_)) => (),
-                    Ok(Err(err)) => {
-                        let err = err.context(format!("BFT failed to advance the subdag for round {anchor_round}"));
-                        error!("{}", &flatten_error(err));
-                        return Ok(());
-                    }
-                    Err(err) => {
-                        let err: anyhow::Error = err.into();
-                        let err = err.context(format!("BFT failed to receive the callback for round {anchor_round}"));
-                        error!("{}", flatten_error(err));
-                        return Ok(());
+            // Trigger consensus (skipped if the round was already committed by a prior call).
+            if !skip_consensus {
+                if let Some(consensus_sender) = self.consensus_sender.get() {
+                    // Initialize a callback sender and receiver.
+                    let (callback_sender, callback_receiver) = oneshot::channel();
+                    // Send the subdag and transmissions to consensus.
+                    consensus_sender.tx_consensus_subdag.send((subdag, transmissions, callback_sender)).await?;
+                    // Await the callback to continue.
+                    match callback_receiver.await {
+                        Ok(Ok(_)) => (),
+                        Ok(Err(err)) => {
+                            let err = err.context(format!("BFT failed to advance the subdag for round {anchor_round}"));
+                            error!("{}", &flatten_error(err));
+                            return Ok(());
+                        }
+                        Err(err) => {
+                            let err: anyhow::Error = err.into();
+                            let err =
+                                err.context(format!("BFT failed to receive the callback for round {anchor_round}"));
+                            error!("{}", flatten_error(err));
+                            return Ok(());
+                        }
                     }
                 }
             }

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use crate::{
-    MAX_LEADER_CERTIFICATE_DELAY_IN_SECS,
+    MAX_LEADER_CERTIFICATE_DELAY,
     helpers::{ConsensusSender, DAG, PrimaryReceiver, PrimarySender, Storage, fmt_id, now},
     primary::{Primary, PrimaryCallback},
     sync::SyncCallback,
@@ -482,7 +482,7 @@ impl<N: Network> BFT<N> {
     ///
     /// This is always true for a new BFT instance.
     fn is_timer_expired(&self) -> bool {
-        self.leader_certificate_timer.load(Ordering::SeqCst) + MAX_LEADER_CERTIFICATE_DELAY_IN_SECS <= now()
+        self.leader_certificate_timer.load(Ordering::SeqCst) + MAX_LEADER_CERTIFICATE_DELAY.as_secs() as i64 <= now()
     }
 
     /// Returns 'true' if the quorum threshold `(N - f)` is reached for this round under one of the following conditions:
@@ -881,7 +881,7 @@ impl<N: Network> BFT<N> {
 mod tests {
     use crate::{
         BFT,
-        MAX_LEADER_CERTIFICATE_DELAY_IN_SECS,
+        MAX_LEADER_CERTIFICATE_DELAY,
         PrimaryCallback,
         helpers::{Storage, dag::test_helpers::mock_dag_with_modified_last_committed_round},
         sync::SyncCallback,
@@ -1113,9 +1113,7 @@ mod tests {
             assert!(!result);
         }
         // Wait for the timer to expire.
-        let leader_certificate_timeout =
-            std::time::Duration::from_millis(MAX_LEADER_CERTIFICATE_DELAY_IN_SECS as u64 * 1000);
-        std::thread::sleep(leader_certificate_timeout);
+        std::thread::sleep(MAX_LEADER_CERTIFICATE_DELAY);
         // Once the leader certificate timer has expired and quorum threshold is reached, we are ready to advance to the next round.
         let result = bft_timer.is_even_round_ready_for_next_round(certificates.clone(), committee.clone(), 2);
         if bft_timer.is_timer_expired() {

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -207,7 +207,13 @@ impl<N: Network> BFT<N> {
 #[async_trait::async_trait]
 impl<N: Network> PrimaryCallback<N> for BFT<N> {
     /// Notification that a new round has started.
-    fn update_to_next_round(&self, current_round: u64) -> bool {
+    ///
+    /// # Arguments
+    /// * `current_round` - the round the caller is in (to avoid race conditions)
+    ///
+    /// # Returns
+    /// `true` if the BFT moved to the next round.
+    fn try_advance_to_next_round(&self, current_round: u64) -> bool {
         // Ensure the current round is at least the storage round (this is a sanity check).
         let storage_round = self.storage().current_round();
         if current_round < storage_round {

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -42,6 +42,8 @@ use colored::Colorize;
 use indexmap::{IndexMap, IndexSet};
 #[cfg(feature = "locktick")]
 use locktick::parking_lot::RwLock;
+#[cfg(feature = "locktick")]
+use locktick::tokio::Mutex;
 #[cfg(not(feature = "locktick"))]
 use parking_lot::RwLock;
 use std::{
@@ -52,6 +54,8 @@ use std::{
         atomic::{AtomicI64, Ordering},
     },
 };
+#[cfg(not(feature = "locktick"))]
+use tokio::sync::Mutex;
 use tokio::sync::{OnceCell, oneshot};
 
 #[derive(Clone)]
@@ -66,6 +70,12 @@ pub struct BFT<N: Network> {
     leader_certificate_timer: Arc<AtomicI64>,
     /// The consensus sender.
     consensus_sender: Arc<OnceCell<ConsensusSender<N>>>,
+    /// Ensures only one call to `commit_leader_certificate` runs at a time.
+    ///
+    /// Without this, a second certificate crossing the availability threshold while the consensus
+    /// callback for a prior commit is still in-flight would re-walk already-committed rounds
+    /// (because `last_committed_round` hasn't been updated yet), causing duplicate subdag commits.
+    commit_lock: Arc<Mutex<()>>,
 }
 
 impl<N: Network> BFT<N> {
@@ -98,6 +108,7 @@ impl<N: Network> BFT<N> {
             leader_certificate: Default::default(),
             leader_certificate_timer: Default::default(),
             consensus_sender: Default::default(),
+            commit_lock: Default::default(),
         })
     }
 
@@ -586,21 +597,32 @@ impl<N: Network> BFT<N> {
         #[cfg(debug_assertions)]
         trace!("Attempting to commit leader certificate for round {}...", leader_certificate.round());
 
+        // Serialize all commits so that `last_committed_round` is up-to-date before the next call
+        // re-walks the DAG, preventing duplicate subdag commits.
+        let _commit_guard = self.commit_lock.lock().await;
+
         // Fetch the leader round.
         let latest_leader_round = leader_certificate.round();
+
         // Determine the list of all previous leader certificates since the last committed round.
         // The order of the leader certificates is from **newest** to **oldest**.
         let mut leader_certificates = vec![leader_certificate.clone()];
         {
-            // Retrieve the leader round and the latest round we committed.
-            let leader_round = leader_certificate.round();
-
             // Read-lock the DAG.
             // We need to hold the lock, so we do not later fail to re-acquire it.
             let dag = self.dag.read();
 
+            // Re-check under the lock: another call may have committed this round while we were waiting.
+            if latest_leader_round <= dag.last_committed_round() {
+                trace!("Skipping already-committed leader round {latest_leader_round}");
+                return Ok(());
+            }
+
+            #[cfg(debug_assertions)]
+            trace!("Attempting to commit leader certificate for round {}...", latest_leader_round);
+
             let mut current_certificate = leader_certificate;
-            for round in (dag.last_committed_round() + 2..=leader_round.saturating_sub(2)).rev().step_by(2) {
+            for round in (dag.last_committed_round() + 2..=latest_leader_round.saturating_sub(2)).rev().step_by(2) {
                 // Retrieve the previous committee for the leader round.
                 let previous_committee_lookback =
                     self.ledger().get_committee_lookback_for_round(round).with_context(|| {

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -17,7 +17,7 @@
 use crate::helpers::Telemetry;
 use crate::{
     CONTEXT,
-    MAX_BATCH_DELAY_IN_MS,
+    MAX_BATCH_DELAY,
     MEMORY_POOL_PORT,
     Worker,
     events::{DisconnectReason, EventCodec, PrimaryPing},
@@ -99,9 +99,9 @@ use tokio_stream::StreamExt;
 use tokio_util::codec::Framed;
 
 /// The maximum interval of events to cache.
-const CACHE_EVENTS_INTERVAL: i64 = (MAX_BATCH_DELAY_IN_MS / 1000) as i64; // seconds
+const CACHE_EVENTS_INTERVAL: i64 = (MAX_BATCH_DELAY.as_secs()) as i64; // seconds
 /// The maximum interval of requests to cache.
-const CACHE_REQUESTS_INTERVAL: i64 = (MAX_BATCH_DELAY_IN_MS / 1000) as i64; // seconds
+const CACHE_REQUESTS_INTERVAL: i64 = (MAX_BATCH_DELAY.as_secs()) as i64; // seconds
 
 /// The maximum number of connection attempts in an interval.
 #[cfg(not(test))]

--- a/node/bft/src/helpers/pending.rs
+++ b/node/bft/src/helpers/pending.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::MAX_FETCH_TIMEOUT_IN_MS;
+use crate::MAX_FETCH_TIMEOUT;
 use snarkos_node_bft_ledger_service::LedgerService;
 use snarkvm::{
     console::network::{Network, consensus_config_value},
@@ -35,8 +35,8 @@ use time::OffsetDateTime;
 use tokio::sync::oneshot;
 
 /// The maximum number of seconds to wait before expiring a callback.
-/// We ensure that we don't truncate `MAX_FETCH_TIMEOUT_IN_MS` when converting to seconds.
-pub(crate) const CALLBACK_EXPIRATION_IN_SECS: i64 = MAX_FETCH_TIMEOUT_IN_MS.div_ceil(1000) as i64;
+/// We ensure that we don't truncate `MAX_FETCH_TIMEOUT` when converting to seconds.
+pub(crate) const CALLBACK_EXPIRATION_IN_SECS: i64 = MAX_FETCH_TIMEOUT.as_secs() as i64;
 
 /// Returns the maximum number of redundant requests for the number of validators in the specified round.
 pub fn max_redundant_requests<N: Network>(ledger: Arc<dyn LedgerService<N>>, round: u64) -> Result<usize> {

--- a/node/bft/src/helpers/timestamp.rs
+++ b/node/bft/src/helpers/timestamp.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::MAX_TIMESTAMP_DELTA_IN_SECS;
+use crate::MAX_TIMESTAMP_DELTA;
 use snarkvm::prelude::{Result, bail};
 
 use time::OffsetDateTime;
@@ -36,7 +36,7 @@ pub fn to_utc_datetime(timestamp: i64) -> OffsetDateTime {
 /// Sanity checks the timestamp for liveness.
 pub fn check_timestamp_for_liveness(timestamp: i64) -> Result<()> {
     // Ensure the timestamp is within range.
-    if timestamp > (now() + MAX_TIMESTAMP_DELTA_IN_SECS) {
+    if timestamp > (now() + MAX_TIMESTAMP_DELTA.as_secs() as i64) {
         bail!("Timestamp {timestamp} is too far in the future")
     }
     Ok(())
@@ -45,17 +45,17 @@ pub fn check_timestamp_for_liveness(timestamp: i64) -> Result<()> {
 #[cfg(test)]
 mod prop_tests {
     use super::*;
-    use crate::MAX_TIMESTAMP_DELTA_IN_SECS;
+    use crate::MAX_TIMESTAMP_DELTA;
 
     use proptest::prelude::*;
     use test_strategy::proptest;
 
     fn any_valid_timestamp() -> BoxedStrategy<i64> {
-        (Just(now()), 0..MAX_TIMESTAMP_DELTA_IN_SECS).prop_map(|(now, delta)| now + delta).boxed()
+        (Just(now()), 0..(MAX_TIMESTAMP_DELTA.as_secs() as i64)).prop_map(|(now, delta)| now + delta).boxed()
     }
 
     fn any_invalid_timestamp() -> BoxedStrategy<i64> {
-        (Just(now()), MAX_TIMESTAMP_DELTA_IN_SECS..).prop_map(|(now, delta)| now + delta).boxed()
+        (Just(now()), (MAX_TIMESTAMP_DELTA.as_secs() as i64)..).prop_map(|(now, delta)| now + delta).boxed()
     }
 
     #[proptest]

--- a/node/bft/src/lib.rs
+++ b/node/bft/src/lib.rs
@@ -55,9 +55,16 @@ pub const MEMORY_POOL_PORT: u16 = 5000; // port
 
 /// The maximum time to wait before proposing a batch.
 pub const MAX_BATCH_DELAY: Duration = Duration::from_millis(2500);
+
 /// The minimum time that needs to elapse between two consecutive batch proposals.
 /// This creates a lower bound on the block interval, and ensures the network will not be overwhelmed with too many blocks/certificates.
 pub const MIN_BATCH_DELAY: Duration = Duration::from_secs(1);
+
+/// The time a primary waits between attempts to create a new batch (only relevant after `MIN_BATCH_DELAY` has passed).
+/// This only serves as a failsafe in case the task does not get woken up through other means.
+/// eowering it too much will most likely waste
+pub const CREATE_BATCH_INTERVAL: Duration = Duration::from_millis(250);
+
 /// The maximum time to wait before timing out on a fetch.
 pub const MAX_FETCH_TIMEOUT: Duration = Duration::from_secs(3 * MAX_BATCH_DELAY.as_secs());
 /// The maximum time allowed for the leader to send their certificate.

--- a/node/bft/src/lib.rs
+++ b/node/bft/src/lib.rs
@@ -62,7 +62,7 @@ pub const MIN_BATCH_DELAY: Duration = Duration::from_secs(1);
 
 /// The time a primary waits between attempts to create a new batch (only relevant after `MIN_BATCH_DELAY` has passed).
 /// This only serves as a failsafe in case the task does not get woken up through other means.
-/// eowering it too much will most likely waste
+/// Lowering it too much would be wasteful.
 pub const CREATE_BATCH_INTERVAL: Duration = Duration::from_millis(250);
 
 /// The maximum time to wait before timing out on a fetch.

--- a/node/bft/src/lib.rs
+++ b/node/bft/src/lib.rs
@@ -66,21 +66,27 @@ pub const MIN_BATCH_DELAY: Duration = Duration::from_secs(1);
 pub const CREATE_BATCH_INTERVAL: Duration = Duration::from_millis(250);
 
 /// The maximum time to wait before timing out on a fetch.
-pub const MAX_FETCH_TIMEOUT: Duration = Duration::from_secs(3 * MAX_BATCH_DELAY.as_secs());
+/// TODO(kaimast): directy multiply by constant once the `const_trait_impl` feature is stable.
+pub const MAX_FETCH_TIMEOUT: Duration = Duration::from_millis(3 * (MAX_BATCH_DELAY.as_millis() as u64));
+
 /// The maximum time allowed for the leader to send their certificate.
 /// After this time, the node will consider the leader as failed and try to advance the round without it.
-pub const MAX_LEADER_CERTIFICATE_DELAY: Duration = Duration::from_secs(2 * MAX_BATCH_DELAY.as_secs());
+pub const MAX_LEADER_CERTIFICATE_DELAY: Duration = Duration::from_millis(2 * (MAX_BATCH_DELAY.as_millis() as u64));
+
 /// The maximum difference allowed between our local time and a certificate's timestamp, for the node to sign the certificate.
 /// This prevents malicious actors from proposing certificates with timestamps that are too log or too far in the future)
+/// w
 pub const MAX_TIMESTAMP_DELTA: Duration = Duration::from_secs(10);
+
 /// The maximum number of workers that can be spawned.
 pub const MAX_WORKERS: u8 = 1; // worker(s)
 
 /// The interval at which each primary broadcasts a ping to every other node.
 /// Note: If this is updated, be sure to update `MAX_BLOCKS_BEHIND` to correspond properly.
-pub const PRIMARY_PING_INTERVAL: Duration = Duration::from_secs(2 * MAX_BATCH_DELAY.as_secs());
+pub const PRIMARY_PING_INTERVAL: Duration = Duration::from_millis(2 * (MAX_BATCH_DELAY.as_millis() as u64));
+
 /// The interval at which each worker broadcasts a ping to every other node.
-pub const WORKER_PING_INTERVAL: Duration = Duration::from_secs(4 * MAX_BATCH_DELAY.as_secs());
+pub const WORKER_PING_INTERVAL: Duration = Duration::from_millis(4 * (MAX_BATCH_DELAY.as_millis() as u64));
 
 /// A helper macro to spawn a blocking task.
 #[macro_export]

--- a/node/bft/src/lib.rs
+++ b/node/bft/src/lib.rs
@@ -29,6 +29,8 @@ pub use snarkos_node_bft_events as events;
 pub use snarkos_node_bft_ledger_service as ledger_service;
 pub use snarkos_node_bft_storage_service as storage_service;
 
+use std::time::Duration;
+
 pub mod helpers;
 
 mod bft;
@@ -51,24 +53,27 @@ pub const CONTEXT: &str = "[MemoryPool]";
 /// The port on which the memory pool listens for incoming connections.
 pub const MEMORY_POOL_PORT: u16 = 5000; // port
 
-/// The maximum number of milliseconds to wait before proposing a batch.
-pub const MAX_BATCH_DELAY_IN_MS: u64 = 2500; // ms
-/// The minimum number of seconds to wait before proposing a batch.
-pub const MIN_BATCH_DELAY_IN_SECS: u64 = 1; // seconds
-/// The maximum number of milliseconds to wait before timing out on a fetch.
-pub const MAX_FETCH_TIMEOUT_IN_MS: u64 = 3 * MAX_BATCH_DELAY_IN_MS; // ms
-/// The maximum number of seconds allowed for the leader to send their certificate.
-pub const MAX_LEADER_CERTIFICATE_DELAY_IN_SECS: i64 = 2 * MAX_BATCH_DELAY_IN_MS as i64 / 1000; // seconds
-/// The maximum number of seconds before the timestamp is considered expired.
-pub const MAX_TIMESTAMP_DELTA_IN_SECS: i64 = 10; // seconds
+/// The maximum time to wait before proposing a batch.
+pub const MAX_BATCH_DELAY: Duration = Duration::from_millis(2500);
+/// The minimum time that needs to elapse between two consecutive batch proposals.
+/// This creates a lower bound on the block interval, and ensures the network will not be overwhelmed with too many blocks/certificates.
+pub const MIN_BATCH_DELAY: Duration = Duration::from_secs(1);
+/// The maximum time to wait before timing out on a fetch.
+pub const MAX_FETCH_TIMEOUT: Duration = Duration::from_secs(3 * MAX_BATCH_DELAY.as_secs());
+/// The maximum time allowed for the leader to send their certificate.
+/// After this time, the node will consider the leader as failed and try to advance the round without it.
+pub const MAX_LEADER_CERTIFICATE_DELAY: Duration = Duration::from_secs(2 * MAX_BATCH_DELAY.as_secs());
+/// The maximum difference allowed between our local time and a certificate's timestamp, for the node to sign the certificate.
+/// This prevents malicious actors from proposing certificates with timestamps that are too log or too far in the future)
+pub const MAX_TIMESTAMP_DELTA: Duration = Duration::from_secs(10);
 /// The maximum number of workers that can be spawned.
 pub const MAX_WORKERS: u8 = 1; // worker(s)
 
 /// The interval at which each primary broadcasts a ping to every other node.
 /// Note: If this is updated, be sure to update `MAX_BLOCKS_BEHIND` to correspond properly.
-pub const PRIMARY_PING_IN_MS: u64 = 2 * MAX_BATCH_DELAY_IN_MS; // ms
+pub const PRIMARY_PING_INTERVAL: Duration = Duration::from_secs(2 * MAX_BATCH_DELAY.as_secs());
 /// The interval at which each worker broadcasts a ping to every other node.
-pub const WORKER_PING_IN_MS: u64 = 4 * MAX_BATCH_DELAY_IN_MS; // ms
+pub const WORKER_PING_INTERVAL: Duration = Duration::from_secs(4 * MAX_BATCH_DELAY.as_secs());
 
 /// A helper macro to spawn a blocking task.
 #[macro_export]

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -70,7 +70,7 @@ use indexmap::{IndexMap, IndexSet};
 #[cfg(feature = "locktick")]
 use locktick::{
     parking_lot::{Mutex, RwLock},
-    tokio::Mutex as TMutex,
+    tokio::RwLock as TRwLock,
 };
 #[cfg(not(feature = "locktick"))]
 use parking_lot::{Mutex, RwLock};
@@ -86,11 +86,11 @@ use std::{
     time::Duration,
 };
 #[cfg(not(feature = "locktick"))]
-use tokio::sync::Mutex as TMutex;
-use tokio::task::JoinHandle;
+use tokio::sync::RwLock as TRwLock;
+use tokio::{sync::Notify, task::JoinHandle};
 
-/// A helper type for an optional proposed batch.
-pub type ProposedBatch<N> = RwLock<Option<Proposal<N>>>;
+/// A helper type to keep track of the latest proposed batch.
+pub(crate) type ProposedBatch<N> = RwLock<Option<Proposal<N>>>;
 
 /// This callback trait allows listening to changes in the Primary, such as round advancement.
 /// This is currently used by BFT.
@@ -119,22 +119,31 @@ pub struct Primary<N: Network> {
     workers: Arc<OnceLock<Vec<Worker<N>>>>,
     /// The primary callback (used by [`BFT`]).
     primary_callback: Arc<CallbackHandle<Arc<dyn PrimaryCallback<N>>>>,
+
     /// The batch proposal, if the primary is currently proposing a batch.
     proposed_batch: Arc<ProposedBatch<N>>,
-    /// The timestamp of the most recent proposed batch.
-    latest_proposed_batch_timestamp: Arc<RwLock<i64>>,
+
     /// The instant at which the current batch was proposed (used to measure certification latency).
     /// (used for higher precision in the metrics compared to the batch timestamp)
     #[cfg(feature = "metrics")]
     batch_propose_start: Arc<Mutex<Option<Instant>>>,
+
+    /// Holds the most recent round and timestamp that the primary proposed a batch for.
+    /// TODO(kaimast): avoiding using an async lock here, so this can be merged with the `proposed_batch`,
+    /// to have a unified `primary_state` field.
+    latest_proposed_batch: Arc<TRwLock<Option<(u64, i64)>>>,
+
     /// The recently-signed batch proposals.
     signed_proposals: Arc<RwLock<SignedProposals<N>>>,
+
     /// The handles for all background tasks spawned by this primary.
     handles: Arc<Mutex<Vec<JoinHandle<()>>>>,
-    /// The lock for propose_batch. It holds the most recent round that was proposed for.
-    propose_lock: Arc<TMutex<u64>>,
+
     /// The node configuration directory.
     node_data_dir: NodeDataDir,
+
+    /// Allows notifying the proposal taks when a new batch can be proposed.
+    is_ready_notify: Arc<Notify>,
 }
 
 impl<N: Network> Primary<N> {
@@ -174,16 +183,16 @@ impl<N: Network> Primary<N> {
             gateway,
             storage,
             ledger,
+            node_data_dir,
             workers: Default::default(),
             primary_callback: Default::default(),
             proposed_batch: Default::default(),
-            latest_proposed_batch_timestamp: Default::default(),
             #[cfg(feature = "metrics")]
             batch_propose_start: Default::default(),
+            latest_proposed_batch: Default::default(),
             signed_proposals: Default::default(),
             handles: Default::default(),
-            propose_lock: Default::default(),
-            node_data_dir,
+            is_ready_notify: Default::default(),
         })
     }
 
@@ -198,26 +207,9 @@ impl<N: Network> Primary<N> {
                     let (latest_certificate_round, proposed_batch, signed_proposals, pending_certificates) =
                         proposal_cache.into();
 
-                    // Verify that the proposal cache is not too far ahead of the ledger.
-                    // If the cache round exceeds the ledger round by more than MAX_GC_ROUNDS, the ledger
-                    // snapshot is too old to recover from the cached state. The operator must restore a
-                    // more recent ledger snapshot before restarting the node.
-                    let ledger_round = self.ledger.latest_round();
-                    let max_gc_rounds = BatchHeader::<N>::MAX_GC_ROUNDS as u64;
-                    if latest_certificate_round > ledger_round.saturating_add(max_gc_rounds) {
-                        bail!(
-                            "The proposal cache (round {latest_certificate_round}) is more than {max_gc_rounds} \
-                             rounds ahead of the ledger (round {ledger_round}). \
-                             Please restore a more recent ledger snapshot before restarting the node."
-                        );
-                    }
-
-                    // Write the proposed batch.
+                    *self.latest_proposed_batch.write().await = Some((latest_certificate_round, now()));
                     *self.proposed_batch.write() = proposed_batch;
-                    // Write the signed proposals.
                     *self.signed_proposals.write() = signed_proposals;
-                    // Writ the propose lock.
-                    *self.propose_lock.lock().await = latest_certificate_round;
 
                     // Update the storage with the pending certificates.
                     for certificate in pending_certificates {
@@ -338,11 +330,6 @@ impl<N: Network> Primary<N> {
     pub fn workers(&self) -> &[Worker<N>] {
         self.workers.get().expect("Primary is not running yet")
     }
-
-    /// Returns the batch proposal of our primary, if one currently exists.
-    pub fn proposed_batch(&self) -> &Arc<ProposedBatch<N>> {
-        &self.proposed_batch
-    }
 }
 
 impl<N: Network> Primary<N> {
@@ -404,9 +391,13 @@ impl<N: Network> Primary<N> {
     /// 2. Sign the batch.
     /// 3. Set the batch proposal in the primary.
     /// 4. Broadcast the batch header to all validators for signing.
+    ///
     pub async fn propose_batch(&self) -> Result<()> {
-        // This function isn't re-entrant.
-        let mut lock_guard = self.propose_lock.lock().await;
+        // Ensure there are not concurrent executions of this function.
+        //
+        // Note, in the current design, this function is only invoked from the batch proposal task, and it is technically
+        // not possible for there to be concurrent invocations of the function, but we keep this lock for now.
+        let mut lock_guard = self.latest_proposed_batch.write().await;
 
         // Check if the proposed batch has expired, and clear it if it has expired.
         if let Err(err) = self
@@ -428,14 +419,16 @@ impl<N: Network> Primary<N> {
         ensure!(round > 0, "Round 0 cannot have transaction batches");
 
         // If the current storage round is below the latest proposal round, then return early.
-        if round < *lock_guard {
-            warn!("Cannot propose a batch for round {round} - the latest proposal cache round is {}", *lock_guard);
+        if let Some((latest_round, _)) = &*lock_guard
+            && round < *latest_round
+        {
+            warn!("Cannot propose a batch for round {round} - the latest proposal cache round is {latest_round}");
             return Ok(());
         }
 
         // If there is a batch being proposed already,
         // rebroadcast the batch header to the non-signers, and return early.
-        if let Some(proposal) = self.proposed_batch.read().as_ref() {
+        if let Some(proposal) = &*self.proposed_batch.read() {
             // Ensure that the storage is caught up to the proposal before proceeding to rebroadcast this.
             if round < proposal.round()
                 || proposal
@@ -479,7 +472,9 @@ impl<N: Network> Primary<N> {
         metrics::gauge(metrics::bft::PROPOSAL_ROUND, round as f64);
 
         // Ensure that the primary does not create a new proposal too quickly.
-        if let Err(err) = self.check_proposal_timestamp(previous_round, self.gateway.account().address(), now()) {
+        if let Some((_, latest_timestamp)) = &*lock_guard
+            && let Err(err) = self.check_own_proposal_timesatmp(previous_round, *latest_timestamp, now())
+        {
             debug!(
                 "{}",
                 flatten_error(err.context(format!("Primary is safely skipping a batch proposal for round {round}")))
@@ -507,7 +502,9 @@ impl<N: Network> Primary<N> {
         // good for network reliability and should not be prevented for the already existing proposed_batch.
         // If a certificate already exists for the current round, an attempt should be made to advance the
         // round as early as possible.
-        if round == *lock_guard {
+        if let Some((latest_round, _)) = &*lock_guard
+            && *latest_round == round
+        {
             debug!("Primary is safely skipping a batch proposal - round {round} already proposed");
             return Ok(());
         }
@@ -698,11 +695,11 @@ impl<N: Network> Primary<N> {
         // Determine the current timestamp.
         let current_timestamp = now();
 
-        *lock_guard = round;
-
         /* Proceeding to sign & propose the batch. */
         info!("Proposing a batch with {} transmissions for round {round}...", transmissions.len());
 
+        // Update the latest proposed round and timestamp.
+        *lock_guard = Some((round, current_timestamp));
         // Retrieve the private key.
         let private_key = *self.gateway.account().private_key();
         // Retrieve the committee ID.
@@ -731,17 +728,17 @@ impl<N: Network> Primary<N> {
                 error!("{}", flatten_error(err.context("Failed to reinsert transmissions")));
             }
         })?;
+
         // Broadcast the batch to all validators for signing.
         self.gateway.broadcast(Event::BatchPropose(batch_header.into()));
-        // Set the timestamp of the latest proposed batch.
-        *self.latest_proposed_batch_timestamp.write() = proposal.timestamp();
+        // Store the proposal.
+        *self.proposed_batch.write() = Some(proposal);
         // Record the wall-clock time at which the batch was proposed.
         #[cfg(feature = "metrics")]
         {
             *self.batch_propose_start.lock() = Some(Instant::now());
         }
-        // Set the proposed batch.
-        *self.proposed_batch.write() = Some(proposal);
+
         Ok(())
     }
 
@@ -854,7 +851,7 @@ impl<N: Network> Primary<N> {
         // Compute the previous round.
         let previous_round = batch_round.saturating_sub(1);
         // Ensure that the peer did not propose a batch too quickly.
-        if let Err(err) = self.check_proposal_timestamp(previous_round, batch_author, batch_header.timestamp()) {
+        if let Err(err) = self.check_peer_proposal_timestamp(previous_round, batch_author, batch_header.timestamp()) {
             // Proceed to disconnect the validator.
             self.gateway.disconnect(peer_ip);
             return Err(err.context(format!("Malicious behavior of peer '{peer_ip}'")));
@@ -1227,9 +1224,9 @@ impl<N: Network> Primary<N> {
         // Determine if we are currently proposing a round that is relevant.
         // Note: This is important, because while our peers have advanced,
         // they may not be proposing yet, and thus still able to sign our proposed batch.
-        let should_advance = match &*self.proposed_batch.read() {
+        let should_advance = match &*self.latest_proposed_batch.read().await {
             // We advance if the proposal round is less than the current round that was just certified.
-            Some(proposal) => proposal.round() < certificate_round,
+            Some((latest_round, _)) => *latest_round < certificate_round,
             // If there's no proposal, we consider advancing.
             None => true,
         };
@@ -1371,32 +1368,28 @@ impl<N: Network> Primary<N> {
             }
         });
 
-        // Start the batch proposer.
+        // Start the batch proposal task.
         let self_ = self.clone();
         self.spawn(async move {
             loop {
-                // Sleep briefly, but longer than if there were no batch.
-                tokio::time::sleep(Duration::from_millis(MAX_BATCH_DELAY_IN_MS)).await;
+                // Wait until the timeout or for is_ready=true.
+                tokio::select! {
+                    _ = self_.is_ready_notify.notified() => {}
+                    _ = tokio::time::sleep(Duration::from_millis(MAX_BATCH_DELAY_IN_MS)) => {}
+                }
+
                 let current_round = self_.current_round();
                 // If the primary is not synced, then do not propose a batch.
                 if !self_.sync.is_synced() {
                     debug!("Skipping batch proposal for round {current_round} {}", "(node is syncing)".dimmed());
                     continue;
                 }
-                // A best-effort attempt to skip the scheduled batch proposal if
-                // round progression already triggered one.
-                if self_.propose_lock.try_lock().is_err() {
-                    trace!(
-                        "Skipping batch proposal for round {current_round} {}",
-                        "(node is already proposing)".dimmed()
-                    );
-                    continue;
-                };
+
                 // If there is no proposed batch, attempt to propose a batch.
                 // Note: Do NOT spawn a task around this function call. Proposing a batch is a critical path,
                 // and only one batch needs to be proposed at a time.
-                if let Err(e) = self_.propose_batch().await {
-                    warn!("Cannot propose a batch - {e}");
+                if let Err(err) = self_.propose_batch().await {
+                    warn!("{}", flatten_error(err.context("Cannot propose a batch")));
                 }
             }
         });
@@ -1629,10 +1622,8 @@ impl<N: Network> Primary<N> {
                 false => debug!("Primary is not ready to propose the next round"),
             }
 
-            // If the node is ready, propose a batch for the next round.
-            if is_ready {
-                self.propose_batch().await?;
-            }
+            // If the node is ready, wake up the proposal task.
+            self.is_ready_notify.notify_one();
         }
         Ok(())
     }
@@ -1664,19 +1655,31 @@ impl<N: Network> Primary<N> {
 
     /// Ensure the primary is not creating batch proposals too frequently.
     /// This checks that the certificate timestamp for the previous round is within the expected range.
-    fn check_proposal_timestamp(&self, previous_round: u64, author: Address<N>, timestamp: i64) -> Result<()> {
+    fn check_peer_proposal_timestamp(&self, previous_round: u64, author: Address<N>, timestamp: i64) -> Result<()> {
+        ensure!(author != self.gateway.account().address(), "Peer cannot propose a batch that is authored by myself");
+
         // Retrieve the timestamp of the previous timestamp to check against.
         let previous_timestamp = match self.storage.get_certificate_for_round_with_author(previous_round, author) {
             // Ensure that the previous certificate was created at least `MIN_BATCH_DELAY_IN_SECS` seconds ago.
             Some(certificate) => certificate.timestamp(),
-            None => match self.gateway.account().address() == author {
-                // If we are the author, then ensure the previous proposal was created at least `MIN_BATCH_DELAY_IN_SECS` seconds ago.
-                true => *self.latest_proposed_batch_timestamp.read(),
-                // If we do not see a previous certificate for the author, then proceed optimistically.
-                false => return Ok(()),
-            },
+            // If we do not see a previous certificate for the author, then proceed optimistically.
+            None => return Ok(()),
         };
 
+        // Determine the elapsed time since the previous timestamp.
+        let elapsed = timestamp
+            .checked_sub(previous_timestamp)
+            .ok_or_else(|| anyhow!("Timestamp cannot be before the previous certificate at round {previous_round}"))?;
+        // Ensure that the previous certificate was created at least `MIN_BATCH_DELAY_IN_SECS` seconds ago.
+        match elapsed < MIN_BATCH_DELAY_IN_SECS as i64 {
+            true => bail!("Timestamp is too soon after the previous certificate at round {previous_round}"),
+            false => Ok(()),
+        }
+    }
+
+    /// Ensure the primary is not creating batch proposals too frequently.
+    /// This checks that the certificate timestamp for the previous round is within the expected range.
+    fn check_own_proposal_timesatmp(&self, previous_round: u64, previous_timestamp: i64, timestamp: i64) -> Result<()> {
         // Determine the elapsed time since the previous timestamp.
         let elapsed = timestamp
             .checked_sub(previous_timestamp)
@@ -2021,7 +2024,10 @@ impl<N: Network> Primary<N> {
         let proposal_cache = {
             let proposal = self.proposed_batch.write().take();
             let signed_proposals = self.signed_proposals.read().clone();
-            let latest_round = proposal.as_ref().map(Proposal::round).unwrap_or(*self.propose_lock.lock().await);
+            let latest_round = proposal
+                .as_ref()
+                .map(Proposal::round)
+                .unwrap_or(self.latest_proposed_batch.read().await.map(|(round, _)| round).unwrap_or(0));
             let pending_certificates = self.storage.get_pending_certificates();
             ProposalCache::new(latest_round, proposal, signed_proposals, pending_certificates)
         };
@@ -2815,15 +2821,17 @@ mod tests {
         primary.workers()[0].process_unconfirmed_transaction(transaction_id, transaction).await.unwrap();
 
         // Set the proposal lock to a round ahead of the storage.
-        let old_proposal_lock_round = *primary.propose_lock.lock().await;
-        *primary.propose_lock.lock().await = round + 1;
+        let (old_proposal_round, old_proposal_timestamp) =
+            primary.latest_proposed_batch.read().await.map(|(round, timestamp)| (round, timestamp)).unwrap_or((0, 0));
+        *primary.latest_proposed_batch.write().await =
+            Some((round + 1, old_proposal_timestamp + MIN_BATCH_DELAY_IN_SECS as i64));
 
         // Propose a batch and enforce that it fails.
         assert!(primary.propose_batch().await.is_ok());
         assert!(primary.proposed_batch.read().is_none());
 
         // Set the proposal lock back to the old round.
-        *primary.propose_lock.lock().await = old_proposal_lock_round;
+        *primary.latest_proposed_batch.write().await = Some((old_proposal_round, old_proposal_timestamp));
 
         // Try to propose a batch again. This time, it should succeed.
         assert!(primary.propose_batch().await.is_ok());

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -13,8 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod proposal_task;
+pub use proposal_task::ProposalTask;
+
 use crate::{
-    CREATE_BATCH_INTERVAL,
     Gateway,
     MAX_BATCH_DELAY,
     MAX_WORKERS,
@@ -149,8 +151,8 @@ pub struct Primary<N: Network> {
     /// The node configuration directory.
     node_data_dir: NodeDataDir,
 
-    /// Allows notifying the proposal taks when a new batch can be proposed.
-    is_ready_notify: Arc<Notify>,
+    /// Manages proposal readiness state and drives the batch proposal loop.
+    proposal_task: ProposalTask<N>,
 
     /// Used to wake up a the dedicated round-increment task, if we may be able to advance to the next round.
     /// This is used, so the timeout for round advancement is reset on every round increment.
@@ -203,7 +205,7 @@ impl<N: Network> Primary<N> {
             latest_proposed_batch: Default::default(),
             signed_proposals: Default::default(),
             handles: Default::default(),
-            is_ready_notify: Default::default(),
+            proposal_task: Default::default(),
             round_increment_notify: Default::default(),
         })
     }
@@ -395,7 +397,21 @@ impl<N: Network> Primary<N> {
     }
 }
 
-impl<N: Network> Primary<N> {
+#[async_trait::async_trait]
+#[async_trait::async_trait]
+impl<N: Network> proposal_task::BatchPropose for Primary<N> {
+    fn current_round(&self) -> u64 {
+        Primary::current_round(self)
+    }
+
+    fn is_synced(&self) -> bool {
+        Primary::is_synced(self)
+    }
+
+    fn wait_for_synced_if_syncing(&self) -> Option<futures::future::BoxFuture<'_, ()>> {
+        self.sync.wait_for_synced_if_syncing()
+    }
+
     /// Proposes the batch for the current round.
     ///
     /// This method performs the following steps:
@@ -408,7 +424,7 @@ impl<N: Network> Primary<N> {
     /// - `Ok(true)` if the batch was proposed.
     /// - `Ok(false)` if the batch was not proposed for a benign reason, e.g., the timestamp is too soon after the previous certificate.
     /// - `Err(err)` if an unexpected error occured.
-    pub async fn propose_batch(&self) -> Result<bool> {
+    async fn propose_batch(&self) -> Result<bool> {
         // Ensure there are not concurrent executions of this function.
         //
         // Note, in the current design, this function is only invoked from the batch proposal task, and it is technically
@@ -751,7 +767,9 @@ impl<N: Network> Primary<N> {
 
         Ok(true)
     }
+}
 
+impl<N: Network> Primary<N> {
     /// Processes a batch propose from a peer.
     ///
     /// This method performs the following steps:
@@ -1379,57 +1397,9 @@ impl<N: Network> Primary<N> {
         });
 
         // Start the batch proposal task.
+        let proposal_task = self.proposal_task.clone();
         let self_ = self.clone();
-        self.spawn(async move {
-            // Each outer loop iteration represents one new proposed batch.
-            loop {
-                let round_start = Instant::now();
-                let current_round = self_.current_round();
-
-                // The inner loop represents multiple attempts to propose a batch within the same round.
-                // Propose a batch within the same round until the timeout is triggered, or the round is advanced by some other means.
-                while self_.current_round() == current_round {
-                    // Assemble a list of conditions that will trigger the primary to attempt batch creation.
-                    let mut futures: Vec<Pin<Box<dyn Future<Output = ()> + Send>>> = vec![];
-
-                    // Always wait for is_ready
-                    futures.push(Box::pin(self_.is_ready_notify.notified()));
-
-                    // If the maximum batch delay has not been reached, wait for it.
-                    // Otherwise, add a small timeout to avoid busy waiting.
-                    //
-                    // TODO(kaimast): ideally, we do not need the minimum timeout at all after MAX_BATCH_DELAY,
-                    // but that would need more testing to ensure this loop never gets stuck.
-                    let timeout = MAX_BATCH_DELAY.saturating_sub(round_start.elapsed()).max(CREATE_BATCH_INTERVAL);
-                    futures.push(Box::pin(tokio::time::sleep(timeout)));
-
-                    // If the node is not synced yet, wait for block sync to complete.
-                    if let Some(fut) = self_.sync.wait_for_synced_if_syncing() {
-                        futures.push(fut);
-                    }
-
-                    // Wait until one of the conditions is met.
-                    futures::future::select_all(futures).await;
-
-                    // If the primary is not synced, then do not propose a batch.
-                    if !self_.sync.is_synced() {
-                        debug!("Skipping batch proposal for round {current_round} {}", "(node is syncing)".dimmed());
-                        continue;
-                    }
-
-                    // If there is no proposed batch, attempt to propose a batch.
-                    // Note: Do NOT spawn a task around this function call. Proposing a batch is a critical path,
-                    // and only one batch needs to be proposed at a time.
-                    match self_.propose_batch().await {
-                        Ok(true) => break,
-                        Ok(false) => (), // retry
-                        Err(err) => {
-                            warn!("{}", flatten_error(err.context("Cannot propose a batch")));
-                        }
-                    }
-                }
-            }
-        });
+        self.spawn(async move { proposal_task.run(self_).await });
 
         // Start the proposed batch handler.
         let self_ = self.clone();
@@ -1666,7 +1636,7 @@ impl<N: Network> Primary<N> {
             // Notify the proposal task if the new round is ready.
             if is_ready && self.is_synced() {
                 debug!("Primary is ready to propose the next round");
-                self.is_ready_notify.notify_one();
+                self.proposal_task.signal();
             } else {
                 debug!("Primary is not ready to propose the next round");
             }
@@ -2107,7 +2077,8 @@ impl<N: Network> Primary<N> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{proposal_task::BatchPropose as _, *};
+
     use snarkos_node_bft_ledger_service::MockLedgerService;
     use snarkos_node_bft_storage_service::BFTMemoryService;
     use snarkos_node_sync::{BlockSync, locators::test_helpers::sample_block_locators};

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -19,6 +19,7 @@ pub use proposal_task::ProposalTask;
 use crate::{
     Gateway,
     MAX_BATCH_DELAY,
+    MAX_LEADER_CERTIFICATE_DELAY,
     MAX_WORKERS,
     MIN_BATCH_DELAY,
     PRIMARY_PING_INTERVAL,
@@ -1496,6 +1497,11 @@ impl<N: Network> Primary<N> {
                     {
                         futures.push(Box::pin(tokio::time::sleep(remaining_delay)));
                     }
+                    // Always ensure a wakeup no later than MAX_LEADER_CERTIFICATE_DELAY so that
+                    // try_advance_to_next_round is called after the leader-certificate timer
+                    // expires, even when no further certificates arrive (e.g. an even round where
+                    // the elected leader was absent and quorum was reached without their cert).
+                    futures.push(Box::pin(tokio::time::sleep(MAX_LEADER_CERTIFICATE_DELAY)));
                     if !self_.sync.is_synced() {
                         futures.push(Box::pin(self_.sync.wait_for_synced()));
                     }

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -404,10 +404,6 @@ impl<N: Network> proposal_task::BatchPropose for Primary<N> {
         Primary::current_round(self)
     }
 
-    fn is_synced(&self) -> bool {
-        Primary::is_synced(self)
-    }
-
     fn wait_for_synced_if_syncing(&self) -> Option<futures::future::BoxFuture<'_, ()>> {
         self.sync.wait_for_synced_if_syncing()
     }

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -15,13 +15,13 @@
 
 use crate::{
     Gateway,
-    MAX_BATCH_DELAY_IN_MS,
+    MAX_BATCH_DELAY,
     MAX_WORKERS,
-    MIN_BATCH_DELAY_IN_SECS,
-    PRIMARY_PING_IN_MS,
+    MIN_BATCH_DELAY,
+    PRIMARY_PING_INTERVAL,
     Sync,
     Transport,
-    WORKER_PING_IN_MS,
+    WORKER_PING_INTERVAL,
     Worker,
     events::{BatchPropose, BatchSignature, Event},
     helpers::{
@@ -83,7 +83,6 @@ use std::{
     future::Future,
     net::SocketAddr,
     sync::{Arc, OnceLock},
-    time::Duration,
 };
 #[cfg(not(feature = "locktick"))]
 use tokio::sync::RwLock as TRwLock;
@@ -1267,7 +1266,7 @@ impl<N: Network> Primary<N> {
         self.spawn(async move {
             loop {
                 // Sleep briefly.
-                tokio::time::sleep(Duration::from_millis(PRIMARY_PING_IN_MS)).await;
+                tokio::time::sleep(PRIMARY_PING_INTERVAL).await;
 
                 // Retrieve the block locators.
                 let self__ = self_.clone();
@@ -1355,7 +1354,7 @@ impl<N: Network> Primary<N> {
         let self_ = self.clone();
         self.spawn(async move {
             loop {
-                tokio::time::sleep(Duration::from_millis(WORKER_PING_IN_MS)).await;
+                tokio::time::sleep(WORKER_PING_INTERVAL).await;
                 // If the primary is not synced, then do not broadcast the worker ping(s).
                 if !self_.sync.is_synced() {
                     trace!("Skipping worker ping(s) {}", "(node is syncing)".dimmed());
@@ -1375,7 +1374,7 @@ impl<N: Network> Primary<N> {
                 // Wait until the timeout or for is_ready=true.
                 tokio::select! {
                     _ = self_.is_ready_notify.notified() => {}
-                    _ = tokio::time::sleep(Duration::from_millis(MAX_BATCH_DELAY_IN_MS)) => {}
+                    _ = tokio::time::sleep(MAX_BATCH_DELAY) => {}
                 }
 
                 let current_round = self_.current_round();
@@ -1478,7 +1477,7 @@ impl<N: Network> Primary<N> {
         self.spawn(async move {
             loop {
                 // Sleep briefly.
-                tokio::time::sleep(Duration::from_millis(MAX_BATCH_DELAY_IN_MS)).await;
+                tokio::time::sleep(MAX_BATCH_DELAY).await;
                 // If the primary is not synced, then do not increment to the next round.
                 if !self_.sync.is_synced() {
                     trace!("Skipping round increment {}", "(node is syncing)".dimmed());
@@ -1671,7 +1670,7 @@ impl<N: Network> Primary<N> {
             .checked_sub(previous_timestamp)
             .ok_or_else(|| anyhow!("Timestamp cannot be before the previous certificate at round {previous_round}"))?;
         // Ensure that the previous certificate was created at least `MIN_BATCH_DELAY_IN_SECS` seconds ago.
-        match elapsed < MIN_BATCH_DELAY_IN_SECS as i64 {
+        match elapsed < MIN_BATCH_DELAY.as_secs() as i64 {
             true => bail!("Timestamp is too soon after the previous certificate at round {previous_round}"),
             false => Ok(()),
         }
@@ -1685,7 +1684,7 @@ impl<N: Network> Primary<N> {
             .checked_sub(previous_timestamp)
             .ok_or_else(|| anyhow!("Timestamp cannot be before the previous certificate at round {previous_round}"))?;
         // Ensure that the previous certificate was created at least `MIN_BATCH_DELAY_IN_SECS` seconds ago.
-        match elapsed < MIN_BATCH_DELAY_IN_SECS as i64 {
+        match elapsed < MIN_BATCH_DELAY.as_secs() as i64 {
             true => bail!("Timestamp is too soon after the previous certificate at round {previous_round}"),
             false => Ok(()),
         }
@@ -2360,7 +2359,7 @@ mod tests {
         store_certificate_chain(&primary, &accounts, round, &mut rng);
 
         // Sleep for a while to ensure the primary is ready to propose the next round.
-        tokio::time::sleep(Duration::from_secs(MIN_BATCH_DELAY_IN_SECS)).await;
+        tokio::time::sleep(MIN_BATCH_DELAY).await;
 
         // Generate a solution and a transaction.
         let (solution_id, solution) = sample_unconfirmed_solution(&mut rng);
@@ -2427,7 +2426,7 @@ mod tests {
         }
 
         // Sleep for a while to ensure the primary is ready to propose the next round.
-        tokio::time::sleep(Duration::from_secs(MIN_BATCH_DELAY_IN_SECS)).await;
+        tokio::time::sleep(MIN_BATCH_DELAY).await;
 
         // Advance to the next round.
         assert!(primary.storage.increment_to_next_round(round).is_ok());
@@ -2492,7 +2491,7 @@ mod tests {
         let round = 1;
         let peer_account = &accounts[1];
         let peer_ip = peer_account.0;
-        let timestamp = now() + MIN_BATCH_DELAY_IN_SECS as i64;
+        let timestamp = now() + MIN_BATCH_DELAY.as_secs() as i64;
         let proposal = create_test_proposal(
             &peer_account.1,
             primary.ledger.current_committee().unwrap(),
@@ -2531,7 +2530,7 @@ mod tests {
         let round = 1;
         let peer_account = &accounts[1];
         let peer_ip = peer_account.0;
-        let timestamp = now() + MIN_BATCH_DELAY_IN_SECS as i64;
+        let timestamp = now() + MIN_BATCH_DELAY.as_secs() as i64;
         let proposal = create_test_proposal(
             &peer_account.1,
             primary.ledger.current_committee().unwrap(),
@@ -2571,7 +2570,7 @@ mod tests {
         // Create a valid proposal with an author that isn't the primary.
         let peer_account = &accounts[1];
         let peer_ip = peer_account.0;
-        let timestamp = now() + MIN_BATCH_DELAY_IN_SECS as i64;
+        let timestamp = now() + MIN_BATCH_DELAY.as_secs() as i64;
         let proposal = create_test_proposal(
             &peer_account.1,
             primary.ledger.current_committee().unwrap(),
@@ -2608,7 +2607,7 @@ mod tests {
         let round = 1;
         let peer_account = &accounts[1];
         let peer_ip = peer_account.0;
-        let timestamp = now() + MIN_BATCH_DELAY_IN_SECS as i64;
+        let timestamp = now() + MIN_BATCH_DELAY.as_secs() as i64;
         let proposal = create_test_proposal(
             &peer_account.1,
             primary.ledger.current_committee().unwrap(),
@@ -2654,7 +2653,7 @@ mod tests {
         // Create a valid proposal with an author that isn't the primary.
         let peer_account = &accounts[1];
         let peer_ip = peer_account.0;
-        let timestamp = now() + MIN_BATCH_DELAY_IN_SECS as i64;
+        let timestamp = now() + MIN_BATCH_DELAY.as_secs() as i64;
         let proposal = create_test_proposal(
             &peer_account.1,
             primary.ledger.current_committee().unwrap(),
@@ -2710,7 +2709,7 @@ mod tests {
             .get_certificate_for_round_with_author(round - 1, peer_account.1.address())
             .expect("No previous proposal exists")
             .timestamp();
-        let invalid_timestamp = last_timestamp + (MIN_BATCH_DELAY_IN_SECS as i64) - 1;
+        let invalid_timestamp = last_timestamp + (MIN_BATCH_DELAY.as_secs() as i64) - 1;
 
         let proposal = create_test_proposal(
             &peer_account.1,
@@ -2764,7 +2763,7 @@ mod tests {
         let peer_account = &accounts[2];
         let peer_ip = peer_account.0;
 
-        let timestamp = now() + MIN_BATCH_DELAY_IN_SECS as i64;
+        let timestamp = now() + MIN_BATCH_DELAY.as_secs() as i64;
 
         let proposal =
             create_test_proposal(&peer_account.1, committee, round, Default::default(), timestamp, 4, &mut rng);
@@ -2824,7 +2823,7 @@ mod tests {
         let (old_proposal_round, old_proposal_timestamp) =
             primary.latest_proposed_batch.read().await.map(|(round, timestamp)| (round, timestamp)).unwrap_or((0, 0));
         *primary.latest_proposed_batch.write().await =
-            Some((round + 1, old_proposal_timestamp + MIN_BATCH_DELAY_IN_SECS as i64));
+            Some((round + 1, old_proposal_timestamp + MIN_BATCH_DELAY.as_secs() as i64));
 
         // Propose a batch and enforce that it fails.
         assert!(primary.propose_batch().await.is_ok());
@@ -2876,7 +2875,7 @@ mod tests {
 
         // Create a valid proposal.
         let round = 1;
-        let timestamp = now() + MIN_BATCH_DELAY_IN_SECS as i64;
+        let timestamp = now() + MIN_BATCH_DELAY.as_secs() as i64;
         let proposal = create_test_proposal(
             primary.gateway.account(),
             primary.ledger.current_committee().unwrap(),
@@ -2951,7 +2950,7 @@ mod tests {
 
         // Create a valid proposal.
         let round = 1;
-        let timestamp = now() + MIN_BATCH_DELAY_IN_SECS as i64;
+        let timestamp = now() + MIN_BATCH_DELAY.as_secs() as i64;
         let proposal = create_test_proposal(
             primary.gateway.account(),
             primary.ledger.current_committee().unwrap(),
@@ -2989,7 +2988,7 @@ mod tests {
         let previous_certificates = store_certificate_chain(&primary, &accounts, round, &mut rng);
 
         // Create a valid proposal.
-        let timestamp = now() + MIN_BATCH_DELAY_IN_SECS as i64;
+        let timestamp = now() + MIN_BATCH_DELAY.as_secs() as i64;
         let proposal = create_test_proposal(
             primary.gateway.account(),
             primary.ledger.current_committee().unwrap(),

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -399,7 +399,6 @@ impl<N: Network> Primary<N> {
 }
 
 #[async_trait::async_trait]
-#[async_trait::async_trait]
 impl<N: Network> proposal_task::BatchPropose for Primary<N> {
     fn current_round(&self) -> u64 {
         Primary::current_round(self)

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -143,7 +143,7 @@ pub struct Primary<N: Network> {
     /// Holds the most recent round and timestamp that the primary proposed a batch for.
     /// TODO(kaimast): avoiding using an async lock here, so this can be merged with the `proposed_batch`,
     /// to have a unified `primary_state` field.
-    latest_proposed_batch: Arc<TRwLock<Option<(u64, i64)>>>,
+    latest_proposal_timestamp: Arc<TRwLock<Option<(u64, i64)>>>,
 
     /// The recently-signed batch proposals.
     signed_proposals: Arc<RwLock<SignedProposals<N>>>,
@@ -205,7 +205,7 @@ impl<N: Network> Primary<N> {
             proposed_batch: Default::default(),
             #[cfg(feature = "metrics")]
             batch_propose_start: Default::default(),
-            latest_proposed_batch: Default::default(),
+            latest_proposal_timestamp: Default::default(),
             signed_proposals: Default::default(),
             handles: Default::default(),
             proposal_task: Default::default(),
@@ -224,7 +224,7 @@ impl<N: Network> Primary<N> {
                     let (latest_certificate_round, proposed_batch, signed_proposals, pending_certificates) =
                         proposal_cache.into();
 
-                    *self.latest_proposed_batch.write().await = Some((latest_certificate_round, now()));
+                    *self.latest_proposal_timestamp.write().await = Some((latest_certificate_round, now()));
                     *self.proposed_batch.write() = proposed_batch;
                     *self.signed_proposals.write() = signed_proposals;
 
@@ -427,7 +427,7 @@ impl<N: Network> proposal_task::BatchPropose for Primary<N> {
         //
         // Note, in the current design, this function is only invoked from the batch proposal task, and it is technically
         // not possible for there to be concurrent invocations of the function, but we keep this lock for now.
-        let mut lock_guard = self.latest_proposed_batch.write().await;
+        let mut lock_guard = self.latest_proposal_timestamp.write().await;
 
         // Check if the proposed batch has expired, and clear it if it has expired.
         if let Err(err) = self
@@ -1250,7 +1250,7 @@ impl<N: Network> Primary<N> {
         // Determine if we are currently proposing a round that is relevant.
         // Note: This is important, because while our peers have advanced,
         // they may not be proposing yet, and thus still able to sign our proposed batch.
-        let should_advance = match &*self.latest_proposed_batch.read().await {
+        let should_advance = match &*self.latest_proposal_timestamp.read().await {
             // We advance if the proposal round is less than the current round that was just certified.
             Some((latest_round, _)) => *latest_round < certificate_round,
             // If there's no proposal, we consider advancing.
@@ -2066,7 +2066,7 @@ impl<N: Network> Primary<N> {
             let latest_round = proposal
                 .as_ref()
                 .map(Proposal::round)
-                .unwrap_or(self.latest_proposed_batch.read().await.map(|(round, _)| round).unwrap_or(0));
+                .unwrap_or(self.latest_proposal_timestamp.read().await.map(|(round, _)| round).unwrap_or(0));
             let pending_certificates = self.storage.get_pending_certificates();
             ProposalCache::new(latest_round, proposal, signed_proposals, pending_certificates)
         };
@@ -2861,9 +2861,13 @@ mod tests {
         primary.workers()[0].process_unconfirmed_transaction(transaction_id, transaction).await.unwrap();
 
         // Set the proposal lock to a round ahead of the storage.
-        let (old_proposal_round, old_proposal_timestamp) =
-            primary.latest_proposed_batch.read().await.map(|(round, timestamp)| (round, timestamp)).unwrap_or((0, 0));
-        *primary.latest_proposed_batch.write().await =
+        let (old_proposal_round, old_proposal_timestamp) = primary
+            .latest_proposal_timestamp
+            .read()
+            .await
+            .map(|(round, timestamp)| (round, timestamp))
+            .unwrap_or((0, 0));
+        *primary.latest_proposal_timestamp.write().await =
             Some((round + 1, old_proposal_timestamp + MIN_BATCH_DELAY.as_secs() as i64));
 
         // Propose a batch and enforce that it fails.
@@ -2871,7 +2875,7 @@ mod tests {
         assert!(primary.proposed_batch.read().is_none());
 
         // Set the proposal lock back to the old round.
-        *primary.latest_proposed_batch.write().await = Some((old_proposal_round, old_proposal_timestamp));
+        *primary.latest_proposal_timestamp.write().await = Some((old_proposal_round, old_proposal_timestamp));
 
         // Try to propose a batch again. This time, it should succeed.
         assert!(primary.propose_batch().await.is_ok());

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use crate::{
+    CREATE_BATCH_INTERVAL,
     Gateway,
     MAX_BATCH_DELAY,
     MAX_WORKERS,
@@ -76,13 +77,13 @@ use locktick::{
 use parking_lot::{Mutex, RwLock};
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
-#[cfg(feature = "metrics")]
-use std::time::Instant;
 use std::{
     collections::{HashMap, HashSet},
     future::Future,
     net::SocketAddr,
+    pin::Pin,
     sync::{Arc, OnceLock},
+    time::Instant,
 };
 #[cfg(not(feature = "locktick"))]
 use tokio::sync::RwLock as TRwLock;
@@ -92,11 +93,17 @@ use tokio::{sync::Notify, task::JoinHandle};
 pub(crate) type ProposedBatch<N> = RwLock<Option<Proposal<N>>>;
 
 /// This callback trait allows listening to changes in the Primary, such as round advancement.
-/// This is currently used by BFT.
+/// This is implemented by [`BFT`].
 #[async_trait::async_trait]
 pub trait PrimaryCallback<N: Network>: Send + std::marker::Sync {
-    /// Notifies that a new round has started.
-    fn update_to_next_round(&self, current_round: u64) -> bool;
+    /// Asks the callback to if we can move to the next round.
+    ///
+    /// # Arguments
+    /// * `current_round` - the round the Primary is in (to avoid race conditions)
+    ///
+    /// # Returns
+    /// `true` if we moved to the next round.
+    fn try_advance_to_next_round(&self, current_round: u64) -> bool;
 
     /// Add a certificated that was created by the primary or received from a peer.
     async fn add_new_certificate(&self, certificate: BatchCertificate<N>) -> Result<()>;
@@ -116,6 +123,7 @@ pub struct Primary<N: Network> {
     ledger: Arc<dyn LedgerService<N>>,
     /// The workers.
     workers: Arc<OnceLock<Vec<Worker<N>>>>,
+
     /// The primary callback (used by [`BFT`]).
     primary_callback: Arc<CallbackHandle<Arc<dyn PrimaryCallback<N>>>>,
 
@@ -143,6 +151,10 @@ pub struct Primary<N: Network> {
 
     /// Allows notifying the proposal taks when a new batch can be proposed.
     is_ready_notify: Arc<Notify>,
+
+    /// Used to wake up a the dedicated round-increment task, if we may be able to advance to the next round.
+    /// This is used, so the timeout for round advancement is reset on every round increment.
+    round_increment_notify: Arc<Notify>,
 }
 
 impl<N: Network> Primary<N> {
@@ -192,6 +204,7 @@ impl<N: Network> Primary<N> {
             signed_proposals: Default::default(),
             handles: Default::default(),
             is_ready_notify: Default::default(),
+            round_increment_notify: Default::default(),
         })
     }
 
@@ -391,7 +404,11 @@ impl<N: Network> Primary<N> {
     /// 3. Set the batch proposal in the primary.
     /// 4. Broadcast the batch header to all validators for signing.
     ///
-    pub async fn propose_batch(&self) -> Result<()> {
+    /// # Returns
+    /// - `Ok(true)` if the batch was proposed.
+    /// - `Ok(false)` if the batch was not proposed for a benign reason, e.g., the timestamp is too soon after the previous certificate.
+    /// - `Err(err)` if an unexpected error occured.
+    pub async fn propose_batch(&self) -> Result<bool> {
         // Ensure there are not concurrent executions of this function.
         //
         // Note, in the current design, this function is only invoked from the batch proposal task, and it is technically
@@ -404,7 +421,7 @@ impl<N: Network> Primary<N> {
             .with_context(|| "Failed to check the proposed batch for expiration")
         {
             warn!("{}", flatten_error(&err));
-            return Ok(());
+            return Ok(false);
         }
 
         // Retrieve the current round.
@@ -422,7 +439,7 @@ impl<N: Network> Primary<N> {
             && round < *latest_round
         {
             warn!("Cannot propose a batch for round {round} - the latest proposal cache round is {latest_round}");
-            return Ok(());
+            return Ok(false);
         }
 
         // If there is a batch being proposed already,
@@ -440,7 +457,7 @@ impl<N: Network> Primary<N> {
                     "Cannot propose a batch for round {} - the current storage (round {round}) is not caught up to the proposed batch.",
                     proposal.round(),
                 );
-                return Ok(());
+                return Ok(false);
             }
             // Construct the event.
             // TODO(ljedrz): the BatchHeader should be serialized only once in advance before being sent to non-signers.
@@ -464,7 +481,7 @@ impl<N: Network> Primary<N> {
                 }
             }
             debug!("Proposed batch for round {} is still valid", proposal.round());
-            return Ok(());
+            return Ok(false);
         }
 
         #[cfg(feature = "metrics")]
@@ -472,28 +489,22 @@ impl<N: Network> Primary<N> {
 
         // Ensure that the primary does not create a new proposal too quickly.
         if let Some((_, latest_timestamp)) = &*lock_guard
-            && let Err(err) = self.check_own_proposal_timesatmp(previous_round, *latest_timestamp, now())
+            && !self.check_own_proposal_timestamp(previous_round, *latest_timestamp, now())?
         {
-            debug!(
-                "{}",
-                flatten_error(err.context(format!("Primary is safely skipping a batch proposal for round {round}")))
-            );
-            return Ok(());
+            return Ok(false);
         }
 
         // Ensure the primary has not proposed a batch for this round before.
         if self.storage.contains_certificate_in_round_from(round, self.gateway.account().address()) {
             // If a BFT sender was provided, attempt to advance the current round.
             if let Some(cb) = &*self.primary_callback.get_ref() {
-                match cb.update_to_next_round(self.current_round()) {
-                    // 'is_ready' is true if the primary is ready to propose a batch for the next round.
+                match cb.try_advance_to_next_round(self.current_round()) {
                     true => (), // continue,
-                    // 'is_ready' is false if the primary is not ready to propose a batch for the next round.
-                    false => return Ok(()),
+                    false => return Ok(false),
                 }
             }
             debug!("Primary is safely skipping {}", format!("(round {round} was already certified)").dimmed());
-            return Ok(());
+            return Ok(false);
         }
 
         // Determine if the current round has been proposed.
@@ -505,7 +516,7 @@ impl<N: Network> Primary<N> {
             && *latest_round == round
         {
             debug!("Primary is safely skipping a batch proposal - round {round} already proposed");
-            return Ok(());
+            return Ok(false);
         }
 
         // Retrieve the committee to check against.
@@ -523,7 +534,7 @@ impl<N: Network> Primary<N> {
                     "(please connect to more validators)".dimmed()
                 );
                 trace!("Primary is connected to {} validators", connected_validators.len() - 1);
-                return Ok(());
+                return Ok(false);
             }
         }
 
@@ -552,7 +563,7 @@ impl<N: Network> Primary<N> {
                 "Primary is safely skipping a batch proposal for round {round} {}",
                 format!("(previous round {previous_round} has not reached quorum)").dimmed()
             );
-            return Ok(());
+            return Ok(false);
         }
 
         // Initialize the map of transmissions.
@@ -738,7 +749,7 @@ impl<N: Network> Primary<N> {
             *self.batch_propose_start.lock() = Some(Instant::now());
         }
 
-        Ok(())
+        Ok(true)
     }
 
     /// Processes a batch propose from a peer.
@@ -1236,7 +1247,7 @@ impl<N: Network> Primary<N> {
         // Determine whether to advance to the next round.
         if is_quorum && should_advance && certificate_round >= current_round {
             // If we have reached the quorum threshold and the round should advance, then proceed to the next round.
-            self.try_increment_to_the_next_round(current_round + 1).await?;
+            self.round_increment_notify.notify_one();
         }
         Ok(())
     }
@@ -1247,8 +1258,8 @@ impl<N: Network> Primary<N> {
     ///
     /// For each receiver in the `primary_receiver` struct, there will be a dedicated task
     /// that awaits new data and handles it accordingly.
-    /// Additionally, this spawns a task that periodically issues PrimaryPings and one that periodically
-    /// tries to move the the next round of batches.
+    /// Additionally, this spawns a task that periodically issues PrimaryPings and one that
+    /// tries to move to the next round when triggered (e.g. after a certificate is stored) or on a timeout.
     ///
     /// This function is called exactly once, in `Self::run()`.
     fn start_handlers(&self, primary_receiver: PrimaryReceiver<N>) {
@@ -1370,25 +1381,52 @@ impl<N: Network> Primary<N> {
         // Start the batch proposal task.
         let self_ = self.clone();
         self.spawn(async move {
+            // Each outer loop iteration represents one new proposed batch.
             loop {
-                // Wait until the timeout or for is_ready=true.
-                tokio::select! {
-                    _ = self_.is_ready_notify.notified() => {}
-                    _ = tokio::time::sleep(MAX_BATCH_DELAY) => {}
-                }
-
+                let round_start = Instant::now();
                 let current_round = self_.current_round();
-                // If the primary is not synced, then do not propose a batch.
-                if !self_.sync.is_synced() {
-                    debug!("Skipping batch proposal for round {current_round} {}", "(node is syncing)".dimmed());
-                    continue;
-                }
 
-                // If there is no proposed batch, attempt to propose a batch.
-                // Note: Do NOT spawn a task around this function call. Proposing a batch is a critical path,
-                // and only one batch needs to be proposed at a time.
-                if let Err(err) = self_.propose_batch().await {
-                    warn!("{}", flatten_error(err.context("Cannot propose a batch")));
+                // The inner loop represents multiple attempts to propose a batch within the same round.
+                // Propose a batch within the same round until the timeout is triggered, or the round is advanced by some other means.
+                while self_.current_round() == current_round {
+                    // Assemble a list of conditions that will trigger the primary to attempt batch creation.
+                    let mut futures: Vec<Pin<Box<dyn Future<Output = ()> + Send>>> = vec![];
+
+                    // Always wait for is_ready
+                    futures.push(Box::pin(self_.is_ready_notify.notified()));
+
+                    // If the maximum batch delay has not been reached, wait for it.
+                    // Otherwise, add a small timeout to avoid busy waiting.
+                    //
+                    // TODO(kaimast): ideally, we do not need the minimum timeout at all after MAX_BATCH_DELAY,
+                    // but that would need more testing to ensure this loop never gets stuck.
+                    let timeout = MAX_BATCH_DELAY.saturating_sub(round_start.elapsed()).max(CREATE_BATCH_INTERVAL);
+                    futures.push(Box::pin(tokio::time::sleep(timeout)));
+
+                    // If the node is not synced yet, wait for block sync to complete.
+                    if let Some(fut) = self_.sync.wait_for_synced_if_syncing() {
+                        futures.push(fut);
+                    }
+
+                    // Wait until one of the conditions is met.
+                    futures::future::select_all(futures).await;
+
+                    // If the primary is not synced, then do not propose a batch.
+                    if !self_.sync.is_synced() {
+                        debug!("Skipping batch proposal for round {current_round} {}", "(node is syncing)".dimmed());
+                        continue;
+                    }
+
+                    // If there is no proposed batch, attempt to propose a batch.
+                    // Note: Do NOT spawn a task around this function call. Proposing a batch is a critical path,
+                    // and only one batch needs to be proposed at a time.
+                    match self_.propose_batch().await {
+                        Ok(true) => break,
+                        Ok(false) => (), // retry
+                        Err(err) => {
+                            warn!("{}", flatten_error(err.context("Cannot propose a batch")));
+                        }
+                    }
                 }
             }
         });
@@ -1402,6 +1440,7 @@ impl<N: Network> Primary<N> {
                     trace!("Skipping a batch proposal from '{peer_ip}' {}", "(node is syncing)".dimmed());
                     continue;
                 }
+
                 // Spawn a task to process the proposed batch.
                 let self_ = self_.clone();
                 tokio::spawn(async move {
@@ -1469,44 +1508,53 @@ impl<N: Network> Primary<N> {
             }
         });
 
-        // This task periodically tries to move to the next round.
-        //
-        // Note: This is necessary to ensure that the primary is not stuck on a previous round
-        // despite having received enough certificates to advance to the next round.
+        // This task tries to move to the next round when triggered (e.g. after a certificate is stored)
+        // or after a timeout, so we are not stuck on a previous round despite having quorum.
         let self_ = self.clone();
         self.spawn(async move {
             loop {
-                // Sleep briefly.
-                tokio::time::sleep(MAX_BATCH_DELAY).await;
-                // If the primary is not synced, then do not increment to the next round.
-                if !self_.sync.is_synced() {
-                    trace!("Skipping round increment {}", "(node is syncing)".dimmed());
-                    continue;
-                }
-                // Attempt to increment to the next round.
+                let round_start = Instant::now();
                 let current_round = self_.current_round();
-                let next_round = current_round.saturating_add(1);
-                // Determine if the quorum threshold is reached for the current round.
-                let is_quorum_threshold_reached = {
-                    // Retrieve the certificate authors for the current round.
-                    let authors = self_.storage.get_certificate_authors_for_round(current_round);
-                    // If there are no certificates, then skip this check.
-                    if authors.is_empty() {
+
+                // Inner loop: wait and try to increment while we're still in the same round.
+                while self_.current_round() == current_round {
+                    let mut futures: Vec<Pin<Box<dyn Future<Output = ()> + Send>>> =
+                        vec![Box::pin(self_.round_increment_notify.notified())];
+
+                    if let Some(remaining_delay) = MAX_BATCH_DELAY.checked_sub(round_start.elapsed())
+                        && !remaining_delay.is_zero()
+                    {
+                        futures.push(Box::pin(tokio::time::sleep(remaining_delay)));
+                    }
+                    if !self_.sync.is_synced() {
+                        futures.push(Box::pin(self_.sync.wait_for_synced()));
+                    }
+                    let _ = futures::future::select_all(futures).await;
+
+                    if !self_.sync.is_synced() {
+                        trace!("Skipping round increment {}", "(node is syncing)".dimmed());
                         continue;
                     }
-                    // Retrieve the committee lookback for the current round.
-                    let Ok(committee_lookback) = self_.ledger.get_committee_lookback_for_round(current_round) else {
-                        warn!("Failed to retrieve the committee lookback for round {current_round}");
-                        continue;
+
+                    let next_round = current_round.saturating_add(1);
+                    let is_quorum_threshold_reached = {
+                        let authors = self_.storage.get_certificate_authors_for_round(current_round);
+                        if authors.is_empty() {
+                            continue;
+                        }
+                        let Ok(committee_lookback) = self_.ledger.get_committee_lookback_for_round(current_round)
+                        else {
+                            warn!("Failed to retrieve the committee lookback for round {current_round}");
+                            continue;
+                        };
+                        committee_lookback.is_quorum_threshold_reached(&authors)
                     };
-                    // Check if the quorum threshold is reached for the current round.
-                    committee_lookback.is_quorum_threshold_reached(&authors)
-                };
-                // Attempt to increment to the next round if the quorum threshold is reached.
-                if is_quorum_threshold_reached {
-                    debug!("Quorum threshold reached for round {current_round}");
-                    if let Err(err) = self_.try_increment_to_the_next_round(next_round).await {
-                        warn!("{}", flatten_error(err.context("Failed to increment to the next round")));
+
+                    if is_quorum_threshold_reached {
+                        debug!("Quorum threshold reached for round {current_round}");
+                        if let Err(err) = self_.try_increment_to_the_next_round(next_round).await {
+                            warn!("{}", flatten_error(err.context("Failed to increment to the next round")));
+                        }
                     }
                 }
             }
@@ -1605,7 +1653,7 @@ impl<N: Network> Primary<N> {
         if current_round < next_round {
             // If a BFT sender was provided, send the current round to the BFT.
             let is_ready = if let Some(cb) = self.primary_callback.get() {
-                cb.update_to_next_round(current_round)
+                cb.try_advance_to_next_round(current_round)
             }
             // Otherwise, handle the Narwhal case.
             else {
@@ -1615,14 +1663,13 @@ impl<N: Network> Primary<N> {
                 true
             };
 
-            // Log whether the next round is ready.
-            match is_ready {
-                true => debug!("Primary is ready to propose the next round"),
-                false => debug!("Primary is not ready to propose the next round"),
+            // Notify the proposal task if the new round is ready.
+            if is_ready && self.is_synced() {
+                debug!("Primary is ready to propose the next round");
+                self.is_ready_notify.notify_one();
+            } else {
+                debug!("Primary is not ready to propose the next round");
             }
-
-            // If the node is ready, wake up the proposal task.
-            self.is_ready_notify.notify_one();
         }
         Ok(())
     }
@@ -1659,7 +1706,7 @@ impl<N: Network> Primary<N> {
 
         // Retrieve the timestamp of the previous timestamp to check against.
         let previous_timestamp = match self.storage.get_certificate_for_round_with_author(previous_round, author) {
-            // Ensure that the previous certificate was created at least `MIN_BATCH_DELAY_IN_SECS` seconds ago.
+            // Ensure that the previous certificate was created at least `MIN_BATCH_DELAY` seconds ago.
             Some(certificate) => certificate.timestamp(),
             // If we do not see a previous certificate for the author, then proceed optimistically.
             None => return Ok(()),
@@ -1669,7 +1716,7 @@ impl<N: Network> Primary<N> {
         let elapsed = timestamp
             .checked_sub(previous_timestamp)
             .ok_or_else(|| anyhow!("Timestamp cannot be before the previous certificate at round {previous_round}"))?;
-        // Ensure that the previous certificate was created at least `MIN_BATCH_DELAY_IN_SECS` seconds ago.
+        // Ensure that the previous certificate was created at least `MIN_BATCH_DELAY` seconds ago.
         match elapsed < MIN_BATCH_DELAY.as_secs() as i64 {
             true => bail!("Timestamp is too soon after the previous certificate at round {previous_round}"),
             false => Ok(()),
@@ -1678,25 +1725,38 @@ impl<N: Network> Primary<N> {
 
     /// Ensure the primary is not creating batch proposals too frequently.
     /// This checks that the certificate timestamp for the previous round is within the expected range.
-    fn check_own_proposal_timesatmp(&self, previous_round: u64, previous_timestamp: i64, timestamp: i64) -> Result<()> {
+    ///
+    /// # Returns
+    /// - `Ok(true)` if the timestamp allows a new proposal.
+    /// - `Ok(false)` if the timestamp is valid but too soon after the previous proposal.
+    /// - `Err(err)` if an unexpected error occured, such as the timestamp being before the previous certificate.
+    fn check_own_proposal_timestamp(
+        &self,
+        previous_round: u64,
+        previous_timestamp: i64,
+        timestamp: i64,
+    ) -> Result<bool> {
         // Determine the elapsed time since the previous timestamp.
         let elapsed = timestamp
             .checked_sub(previous_timestamp)
             .ok_or_else(|| anyhow!("Timestamp cannot be before the previous certificate at round {previous_round}"))?;
-        // Ensure that the previous certificate was created at least `MIN_BATCH_DELAY_IN_SECS` seconds ago.
-        match elapsed < MIN_BATCH_DELAY.as_secs() as i64 {
-            true => bail!("Timestamp is too soon after the previous certificate at round {previous_round}"),
-            false => Ok(()),
-        }
+
+        Ok(elapsed >= MIN_BATCH_DELAY.as_secs() as i64)
     }
 
     /// Stores the certified batch and broadcasts it to all validators, returning the certificate.
     async fn store_and_broadcast_certificate(&self, proposal: &Proposal<N>, committee: &Committee<N>) -> Result<()> {
         // Create the batch certificate and transmissions.
         let (certificate, transmissions) = tokio::task::block_in_place(|| proposal.to_certificate(committee))?;
+
         // Convert the transmissions into a HashMap.
         // Note: Do not change the `Proposal` to use a HashMap. The ordering there is necessary for safety.
         let transmissions = transmissions.into_iter().collect::<HashMap<_, _>>();
+
+        // Store some metadata about the certified batch.
+        let round = certificate.round();
+        let num_transmissions = certificate.transmission_ids().len();
+
         // Store the certified batch.
         let (storage, certificate_) = (self.storage.clone(), certificate.clone());
         spawn_blocking!(storage.insert_certificate(certificate_, transmissions, Default::default()))?;
@@ -1704,23 +1764,26 @@ impl<N: Network> Primary<N> {
         // If a BFT sender was provided, send the certificate to the BFT.
         if let Some(cb) = self.primary_callback.get() {
             // Await the callback to continue.
-            cb.add_new_certificate(certificate.clone())
-                .await
-                .with_context(|| "Failed to add new certificate from primary")?;
+            cb.add_new_certificate(certificate.clone()).await.with_context(|| {
+                format!("Failed to insert our newly certified batch for round {round} into the DAG")
+            })?;
         }
         // Broadcast the certified batch to all validators.
-        self.gateway.broadcast(Event::BatchCertified(certificate.clone().into()));
+        self.gateway.broadcast(Event::BatchCertified(certificate.into()));
+
         // Log the certified batch.
-        let num_transmissions = certificate.transmission_ids().len();
-        let round = certificate.round();
         info!("Our batch with {num_transmissions} transmissions for round {round} was certified!");
+
         // Record the certification latency (time from batch proposal to certification).
         #[cfg(feature = "metrics")]
         if let Some(start) = self.batch_propose_start.lock().take() {
             metrics::histogram(metrics::bft::BATCH_CERTIFICATION_LATENCY, start.elapsed().as_secs_f64());
         }
-        // Increment to the next round.
-        self.try_increment_to_the_next_round(round + 1).await
+
+        // Wake up the round increment task to re-check quorum.
+        self.round_increment_notify.notify_one();
+
+        Ok(())
     }
 
     /// Inserts the missing transmissions from the proposal into the workers.
@@ -1797,6 +1860,8 @@ impl<N: Network> Primary<N> {
             if let Some(cb) = self.primary_callback.get() {
                 cb.add_new_certificate(certificate).await.with_context(|| "Failed to update the DAG from sync")?;
             }
+            // Wake the round-increment task to re-check quorum.
+            self.round_increment_notify.notify_one();
         }
         Ok(())
     }
@@ -1840,7 +1905,9 @@ impl<N: Network> Primary<N> {
         // If our primary is far behind the peer, update our committee to the batch round.
         if is_behind_schedule || is_peer_far_in_future {
             // If the batch round is greater than the current committee round, update the committee.
-            self.try_increment_to_the_next_round(batch_round).await?;
+            self.try_increment_to_the_next_round(batch_round)
+                .await
+                .with_context(|| "Failed to fast forward current round")?;
         }
 
         // Ensure the primary has all of the transmissions.
@@ -2899,6 +2966,8 @@ mod tests {
 
         // Check the certificate was created and stored by the primary.
         assert!(primary.storage.contains_certificate_in_round_from(round, primary.gateway.account().address()));
+        // Manually attempt round advancement (because the handler is not running).
+        primary.try_increment_to_the_next_round(round + 1).await.unwrap();
         // Check the round was incremented.
         assert_eq!(primary.current_round(), round + 1);
     }
@@ -2938,6 +3007,8 @@ mod tests {
 
         // Check the certificate was created and stored by the primary.
         assert!(primary.storage.contains_certificate_in_round_from(round, primary.gateway.account().address()));
+        // Manually attempt round advancement (because the handler is not running).
+        primary.try_increment_to_the_next_round(round + 1).await.unwrap();
         // Check the round was incremented.
         assert_eq!(primary.current_round(), round + 1);
     }

--- a/node/bft/src/primary/proposal_task.rs
+++ b/node/bft/src/primary/proposal_task.rs
@@ -171,8 +171,12 @@ impl<N: Network> ProposalTask<N> {
                     let timeout = MAX_BATCH_DELAY.saturating_sub(round_start.elapsed());
                     futures.push(tokio::time::sleep(timeout).boxed());
 
-                    // All conditions must hold for us to advance.
-                    futures::future::join_all(futures).await;
+                    // Any condition completing is sufficient to attempt a proposal.
+                    // Using select_all (not join_all) ensures that once MAX_BATCH_DELAY elapses
+                    // we call propose_batch() even if signal() was never fired — which happens
+                    // when an even round has no leader cert. propose_batch() calls
+                    // try_advance_to_next_round, which checks the leader-certificate timer.
+                    futures::future::select_all(futures).await;
                     reached_min_batch_delay = true;
                 }
 
@@ -369,6 +373,71 @@ mod tests {
         tokio::task::yield_now().await;
 
         assert_eq!(propose_count.load(Ordering::SeqCst), 0, "propose_batch called despite round advancement");
+    }
+
+    /// Tests the following scenario
+    ///
+    ///   1. A batch was already certified for the current round, so `is_proposal_ready` is `false`.
+    ///   2. `signal()` is **never** called externally — the BFT cannot advance the round until
+    ///      `propose_batch()` is called (which internally checks the leader-certificate timer).
+    #[test_log::test(tokio::test)]
+    async fn test_proposal_task_advances_without_leader_cert() {
+        // Start NOT ready: simulates a batch that was already certified for the round but the
+        // round has not yet advanced (the even-round leader cert was missing — e.g. the elected
+        // leader was one of the freshly-reset minority validators).
+        let task = ProposalTask::<MainnetV0> {
+            inner: Arc::new(ProposalTaskInner {
+                is_proposal_ready: RwLock::new(false),
+                is_ready_notify: Notify::new(),
+            }),
+            _phantom: PhantomData,
+        };
+
+        let proposed_notify = Arc::new(Notify::new());
+        let propose_count = Arc::new(AtomicU32::new(0));
+
+        // A proposer that stays on round 1 and returns Ok(true) on every call to
+        // propose_batch(), simulating try_advance_to_next_round finding the leader-certificate
+        // timer expired and advancing the round without an external signal().
+        struct NoSignalProposer {
+            propose_count: Arc<AtomicU32>,
+            proposed_notify: Arc<Notify>,
+        }
+
+        #[async_trait::async_trait]
+        impl BatchPropose for NoSignalProposer {
+            fn current_round(&self) -> u64 {
+                1
+            }
+
+            fn is_synced(&self) -> bool {
+                true
+            }
+
+            fn wait_for_synced_if_syncing(&self) -> Option<BoxFuture<'_, ()>> {
+                None
+            }
+
+            async fn propose_batch(&self) -> Result<bool> {
+                self.propose_count.fetch_add(1, Ordering::SeqCst);
+                self.proposed_notify.notify_one();
+                Ok(true)
+            }
+        }
+
+        let proposer =
+            NoSignalProposer { propose_count: propose_count.clone(), proposed_notify: proposed_notify.clone() };
+
+        // signal() is intentionally never called — the task must retry on its own.
+        tokio::spawn(task.run(proposer));
+
+        // Allow enough time for MAX_BATCH_DELAY (2.5 s) to elapse plus the CREATE_BATCH_INTERVAL
+        // (250 ms) retry window. Use 10 s to give generous headroom on slow CI machines.
+        tokio::time::timeout(std::time::Duration::from_secs(10), proposed_notify.notified())
+            .await
+            .expect("propose_batch was not called");
+
+        assert!(propose_count.load(Ordering::SeqCst) >= 1, "propose_batch should have been called at least once");
     }
 
     /// When `propose_batch` returns `Ok(false)`, the task retries within the same round until

--- a/node/bft/src/primary/proposal_task.rs
+++ b/node/bft/src/primary/proposal_task.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{CREATE_BATCH_INTERVAL, MAX_BATCH_DELAY};
+use crate::{CREATE_BATCH_INTERVAL, MAX_BATCH_DELAY, MIN_BATCH_DELAY};
 
 use anyhow::Result;
 use colored::Colorize;
@@ -23,10 +23,10 @@ use locktick::parking_lot::RwLock;
 #[cfg(not(feature = "locktick"))]
 use parking_lot::RwLock;
 use snarkvm::{prelude::Network, utilities::flatten_error};
-use std::{marker::PhantomData, sync::Arc, time::Instant};
+use std::{marker::PhantomData, sync::Arc};
 use tokio::{
     sync::Notify,
-    time::{sleep, timeout},
+    time::{Instant, sleep, sleep_until},
 };
 use tracing::{debug, warn};
 
@@ -36,9 +36,6 @@ use tracing::{debug, warn};
 pub(super) trait BatchPropose: Send + Sync {
     /// Returns the current consensus round.
     fn current_round(&self) -> u64;
-
-    /// Reurns `true` if the node is fully synced.
-    fn is_synced(&self) -> bool;
 
     /// Returns `None` if the node is already synced; otherwise returns a future that resolves
     /// once sync completes.
@@ -100,29 +97,6 @@ impl<N: Network> ProposalTask<N> {
         self.inner.is_ready_notify.notify_one();
     }
 
-    /// Returns `None` if the primary is already ready to propose.
-    /// Otherwise returns a future that resolves once the primary becomes ready.
-    ///
-    /// Atomically registers the wakeup before releasing the readiness lock, so no signal is missed
-    /// between the state check and the registration.
-    fn wait_if_not_ready(&self) -> Option<BoxFuture<'_, ()>> {
-        let mut notified = Box::pin(self.inner.is_ready_notify.notified());
-        {
-            if *self.inner.is_proposal_ready.read() {
-                return None;
-            }
-            // Register the wakeup while still holding the lock, to avoid a missed notification.
-            notified.as_mut().enable();
-        }
-        Some(
-            async move {
-                notified.await;
-                self.wait().await;
-            }
-            .boxed(),
-        )
-    }
-
     /// Waits until the primary is ready to propose. Returns immediately if already ready.
     async fn wait(&self) {
         loop {
@@ -144,53 +118,49 @@ impl<N: Network> ProposalTask<N> {
     pub(super) async fn run<P: BatchPropose + 'static>(self, primary: P) {
         loop {
             let round_start = Instant::now();
-            let current_round = primary.current_round();
-            let mut reached_min_batch_delay = false;
+            let round = primary.current_round();
+            let mut leader_timeout_reached = false;
+            let mut attempt = 1;
 
             // The inner loop represents multiple attempts to propose a batch within the same round.
             // It exits when the round advances or a batch is successfully proposed.
-            while primary.current_round() == current_round {
-                // Assemble a list of conditions that will trigger the primary to attempt batch
-                // creation.
-                let mut futures = vec![];
-
-                // Wait for the primary to be ready to propose, unless it already is.
-                if let Some(fut) = self.wait_if_not_ready() {
-                    futures.push(fut);
-                }
-
-                // If the node is not synced yet, wait for block sync to complete.
-                if let Some(sync_fut) = primary.wait_for_synced_if_syncing() {
-                    futures.push(sync_fut);
-                }
-
-                // If the maximum batch delay has not been reached, wait for it.
-                // Otherwise, add a small timeout to avoid busy waiting.
-                if reached_min_batch_delay && futures.is_empty() {
-                    // If there are no futures to await on, sleep on `CREATE_BATCH_INTERVAL`
-                    // to avoid busy waiting.
-                    sleep(CREATE_BATCH_INTERVAL).await;
-                } else if reached_min_batch_delay {
-                    // Add a timeout to prevent nodes from getting stuck
-                    // (removing this would require more testing)
-                    let _ = timeout(CREATE_BATCH_INTERVAL, futures::future::join_all(futures)).await;
-                } else {
-                    let timeout = MAX_BATCH_DELAY.saturating_sub(round_start.elapsed());
-                    futures.push(sleep(timeout).boxed());
-
-                    // Any condition completing is sufficient to attempt a proposal.
-                    // Using select_all (not join_all) ensures that once MAX_BATCH_DELAY elapses
-                    // we call propose_batch() even if signal() was never fired — which happens
-                    // when an even round has no leader cert. propose_batch() calls
-                    // try_advance_to_next_round, which checks the leader-certificate timer.
-                    futures::future::select_all(futures).await;
-                    reached_min_batch_delay = true;
-                }
-
-                // If the primary is not synced, then do not propose a batch.
-                if !primary.is_synced() {
-                    debug!("Skipping batch proposal for round {current_round} {}", "(node is syncing)".dimmed());
+            while primary.current_round() == round {
+                // A node cannot propose while it is syncing. So, block here first.
+                if let Some(fut) = primary.wait_for_synced_if_syncing() {
+                    fut.await;
+                    // Restart the loop, as the current round may have changed.
                     continue;
+                }
+
+                // If the minimum batch delay has not been reached yet, wait for it first,
+                // as we cannot propose without it having elapsed in any case.e
+                // TODO(kaimast): the sleep time should be based on the timestamp of the previous batch
+                sleep_until(round_start + MIN_BATCH_DELAY).await;
+
+                // Wait for either the leader to time-out or for the proposal to be ready.
+                // Additionally, we add a smaller timeout here out of caution, to ensure node does not get stuck on this select! call.
+                tokio::select! {
+                                    _ = sleep_until(round_start + MAX_BATCH_DELAY) => {
+                                        if !leader_timeout_reached {
+                                            info!("Leader for round {round} timed out");
+                                        }
+                                        leader_timeout_reached = true;
+                                    },
+                                    _ = self.wait().boxed() => {},
+                                    _ = sleep(CREATE_BATCH_INTERVAL) => {
+                // Retry if the timeout triggered (but do not count it as a proper attempt).
+                                    debug!("Skipping batch proposal for round {round} {}", "(not ready yet)".dimmed());
+                                    continue;
+                                    }
+                                };
+
+                if attempt > 1 {
+                    // Sleep to avoid busy waiting, if all conditions were met
+                    // and we still need to retry.
+                    sleep(CREATE_BATCH_INTERVAL).await;
+
+                    // Print a log message to see how often these retries happen (or if ever).
+                    debug!("Retrying batch proposal for round {round} (attempt #{attempt})");
                 }
 
                 // If there is no proposed batch, attempt to propose a batch.
@@ -204,9 +174,12 @@ impl<N: Network> ProposalTask<N> {
                     }
                     Ok(false) => (), // retry
                     Err(err) => {
+                        // Log warning and retry
                         warn!("{}", flatten_error(err.context("Cannot propose a batch")));
                     }
                 }
+
+                attempt += 1;
             }
         }
     }
@@ -240,10 +213,6 @@ mod tests {
             1
         }
 
-        fn is_synced(&self) -> bool {
-            true
-        }
-
         fn wait_for_synced_if_syncing(&self) -> Option<BoxFuture<'_, ()>> {
             None
         }
@@ -273,10 +242,6 @@ mod tests {
             if n == 0 { 1 } else { 2 }
         }
 
-        fn is_synced(&self) -> bool {
-            true
-        }
-
         fn wait_for_synced_if_syncing(&self) -> Option<BoxFuture<'_, ()>> {
             None
         }
@@ -299,10 +264,6 @@ mod tests {
     impl BatchPropose for RetryProposer {
         fn current_round(&self) -> u64 {
             1
-        }
-
-        fn is_synced(&self) -> bool {
-            true
         }
 
         fn wait_for_synced_if_syncing(&self) -> Option<BoxFuture<'_, ()>> {
@@ -418,10 +379,6 @@ mod tests {
         impl BatchPropose for NoSignalProposer {
             fn current_round(&self) -> u64 {
                 1
-            }
-
-            fn is_synced(&self) -> bool {
-                true
             }
 
             fn wait_for_synced_if_syncing(&self) -> Option<BoxFuture<'_, ()>> {

--- a/node/bft/src/primary/proposal_task.rs
+++ b/node/bft/src/primary/proposal_task.rs
@@ -88,96 +88,154 @@ impl<N: Network> ProposalTask<N> {
 
     /// Runs the batch proposal loop. This is intended to be spawned as a long-running task.
     ///
-    /// Each outer loop iteration covers one proposed batch.  The inner loop retries within the
-    /// same round until the round advances or a batch is successfully certified.
+    /// Each iteration covers one full round (wait → propose → wait for signatures).
+    /// The three stages are implemented as separate methods; see their doc-comments for details.
     pub(super) async fn run<P: BatchPropose + 'static>(self, primary: P) {
         let mut ready_rx = self.inner.ready.subscribe();
 
         loop {
-            // Note: This is technically the timestamp of when we last proposed a batch.
+            let round = primary.current_round();
+            // TODO(kaimast): the round_start time should be based on the timestamp of the
+            // previous batch, not the current wall-clock time.
             let round_start = Instant::now();
 
-            let round = primary.current_round();
-            let mut max_batch_delay_reached = false;
-            let mut attempt = 1;
+            if !Self::wait_until_proposal_ready(&primary, &mut ready_rx, round, round_start).await {
+                continue; // round changed; restart
+            }
 
-            // The inner loop represents multiple attempts to propose a batch within the same round.
-            // It exits when the round advances or a batch is successfully proposed.
-            while primary.current_round() == round {
-                // A node cannot propose while it is syncing. So, block here first.
-                if let Some(fut) = primary.wait_for_synced_if_syncing() {
-                    fut.await;
-                    // Restart the loop, as the current round may have changed.
-                    continue;
+            if !Self::propose(&primary, round).await {
+                continue; // round changed; restart
+            }
+
+            // Reset readiness so the next round waits for an explicit signal.
+            self.inner.ready.send_replace(false);
+
+            Self::wait_for_signatures(&primary, &mut ready_rx, round).await;
+        }
+    }
+
+    /// Stage 1: Wait until conditions are met to propose a batch.
+    ///
+    /// Blocks until sync is complete, MIN_BATCH_DELAY has elapsed since `round_start`, and either
+    /// `signal()` fires (leader cert arrived) or MAX_BATCH_DELAY expires without one.
+    ///
+    /// Returns `true` if ready to propose, `false` if the round changed (caller should restart).
+    async fn wait_until_proposal_ready<P: BatchPropose>(
+        primary: &P,
+        ready_rx: &mut watch::Receiver<bool>,
+        round: u64,
+        round_start: Instant,
+    ) -> bool {
+        loop {
+            if primary.current_round() != round {
+                return false;
+            }
+
+            // A node cannot propose while it is syncing.
+            if let Some(fut) = primary.wait_for_synced_if_syncing() {
+                fut.await;
+                // Re-check round after sync completes.
+                continue;
+            }
+
+            // Enforce the minimum inter-proposal delay.
+            // This is a no-op once the deadline has already passed.
+            sleep_until(round_start + MIN_BATCH_DELAY).await;
+
+            // Wait for a readiness signal, the MAX_BATCH_DELAY deadline, or a short heartbeat
+            // that lets the round-change check at the top of the loop fire regularly.
+            tokio::select! {
+                _ = sleep_until(round_start + MAX_BATCH_DELAY) => {
+                    debug!("Did not receive leader certificate within MAX_BATCH_DELAY");
+                    return true;
+                },
+                _ = Self::wait_until_ready(ready_rx) => {
+                    return true;
+                },
+                _ = sleep(CREATE_BATCH_INTERVAL) => {
+                    debug!("Skipping batch proposal for round {round} {}", "(not ready yet)".dimmed());
                 }
+            };
+        }
+    }
 
-                // If the minimum batch delay has not been reached yet, wait for it first,
-                // as we cannot propose without it having elapsed in any case.
-                // TODO(kaimast): the sleep time should be based on the timestamp of the previous batch
-                sleep_until(round_start + MIN_BATCH_DELAY).await;
+    /// Stage 2: Propose a batch.
+    ///
+    /// Calls `propose_batch()` with CREATE_BATCH_INTERVAL retries until it returns `Ok(true)`
+    /// (batch submitted to the network).
+    ///
+    /// Returns `true` if the batch was submitted, `false` if the round changed (caller should restart).
+    async fn propose<P: BatchPropose>(primary: &P, round: u64) -> bool {
+        let mut attempt = 1u32;
+        loop {
+            if primary.current_round() != round {
+                return false;
+            }
 
-                // Wait for either the leader to time-out or for the proposal to be ready.
-                // Additionally, we add a smaller timeout here out of caution, to ensure the node
-                // does not get stuck on this select! call.
-                tokio::select! {
-                    _ = sleep_until(round_start + MAX_BATCH_DELAY) => {
-                        if !max_batch_delay_reached {
-                            max_batch_delay_reached = true;
-                            debug!("Did not receive leader certificate within MAX_BATCH_DELAY");
-                        }
-                    },
-                    _ = wait_until_ready(&mut ready_rx) => {},
-                    _ = sleep(CREATE_BATCH_INTERVAL) => {
-                        // Retry if the timeout triggered (but do not count it as a proper attempt).
-                        debug!("Skipping batch proposal for round {round} {}", "(not ready yet)".dimmed());
-                        continue;
-                    }
-                };
+            if attempt > 1 {
+                sleep(CREATE_BATCH_INTERVAL).await;
+                debug!("Retrying batch proposal for round {round} (attempt #{attempt})");
+            }
 
-                if attempt > 1 {
-                    // Sleep to avoid busy waiting, if all conditions were met
-                    // and we still need to retry.
-                    sleep(CREATE_BATCH_INTERVAL).await;
-
-                    // Print a log message to see how often these retries happen (or if ever).
-                    debug!("Retrying batch proposal for round {round} (attempt #{attempt})");
+            // Note: Do NOT spawn a task around this function call.  Proposing a batch is a
+            // critical path, and only one batch needs to be proposed at a time.
+            match primary.propose_batch().await {
+                Ok(true) => return true, // batch submitted; proceed to Stage 3
+                Ok(false) => {}          // not ready yet; retry
+                Err(err) => {
+                    warn!("{}", flatten_error(err.context("Cannot propose a batch")));
                 }
+            }
 
-                // If there is no proposed batch, attempt to propose a batch.
-                // Note: Do NOT spawn a task around this function call. Proposing a batch is a
-                // critical path, and only one batch needs to be proposed at a time.
-                match primary.propose_batch().await {
-                    Ok(true) => {
-                        // Reset readiness so the next round waits for an explicit signal.
-                        self.inner.ready.send_replace(false);
-                        break;
-                    }
-                    Ok(false) => (), // retry
-                    Err(err) => {
-                        // Log warning and retry
-                        warn!("{}", flatten_error(err.context("Cannot propose a batch")));
-                    }
+            attempt += 1;
+        }
+    }
+
+    /// Stage 3: Wait for the proposed batch to collect enough signatures.
+    ///
+    /// Periodically rebroadcasts the batch to non-signers (via `propose_batch`) at most once per
+    /// MAX_BATCH_DELAY until the round advances.  Returns when the round changes.
+    async fn wait_for_signatures<P: BatchPropose>(primary: &P, ready_rx: &mut watch::Receiver<bool>, round: u64) {
+        loop {
+            if primary.current_round() != round {
+                return;
+            }
+
+            // Wait for the rebroadcast interval or an explicit round-advance signal,
+            // whichever comes first.
+            tokio::select! {
+                _ = Self::wait_until_ready(ready_rx) => return, // round advanced
+                _ = sleep(MAX_BATCH_DELAY) => {}
+            }
+
+            if primary.current_round() != round {
+                return;
+            }
+
+            // Rebroadcast to non-signers (`propose_batch` handles this internally).
+            match primary.propose_batch().await {
+                Ok(_) => {}
+                Err(err) => {
+                    warn!("{}", flatten_error(err.context("Cannot rebroadcast a batch")));
                 }
-
-                attempt += 1;
             }
         }
     }
-}
 
-/// Waits until the readiness watch channel holds `true`. Returns immediately if it already does.
-///
-/// Spurious wakeups (e.g. from a reset to `false`) are handled by re-checking the value in a loop.
-async fn wait_until_ready(receiver: &mut watch::Receiver<bool>) {
-    loop {
-        // Fetch the `is_ready` value and return if it is true.
-        if *receiver.borrow_and_update() {
-            return;
-        }
+    /// Waits until the readiness watch channel holds `true`. Returns immediately if it already does.
+    ///
+    /// Spurious wakeups (e.g. from a reset to `false`) are handled by re-checking the value in a loop.
+    async fn wait_until_ready(receiver: &mut watch::Receiver<bool>) {
+        loop {
+            // Fetch the `is_ready` value and return if it is true.
+            if *receiver.borrow_and_update() {
+                return;
+            }
 
-        // Block until the `is_value` changed, or the channel is closed.
-        if receiver.changed().await.is_err() {
-            return;
+            // Block until the `is_value` changed, or the channel is closed.
+            if receiver.changed().await.is_err() {
+                return;
+            }
         }
     }
 }
@@ -423,7 +481,8 @@ mod tests {
             .await
             .expect("propose_batch did not succeed within 10 seconds after leader timeout");
 
-        assert_eq!(propose_count.load(Ordering::SeqCst), RETRIES + 1, "expected {} total attempts", RETRIES + 1);
+        // Stage 3 may make additional rebroadcast calls after success, so use >.
+        assert!(propose_count.load(Ordering::SeqCst) > RETRIES, "expected at least {} total attempts", RETRIES + 1);
     }
 
     /// When `propose_batch` returns `Ok(false)`, the task retries within the same round until
@@ -450,6 +509,7 @@ mod tests {
             .await
             .expect("propose_batch did not succeed within 10 seconds");
 
-        assert_eq!(propose_count.load(Ordering::SeqCst), RETRIES + 1, "expected {} total attempts", RETRIES + 1);
+        // Stage 3 may make additional rebroadcast calls after success, so use >.
+        assert!(propose_count.load(Ordering::SeqCst) > RETRIES, "expected at least {} total attempts", RETRIES + 1);
     }
 }

--- a/node/bft/src/primary/proposal_task.rs
+++ b/node/bft/src/primary/proposal_task.rs
@@ -17,18 +17,14 @@ use crate::{CREATE_BATCH_INTERVAL, MAX_BATCH_DELAY, MIN_BATCH_DELAY};
 
 use anyhow::Result;
 use colored::Colorize;
-use futures::{FutureExt, future::BoxFuture};
-#[cfg(feature = "locktick")]
-use locktick::parking_lot::RwLock;
-#[cfg(not(feature = "locktick"))]
-use parking_lot::RwLock;
+use futures::future::BoxFuture;
 use snarkvm::{prelude::Network, utilities::flatten_error};
 use std::{marker::PhantomData, sync::Arc};
 use tokio::{
-    sync::Notify,
+    sync::watch,
     time::{Instant, sleep, sleep_until},
 };
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 /// Abstracts over batch-proposal operations, allowing the proposal loop to be tested without a
 /// real primary.
@@ -50,9 +46,8 @@ pub(super) trait BatchPropose: Send + Sync {
 
 /// Manages batch proposal readiness and drives the batch proposal loop.
 ///
-/// Holds the condition-variable state (`is_proposal_ready` + `is_ready_notify`) and the
-/// logic for the proposal task.  The actual task is started by calling [`Self::run`] inside a
-/// spawned future (see [`Primary::start_handlers`]).
+/// Holds the readiness state and the logic for the proposal task. The actual task is started by
+/// calling [`Self::run`] inside a spawned future (see [`Primary::start_handlers`]).
 pub struct ProposalTask<N: Network> {
     inner: Arc<ProposalTaskInner>,
     _phantom: PhantomData<N>,
@@ -67,23 +62,18 @@ impl<N: Network> Clone for ProposalTask<N> {
 
 /// The inner state of a [`ProposalTask`], shared via `Arc`.
 struct ProposalTaskInner {
-    /// Whether the primary is ready to propose a new batch.
+    /// Tracks whether the primary is ready to propose a new batch.
     ///
     /// Initialized to `true` so round 1 can be proposed immediately without an explicit signal.
     /// Set to `true` by [`ProposalTask::signal`] when a new round starts,
     /// and reset to `false` after a batch is successfully proposed.
-    is_proposal_ready: RwLock<bool>,
-
-    /// Notifies the proposal loop when `is_proposal_ready` transitions to `true`.
-    is_ready_notify: Notify,
+    ready: watch::Sender<bool>,
 }
 
 impl<N: Network> Default for ProposalTask<N> {
     fn default() -> Self {
-        Self {
-            inner: Arc::new(ProposalTaskInner { is_proposal_ready: RwLock::new(true), is_ready_notify: Notify::new() }),
-            _phantom: PhantomData,
-        }
+        let (ready, _) = watch::channel(true);
+        Self { inner: Arc::new(ProposalTaskInner { ready }), _phantom: PhantomData }
     }
 }
 
@@ -93,22 +83,7 @@ impl<N: Network> ProposalTask<N> {
     /// Should be called from [`Primary::try_increment_to_the_next_round`] whenever the primary
     /// successfully advances to a new round.
     pub fn signal(&self) {
-        *self.inner.is_proposal_ready.write() = true;
-        self.inner.is_ready_notify.notify_one();
-    }
-
-    /// Waits until the primary is ready to propose. Returns immediately if already ready.
-    async fn wait(&self) {
-        loop {
-            let mut fut = std::pin::pin!(self.inner.is_ready_notify.notified());
-            {
-                if *self.inner.is_proposal_ready.read() {
-                    return;
-                }
-                fut.as_mut().enable();
-            }
-            fut.await;
-        }
+        self.inner.ready.send_replace(true);
     }
 
     /// Runs the batch proposal loop. This is intended to be spawned as a long-running task.
@@ -116,6 +91,8 @@ impl<N: Network> ProposalTask<N> {
     /// Each outer loop iteration covers one proposed batch.  The inner loop retries within the
     /// same round until the round advances or a batch is successfully certified.
     pub(super) async fn run<P: BatchPropose + 'static>(self, primary: P) {
+        let mut ready_rx = self.inner.ready.subscribe();
+
         loop {
             let round_start = Instant::now();
             let round = primary.current_round();
@@ -133,26 +110,27 @@ impl<N: Network> ProposalTask<N> {
                 }
 
                 // If the minimum batch delay has not been reached yet, wait for it first,
-                // as we cannot propose without it having elapsed in any case.e
+                // as we cannot propose without it having elapsed in any case.
                 // TODO(kaimast): the sleep time should be based on the timestamp of the previous batch
                 sleep_until(round_start + MIN_BATCH_DELAY).await;
 
                 // Wait for either the leader to time-out or for the proposal to be ready.
-                // Additionally, we add a smaller timeout here out of caution, to ensure node does not get stuck on this select! call.
+                // Additionally, we add a smaller timeout here out of caution, to ensure the node
+                // does not get stuck on this select! call.
                 tokio::select! {
-                                    _ = sleep_until(round_start + MAX_BATCH_DELAY) => {
-                                        if !leader_timeout_reached {
-                                            info!("Leader for round {round} timed out");
-                                        }
-                                        leader_timeout_reached = true;
-                                    },
-                                    _ = self.wait().boxed() => {},
-                                    _ = sleep(CREATE_BATCH_INTERVAL) => {
-                // Retry if the timeout triggered (but do not count it as a proper attempt).
-                                    debug!("Skipping batch proposal for round {round} {}", "(not ready yet)".dimmed());
-                                    continue;
-                                    }
-                                };
+                    _ = sleep_until(round_start + MAX_BATCH_DELAY) => {
+                        if !leader_timeout_reached {
+                            info!("Leader for round {round} timed out");
+                        }
+                        leader_timeout_reached = true;
+                    },
+                    _ = wait_until_ready(&mut ready_rx) => {},
+                    _ = sleep(CREATE_BATCH_INTERVAL) => {
+                        // Retry if the timeout triggered (but do not count it as a proper attempt).
+                        debug!("Skipping batch proposal for round {round} {}", "(not ready yet)".dimmed());
+                        continue;
+                    }
+                };
 
                 if attempt > 1 {
                     // Sleep to avoid busy waiting, if all conditions were met
@@ -169,7 +147,7 @@ impl<N: Network> ProposalTask<N> {
                 match primary.propose_batch().await {
                     Ok(true) => {
                         // Reset readiness so the next round waits for an explicit signal.
-                        *self.inner.is_proposal_ready.write() = false;
+                        self.inner.ready.send_replace(false);
                         break;
                     }
                     Ok(false) => (), // retry
@@ -181,6 +159,23 @@ impl<N: Network> ProposalTask<N> {
 
                 attempt += 1;
             }
+        }
+    }
+}
+
+/// Waits until the readiness watch channel holds `true`. Returns immediately if it already does.
+///
+/// Spurious wakeups (e.g. from a reset to `false`) are handled by re-checking the value in a loop.
+async fn wait_until_ready(receiver: &mut watch::Receiver<bool>) {
+    loop {
+        // Fetch the `is_ready` value and return if it is true.
+        if *receiver.borrow_and_update() {
+            return;
+        }
+
+        // Block until the `is_value` changed, or the channel is closed.
+        if receiver.changed().await.is_err() {
+            return;
         }
     }
 }
@@ -197,6 +192,7 @@ mod tests {
         },
         time::Duration,
     };
+    use tokio::sync::Notify;
 
     /// A minimal [`BatchPropose`] implementation for testing.
     ///
@@ -285,13 +281,8 @@ mod tests {
     #[tokio::test]
     async fn test_proposal_task_calls_propose_batch_on_signal() {
         // Start with the task not ready so the initial signal is the trigger.
-        let task = ProposalTask::<MainnetV0> {
-            inner: Arc::new(ProposalTaskInner {
-                is_proposal_ready: RwLock::new(false),
-                is_ready_notify: Notify::new(),
-            }),
-            _phantom: PhantomData,
-        };
+        let (ready, _) = watch::channel(false);
+        let task = ProposalTask::<MainnetV0> { inner: Arc::new(ProposalTaskInner { ready }), _phantom: PhantomData };
 
         let proposed_notify = Arc::new(Notify::new());
         let propose_count = Arc::new(AtomicU32::new(0));
@@ -329,18 +320,13 @@ mod tests {
         };
 
         // Start not-ready so the task parks in round 2's inner loop without proposing round 1.
-        let task = ProposalTask::<MainnetV0> {
-            inner: Arc::new(ProposalTaskInner {
-                is_proposal_ready: RwLock::new(false),
-                is_ready_notify: Notify::new(),
-            }),
-            _phantom: PhantomData,
-        };
+        let (ready, _) = watch::channel(false);
+        let task = ProposalTask::<MainnetV0> { inner: Arc::new(ProposalTaskInner { ready }), _phantom: PhantomData };
 
         tokio::spawn(task.run(proposer));
 
         // Yield once: the task runs through round 1 (inner loop exits immediately because
-        // current_round() already returns 2) and then parks in round 2's join_all.
+        // current_round() already returns 2) and then parks in round 2's inner loop.
         tokio::task::yield_now().await;
 
         assert_eq!(propose_count.load(Ordering::SeqCst), 0, "propose_batch called despite round advancement");
@@ -348,7 +334,7 @@ mod tests {
 
     /// Tests the following scenario
     ///
-    ///   1. A batch was already certified for the current round, so `is_proposal_ready` is `false`.
+    ///   1. A batch was already certified for the current round, so readiness is `false`.
     ///   2. `signal()` is **never** called externally — the BFT cannot advance the round until
     ///      `propose_batch()` is called (which internally checks the leader-certificate timer).
     #[test_log::test(tokio::test)]
@@ -356,13 +342,8 @@ mod tests {
         // Start NOT ready: simulates a batch that was already certified for the round but the
         // round has not yet advanced (the even-round leader cert was missing — e.g. the elected
         // leader was one of the freshly-reset minority validators).
-        let task = ProposalTask::<MainnetV0> {
-            inner: Arc::new(ProposalTaskInner {
-                is_proposal_ready: RwLock::new(false),
-                is_ready_notify: Notify::new(),
-            }),
-            _phantom: PhantomData,
-        };
+        let (ready, _) = watch::channel(false);
+        let task = ProposalTask::<MainnetV0> { inner: Arc::new(ProposalTaskInner { ready }), _phantom: PhantomData };
 
         let proposed_notify = Arc::new(Notify::new());
         let propose_count = Arc::new(AtomicU32::new(0));
@@ -409,9 +390,6 @@ mod tests {
 
     /// When `propose_batch` returns `Ok(false)`, the task retries within the same round until
     /// it succeeds.
-    ///
-    /// The first attempt is gated behind `MAX_BATCH_DELAY`; subsequent retries are nearly
-    /// instant because `reached_min_batch_delay` is true and the futures list is empty.
     #[tokio::test]
     async fn test_proposal_task_retries_on_false() {
         const RETRIES: u32 = 2;

--- a/node/bft/src/primary/proposal_task.rs
+++ b/node/bft/src/primary/proposal_task.rs
@@ -1,0 +1,403 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{CREATE_BATCH_INTERVAL, MAX_BATCH_DELAY};
+
+use anyhow::Result;
+use colored::Colorize;
+use futures::{FutureExt, future::BoxFuture};
+#[cfg(feature = "locktick")]
+use locktick::parking_lot::RwLock;
+#[cfg(not(feature = "locktick"))]
+use parking_lot::RwLock;
+use snarkvm::{prelude::Network, utilities::flatten_error};
+use std::{marker::PhantomData, sync::Arc, time::Instant};
+use tokio::sync::Notify;
+use tracing::{debug, warn};
+
+/// Abstracts over batch-proposal operations, allowing the proposal loop to be tested without a
+/// real primary.
+#[async_trait::async_trait]
+pub(super) trait BatchPropose: Send + Sync {
+    /// Returns the current consensus round.
+    fn current_round(&self) -> u64;
+
+    /// Reurns `true` if the node is fully synced.
+    fn is_synced(&self) -> bool;
+
+    /// Returns `None` if the node is already synced; otherwise returns a future that resolves
+    /// once sync completes.
+    fn wait_for_synced_if_syncing(&self) -> Option<BoxFuture<'_, ()>>;
+
+    /// Attempts to propose a batch.
+    ///
+    /// Returns `Ok(true)` when a batch was successfully proposed, `Ok(false)` to retry, and
+    /// `Err` on an unexpected error.
+    async fn propose_batch(&self) -> Result<bool>;
+}
+
+/// Manages batch proposal readiness and drives the batch proposal loop.
+///
+/// Holds the condition-variable state (`is_proposal_ready` + `is_ready_notify`) and the
+/// logic for the proposal task.  The actual task is started by calling [`Self::run`] inside a
+/// spawned future (see [`Primary::start_handlers`]).
+pub struct ProposalTask<N: Network> {
+    inner: Arc<ProposalTaskInner>,
+    _phantom: PhantomData<N>,
+}
+
+/// Manual `Clone` impl so that `N: Clone` is not required.
+impl<N: Network> Clone for ProposalTask<N> {
+    fn clone(&self) -> Self {
+        Self { inner: Arc::clone(&self.inner), _phantom: PhantomData }
+    }
+}
+
+/// The inner state of a [`ProposalTask`], shared via `Arc`.
+struct ProposalTaskInner {
+    /// Whether the primary is ready to propose a new batch.
+    ///
+    /// Initialized to `true` so round 1 can be proposed immediately without an explicit signal.
+    /// Set to `true` by [`ProposalTask::signal`] when a new round starts,
+    /// and reset to `false` after a batch is successfully proposed.
+    is_proposal_ready: RwLock<bool>,
+
+    /// Notifies the proposal loop when `is_proposal_ready` transitions to `true`.
+    is_ready_notify: Notify,
+}
+
+impl<N: Network> Default for ProposalTask<N> {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(ProposalTaskInner { is_proposal_ready: RwLock::new(true), is_ready_notify: Notify::new() }),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<N: Network> ProposalTask<N> {
+    /// Signals that the primary is ready to propose a new batch for the current round.
+    ///
+    /// Should be called from [`Primary::try_increment_to_the_next_round`] whenever the primary
+    /// successfully advances to a new round.
+    pub fn signal(&self) {
+        *self.inner.is_proposal_ready.write() = true;
+        self.inner.is_ready_notify.notify_one();
+    }
+
+    /// Returns `None` if the primary is already ready to propose.
+    /// Otherwise returns a future that resolves once the primary becomes ready.
+    ///
+    /// Atomically registers the wakeup before releasing the readiness lock, so no signal is missed
+    /// between the state check and the registration.
+    fn wait_if_not_ready(&self) -> Option<BoxFuture<'_, ()>> {
+        let mut notified = Box::pin(self.inner.is_ready_notify.notified());
+        {
+            if *self.inner.is_proposal_ready.read() {
+                return None;
+            }
+            // Register the wakeup while still holding the lock, to avoid a missed notification.
+            notified.as_mut().enable();
+        }
+        Some(
+            async move {
+                notified.await;
+                self.wait().await;
+            }
+            .boxed(),
+        )
+    }
+
+    /// Waits until the primary is ready to propose. Returns immediately if already ready.
+    async fn wait(&self) {
+        loop {
+            let mut fut = std::pin::pin!(self.inner.is_ready_notify.notified());
+            {
+                if *self.inner.is_proposal_ready.read() {
+                    return;
+                }
+                fut.as_mut().enable();
+            }
+            fut.await;
+        }
+    }
+
+    /// Runs the batch proposal loop. This is intended to be spawned as a long-running task.
+    ///
+    /// Each outer loop iteration covers one proposed batch.  The inner loop retries within the
+    /// same round until the round advances or a batch is successfully certified.
+    pub(super) async fn run<P: BatchPropose + 'static>(self, primary: P) {
+        loop {
+            let round_start = Instant::now();
+            let current_round = primary.current_round();
+            let mut reached_min_batch_delay = false;
+
+            // The inner loop represents multiple attempts to propose a batch within the same round.
+            // It exits when the round advances or a batch is successfully proposed.
+            while primary.current_round() == current_round {
+                // Assemble a list of conditions that will trigger the primary to attempt batch
+                // creation.
+                let mut futures = vec![];
+
+                // Wait for the primary to be ready to propose, unless it already is.
+                if let Some(fut) = self.wait_if_not_ready() {
+                    futures.push(fut);
+                }
+
+                // If the node is not synced yet, wait for block sync to complete.
+                if let Some(sync_fut) = primary.wait_for_synced_if_syncing() {
+                    futures.push(sync_fut);
+                }
+
+                // If the maximum batch delay has not been reached, wait for it.
+                // Otherwise, add a small timeout to avoid busy waiting.
+                if reached_min_batch_delay {
+                    // Add a timeout to prevent nodes from getting stuck
+                    // (removing this would require more testing)
+                    let _ = tokio::time::timeout(CREATE_BATCH_INTERVAL, futures::future::join_all(futures)).await;
+                } else {
+                    let timeout = MAX_BATCH_DELAY.saturating_sub(round_start.elapsed());
+                    futures.push(tokio::time::sleep(timeout).boxed());
+
+                    // All conditions must hold for us to advance.
+                    futures::future::join_all(futures).await;
+                    reached_min_batch_delay = true;
+                }
+
+                // If the primary is not synced, then do not propose a batch.
+                if !primary.is_synced() {
+                    debug!("Skipping batch proposal for round {current_round} {}", "(node is syncing)".dimmed());
+                    continue;
+                }
+
+                // If there is no proposed batch, attempt to propose a batch.
+                // Note: Do NOT spawn a task around this function call. Proposing a batch is a
+                // critical path, and only one batch needs to be proposed at a time.
+                match primary.propose_batch().await {
+                    Ok(true) => {
+                        // Reset readiness so the next round waits for an explicit signal.
+                        *self.inner.is_proposal_ready.write() = false;
+                        break;
+                    }
+                    Ok(false) => (), // retry
+                    Err(err) => {
+                        warn!("{}", flatten_error(err.context("Cannot propose a batch")));
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use snarkvm::prelude::MainnetV0;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicU32, Ordering},
+    };
+
+    /// A minimal [`BatchPropose`] implementation for testing.
+    ///
+    /// Always reports round 1 and synced. Records how many times [`propose_batch`] is called and
+    /// fires a [`Notify`] on each call.
+    struct DummyProposer {
+        propose_count: Arc<AtomicU32>,
+        proposed_notify: Arc<Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl BatchPropose for DummyProposer {
+        fn current_round(&self) -> u64 {
+            1
+        }
+
+        fn is_synced(&self) -> bool {
+            true
+        }
+
+        fn wait_for_synced_if_syncing(&self) -> Option<BoxFuture<'_, ()>> {
+            None
+        }
+
+        async fn propose_batch(&self) -> Result<bool> {
+            self.propose_count.fetch_add(1, Ordering::SeqCst);
+            self.proposed_notify.notify_one();
+
+            Ok(true)
+        }
+    }
+
+    /// A [`BatchPropose`] implementation that returns round 1 on the very first call to
+    /// `current_round`, then round 2 for all subsequent calls.
+    ///
+    /// This simulates the round advancing between the outer-loop capture and the inner-loop
+    /// condition check, without any real-time waiting or time mocking.
+    struct RoundAdvancingProposer {
+        current_round_calls: Arc<AtomicU32>,
+        propose_count: Arc<AtomicU32>,
+    }
+
+    #[async_trait::async_trait]
+    impl BatchPropose for RoundAdvancingProposer {
+        fn current_round(&self) -> u64 {
+            let n = self.current_round_calls.fetch_add(1, Ordering::SeqCst);
+            if n == 0 { 1 } else { 2 }
+        }
+
+        fn is_synced(&self) -> bool {
+            true
+        }
+
+        fn wait_for_synced_if_syncing(&self) -> Option<BoxFuture<'_, ()>> {
+            None
+        }
+
+        async fn propose_batch(&self) -> Result<bool> {
+            self.propose_count.fetch_add(1, Ordering::SeqCst);
+            Ok(true)
+        }
+    }
+
+    /// A [`BatchPropose`] implementation that returns `Ok(false)` a fixed number of times before
+    /// succeeding.
+    struct RetryProposer {
+        retries_before_success: u32,
+        propose_count: Arc<AtomicU32>,
+        proposed_notify: Arc<Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl BatchPropose for RetryProposer {
+        fn current_round(&self) -> u64 {
+            1
+        }
+
+        fn is_synced(&self) -> bool {
+            true
+        }
+
+        fn wait_for_synced_if_syncing(&self) -> Option<BoxFuture<'_, ()>> {
+            None
+        }
+
+        async fn propose_batch(&self) -> Result<bool> {
+            let count = self.propose_count.fetch_add(1, Ordering::SeqCst) + 1;
+            if count <= self.retries_before_success {
+                Ok(false)
+            } else {
+                self.proposed_notify.notify_one();
+                Ok(true)
+            }
+        }
+    }
+
+    /// Signals the proposal task and verifies that `propose_batch` is called on the dummy.
+    #[tokio::test]
+    async fn test_proposal_task_calls_propose_batch_on_signal() {
+        // Start with the task not ready so the initial signal is the trigger.
+        let task = ProposalTask::<MainnetV0> {
+            inner: Arc::new(ProposalTaskInner {
+                is_proposal_ready: RwLock::new(false),
+                is_ready_notify: Notify::new(),
+            }),
+            _phantom: PhantomData,
+        };
+
+        let proposed_notify = Arc::new(Notify::new());
+        let propose_count = Arc::new(AtomicU32::new(0));
+
+        let proposer = DummyProposer { propose_count: propose_count.clone(), proposed_notify: proposed_notify.clone() };
+
+        let task_for_spawn = task.clone();
+        tokio::spawn(task_for_spawn.run(proposer));
+
+        // Before signalling, propose_batch should not have been called.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(propose_count.load(Ordering::SeqCst), 0, "propose_batch called before signal");
+
+        // Signal readiness — the proposal loop should wake up and call propose_batch.
+        task.signal();
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), proposed_notify.notified())
+            .await
+            .expect("propose_batch was not called within 5 seconds after signal");
+
+        assert!(propose_count.load(Ordering::SeqCst) >= 1, "propose_batch was not called");
+    }
+
+    /// When the round advances between iterations, `propose_batch` is not called for the old round.
+    ///
+    /// `RoundAdvancingProposer` returns round 1 on the first `current_round()` call (outer-loop
+    /// capture) and round 2 on every subsequent call. The inner-loop condition therefore fails
+    /// immediately — no time mocking needed.
+    #[tokio::test]
+    async fn test_proposal_task_exits_on_round_advancement() {
+        let propose_count = Arc::new(AtomicU32::new(0));
+        let proposer = RoundAdvancingProposer {
+            current_round_calls: Arc::new(AtomicU32::new(0)),
+            propose_count: propose_count.clone(),
+        };
+
+        // Start not-ready so the task parks in round 2's inner loop without proposing round 1.
+        let task = ProposalTask::<MainnetV0> {
+            inner: Arc::new(ProposalTaskInner {
+                is_proposal_ready: RwLock::new(false),
+                is_ready_notify: Notify::new(),
+            }),
+            _phantom: PhantomData,
+        };
+
+        tokio::spawn(task.run(proposer));
+
+        // Yield once: the task runs through round 1 (inner loop exits immediately because
+        // current_round() already returns 2) and then parks in round 2's join_all.
+        tokio::task::yield_now().await;
+
+        assert_eq!(propose_count.load(Ordering::SeqCst), 0, "propose_batch called despite round advancement");
+    }
+
+    /// When `propose_batch` returns `Ok(false)`, the task retries within the same round until
+    /// it succeeds.
+    ///
+    /// The first attempt is gated behind `MAX_BATCH_DELAY`; subsequent retries are nearly
+    /// instant because `reached_min_batch_delay` is true and the futures list is empty.
+    #[tokio::test]
+    async fn test_proposal_task_retries_on_false() {
+        const RETRIES: u32 = 2;
+
+        // Default starts ready, so no signal needed.
+        let task = ProposalTask::<MainnetV0>::default();
+
+        let proposed_notify = Arc::new(Notify::new());
+        let propose_count = Arc::new(AtomicU32::new(0));
+        let proposer = RetryProposer {
+            retries_before_success: RETRIES,
+            propose_count: propose_count.clone(),
+            proposed_notify: proposed_notify.clone(),
+        };
+
+        tokio::spawn(task.run(proposer));
+
+        // The task internally waits MAX_BATCH_DELAY before the first attempt; allow up to 10s.
+        tokio::time::timeout(std::time::Duration::from_secs(10), proposed_notify.notified())
+            .await
+            .expect("propose_batch did not succeed within 10 seconds");
+
+        assert_eq!(propose_count.load(Ordering::SeqCst), RETRIES + 1, "expected {} total attempts", RETRIES + 1);
+    }
+}

--- a/node/bft/src/primary/proposal_task.rs
+++ b/node/bft/src/primary/proposal_task.rs
@@ -24,7 +24,7 @@ use tokio::{
     sync::watch,
     time::{Instant, sleep, sleep_until},
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 /// Abstracts over batch-proposal operations, allowing the proposal loop to be tested without a
 /// real primary.
@@ -94,9 +94,11 @@ impl<N: Network> ProposalTask<N> {
         let mut ready_rx = self.inner.ready.subscribe();
 
         loop {
+            // Note: This is technically the timestamp of when we last proposed a batch.
             let round_start = Instant::now();
+
             let round = primary.current_round();
-            let mut leader_timeout_reached = false;
+            let mut max_batch_delay_reached = false;
             let mut attempt = 1;
 
             // The inner loop represents multiple attempts to propose a batch within the same round.
@@ -119,10 +121,10 @@ impl<N: Network> ProposalTask<N> {
                 // does not get stuck on this select! call.
                 tokio::select! {
                     _ = sleep_until(round_start + MAX_BATCH_DELAY) => {
-                        if !leader_timeout_reached {
-                            info!("Leader for round {round} timed out");
+                        if !max_batch_delay_reached {
+                            max_batch_delay_reached = true;
+                            debug!("Did not receive leader certificate within MAX_BATCH_DELAY");
                         }
-                        leader_timeout_reached = true;
                     },
                     _ = wait_until_ready(&mut ready_rx) => {},
                     _ = sleep(CREATE_BATCH_INTERVAL) => {
@@ -388,6 +390,42 @@ mod tests {
         assert!(propose_count.load(Ordering::SeqCst) >= 1, "propose_batch should have been called at least once");
     }
 
+    /// After the leader-certificate timer fires (MAX_BATCH_DELAY elapses without an explicit
+    /// `signal()`), the task should still retry `propose_batch` when it returns `Ok(false)` and
+    /// eventually succeed once it returns `Ok(true)`.
+    ///
+    /// This models the real primary: when a round is already certified but the round has not yet
+    /// advanced (e.g. the elected leader was a freshly-reset minority validator), `propose_batch`
+    /// returns `Ok(false)` until `try_advance_to_next_round` can make progress.
+    #[test_log::test(tokio::test)]
+    async fn test_proposal_task_retries_after_leader_timeout() {
+        const RETRIES: u32 = 2;
+
+        // Start NOT ready — no external signal will be sent. The task must wait for
+        // MAX_BATCH_DELAY to fire, then retry until propose_batch succeeds.
+        let (ready, _) = watch::channel(false);
+        let task = ProposalTask::<MainnetV0> { inner: Arc::new(ProposalTaskInner { ready }), _phantom: PhantomData };
+
+        let proposed_notify = Arc::new(Notify::new());
+        let propose_count = Arc::new(AtomicU32::new(0));
+        let proposer = RetryProposer {
+            retries_before_success: RETRIES,
+            propose_count: propose_count.clone(),
+            proposed_notify: proposed_notify.clone(),
+        };
+
+        // signal() is intentionally never called — the leader timeout arm must trigger.
+        tokio::spawn(task.run(proposer));
+
+        // Allow enough time for MAX_BATCH_DELAY (2.5 s) plus RETRIES × CREATE_BATCH_INTERVAL (250 ms each).
+        // Use 10 s to give generous headroom on slow CI machines.
+        tokio::time::timeout(std::time::Duration::from_secs(10), proposed_notify.notified())
+            .await
+            .expect("propose_batch did not succeed within 10 seconds after leader timeout");
+
+        assert_eq!(propose_count.load(Ordering::SeqCst), RETRIES + 1, "expected {} total attempts", RETRIES + 1);
+    }
+
     /// When `propose_batch` returns `Ok(false)`, the task retries within the same round until
     /// it succeeds.
     #[tokio::test]
@@ -407,7 +445,7 @@ mod tests {
 
         tokio::spawn(task.run(proposer));
 
-        // The task internally waits MAX_BATCH_DELAY before the first attempt; allow up to 10s.
+        // The task internally waits MIN_BATCH_DELAY before the first attempt; allow up to 10s.
         tokio::time::timeout(std::time::Duration::from_secs(10), proposed_notify.notified())
             .await
             .expect("propose_batch did not succeed within 10 seconds");

--- a/node/bft/src/primary/proposal_task.rs
+++ b/node/bft/src/primary/proposal_task.rs
@@ -24,7 +24,10 @@ use locktick::parking_lot::RwLock;
 use parking_lot::RwLock;
 use snarkvm::{prelude::Network, utilities::flatten_error};
 use std::{marker::PhantomData, sync::Arc, time::Instant};
-use tokio::sync::Notify;
+use tokio::{
+    sync::Notify,
+    time::{sleep, timeout},
+};
 use tracing::{debug, warn};
 
 /// Abstracts over batch-proposal operations, allowing the proposal loop to be tested without a
@@ -163,13 +166,17 @@ impl<N: Network> ProposalTask<N> {
 
                 // If the maximum batch delay has not been reached, wait for it.
                 // Otherwise, add a small timeout to avoid busy waiting.
-                if reached_min_batch_delay {
+                if reached_min_batch_delay && futures.is_empty() {
+                    // If there are no futures to await on, sleep on `CREATE_BATCH_INTERVAL`
+                    // to avoid busy waiting.
+                    sleep(CREATE_BATCH_INTERVAL).await;
+                } else if reached_min_batch_delay {
                     // Add a timeout to prevent nodes from getting stuck
                     // (removing this would require more testing)
-                    let _ = tokio::time::timeout(CREATE_BATCH_INTERVAL, futures::future::join_all(futures)).await;
+                    let _ = timeout(CREATE_BATCH_INTERVAL, futures::future::join_all(futures)).await;
                 } else {
                     let timeout = MAX_BATCH_DELAY.saturating_sub(round_start.elapsed());
-                    futures.push(tokio::time::sleep(timeout).boxed());
+                    futures.push(sleep(timeout).boxed());
 
                     // Any condition completing is sufficient to attempt a proposal.
                     // Using select_all (not join_all) ensures that once MAX_BATCH_DELAY elapses
@@ -210,9 +217,12 @@ mod tests {
     use super::*;
 
     use snarkvm::prelude::MainnetV0;
-    use std::sync::{
-        Arc,
-        atomic::{AtomicU32, Ordering},
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicU32, Ordering},
+        },
+        time::Duration,
     };
 
     /// A minimal [`BatchPropose`] implementation for testing.
@@ -331,7 +341,7 @@ mod tests {
         tokio::spawn(task_for_spawn.run(proposer));
 
         // Before signalling, propose_batch should not have been called.
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        sleep(Duration::from_millis(50)).await;
         assert_eq!(propose_count.load(Ordering::SeqCst), 0, "propose_batch called before signal");
 
         // Signal readiness — the proposal loop should wake up and call propose_batch.

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -52,10 +52,7 @@ use std::{
 };
 #[cfg(not(feature = "locktick"))]
 use tokio::sync::Mutex as TMutex;
-use tokio::{
-    sync::{Notify, oneshot},
-    task::JoinHandle,
-};
+use tokio::{sync::oneshot, task::JoinHandle};
 
 /// This callback trait allows listening to synchronization updates, such as discorvering new `BatchCertificate`s.
 /// This is currently used by BFT.
@@ -107,8 +104,6 @@ pub struct Sync<N: Network> {
     ///
     /// Whenever a new block is added to this map, BlockSync::set_sync_height needs to be called.
     pending_blocks: Arc<Mutex<VecDeque<PendingBlock<N>>>>,
-    /// Notified after sync progress when the node is synced; used by [`Self::wait_for_synced`].
-    synced_notify: Arc<Notify>,
 }
 
 impl<N: Network> Sync<N> {
@@ -137,7 +132,6 @@ impl<N: Network> Sync<N> {
             handles: Default::default(),
             response_lock: Default::default(),
             pending_blocks: Default::default(),
-            synced_notify: Default::default(),
         }
     }
 
@@ -509,11 +503,6 @@ impl<N: Network> Sync<N> {
                 false
             }
         };
-
-        // When we are synced, wake waiters in [`Self::wait_for_synced`].
-        if self.is_synced() {
-            self.synced_notify.notify_waiters();
-        }
 
         if let Some(ping) = &ping
             && new_blocks

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -15,7 +15,7 @@
 
 use crate::{
     Gateway,
-    MAX_FETCH_TIMEOUT_IN_MS,
+    MAX_FETCH_TIMEOUT,
     Transport,
     events::{CertificateRequest, CertificateResponse, Event},
     helpers::{Pending, Storage, SyncReceiver, fmt_id, max_redundant_requests},
@@ -205,7 +205,7 @@ impl<N: Network> Sync<N> {
         self.spawn(async move {
             loop {
                 // Sleep briefly.
-                tokio::time::sleep(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS)).await;
+                tokio::time::sleep(MAX_FETCH_TIMEOUT).await;
 
                 // Remove the expired pending transmission requests.
                 let self__ = self_.clone();
@@ -1041,7 +1041,7 @@ impl<N: Network> Sync<N> {
         }
         // Wait for the certificate to be fetched.
         // TODO (raychu86): Consider making the timeout dynamic based on network traffic and/or the number of validators.
-        tokio::time::timeout(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS), callback_receiver)
+        tokio::time::timeout(MAX_FETCH_TIMEOUT, callback_receiver)
             .await
             .with_context(|| format!("Unable to fetch batch certificate {} (timeout)", fmt_id(certificate_id)))?
             .with_context(|| format!("Unable to fetch batch certificate {}", fmt_id(certificate_id)))

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -23,7 +23,6 @@ use crate::{
     spawn_blocking,
 };
 
-use snarkos_node_network::PeerPoolHandling;
 use snarkos_node_sync::{BftSyncMode, BlockSync, InsertBlockResponseError, Ping, locators::BlockLocators};
 use snarkos_utilities::CallbackHandle;
 
@@ -53,7 +52,10 @@ use std::{
 };
 #[cfg(not(feature = "locktick"))]
 use tokio::sync::Mutex as TMutex;
-use tokio::{sync::oneshot, task::JoinHandle};
+use tokio::{
+    sync::{Notify, oneshot},
+    task::JoinHandle,
+};
 
 /// This callback trait allows listening to synchronization updates, such as discorvering new `BatchCertificate`s.
 /// This is currently used by BFT.
@@ -105,6 +107,8 @@ pub struct Sync<N: Network> {
     ///
     /// Whenever a new block is added to this map, BlockSync::set_sync_height needs to be called.
     pending_blocks: Arc<Mutex<VecDeque<PendingBlock<N>>>>,
+    /// Notified after sync progress when the node is synced; used by [`Self::wait_for_synced`].
+    synced_notify: Arc<Notify>,
 }
 
 impl<N: Network> Sync<N> {
@@ -133,7 +137,20 @@ impl<N: Network> Sync<N> {
             handles: Default::default(),
             response_lock: Default::default(),
             pending_blocks: Default::default(),
+            synced_notify: Default::default(),
         }
+    }
+
+    /// Waits until the node is synced (has connected peers and is block-synced).
+    /// Returns immediately if already synced.
+    pub async fn wait_for_synced(&self) {
+        self.block_sync.wait_for_synced().await;
+    }
+
+    /// Returns `None` if the node is already synced.
+    /// Otherwise, returns a future that completes once the node becomes synced.
+    pub fn wait_for_synced_if_syncing(&self) -> Option<futures::future::BoxFuture<()>> {
+        self.block_sync.wait_for_synced_if_syncing()
     }
 
     /// Initializes the sync module and sync the storage with the ledger at bootup.
@@ -492,6 +509,11 @@ impl<N: Network> Sync<N> {
                 false
             }
         };
+
+        // When we are synced, wake waiters in [`Self::wait_for_synced`].
+        if self.is_synced() {
+            self.synced_notify.notify_waiters();
+        }
 
         if let Some(ping) = &ping
             && new_blocks
@@ -984,12 +1006,6 @@ impl<N: Network> Sync<N> {
 impl<N: Network> Sync<N> {
     /// Returns `true` if the node is synced and has connected peers.
     pub fn is_synced(&self) -> bool {
-        // Ensure the validator is connected to other validators,
-        // not just clients.
-        if self.gateway.number_of_connected_peers() == 0 {
-            return false;
-        }
-
         self.block_sync.is_block_synced()
     }
 

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use crate::{
-    MAX_FETCH_TIMEOUT_IN_MS,
+    MAX_FETCH_TIMEOUT,
     MAX_WORKERS,
     ProposedBatch,
     Transport,
@@ -41,7 +41,7 @@ use locktick::parking_lot::{Mutex, RwLock};
 use parking_lot::{Mutex, RwLock};
 use rand::seq::IteratorRandom;
 
-use std::{future::Future, net::SocketAddr, sync::Arc, time::Duration};
+use std::{future::Future, net::SocketAddr, sync::Arc};
 use tokio::{sync::oneshot, task::JoinHandle, time::timeout};
 
 /// A worker's main role is maintaining a queue of verified ("ready") transmissions,
@@ -442,7 +442,7 @@ impl<N: Network> Worker<N> {
         self.spawn(async move {
             loop {
                 // Sleep briefly.
-                tokio::time::sleep(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS)).await;
+                tokio::time::sleep(MAX_FETCH_TIMEOUT).await;
 
                 // Remove the expired pending certificate requests.
                 let self__ = self_.clone();
@@ -520,9 +520,9 @@ impl<N: Network> Worker<N> {
                 self.format_transmission_id(transmission_id)
             );
         }
-        // Wait for the transmission to be fetched.
 
-        let transmission = timeout(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS), callback_receiver)
+        // Wait for the transmission to be fetched.
+        let transmission = timeout(MAX_FETCH_TIMEOUT, callback_receiver)
             .await
             .with_context(|| {
                 format!("Unable to fetch transmission {} (timeout)", self.format_transmission_id(transmission_id))
@@ -605,7 +605,7 @@ mod tests {
     use bytes::Bytes;
     use mockall::mock;
     use rand::RngExt;
-    use std::{io, ops::Range};
+    use std::{io, ops::Range, time::Duration};
 
     type CurrentNetwork = snarkvm::prelude::MainnetV0;
 

--- a/node/bft/tests/bft_e2e.rs
+++ b/node/bft/tests/bft_e2e.rs
@@ -21,7 +21,7 @@ mod components;
 use crate::common::primary::{TestNetwork, TestNetworkConfig};
 use deadline::deadline;
 use itertools::Itertools;
-use snarkos_node_bft::MAX_FETCH_TIMEOUT_IN_MS;
+use snarkos_node_bft::MAX_FETCH_TIMEOUT;
 use std::time::Duration;
 use tokio::time::sleep;
 
@@ -122,7 +122,7 @@ async fn test_quorum_threshold() {
     // Start the cannons for node 0.
     network.fire_transmissions_at(0, TRANSMISSION_INTERVAL_MS);
 
-    sleep(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS)).await;
+    sleep(MAX_FETCH_TIMEOUT).await;
 
     // Check each node is still at round 1.
     for validator in network.validators.values() {
@@ -133,7 +133,7 @@ async fn test_quorum_threshold() {
     network.connect_validators(0, 1).await;
     network.fire_transmissions_at(1, TRANSMISSION_INTERVAL_MS);
 
-    sleep(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS)).await;
+    sleep(MAX_FETCH_TIMEOUT).await;
 
     // Check each node is still at round 1.
     for validator in network.validators.values() {

--- a/node/bft/tests/bft_e2e.rs
+++ b/node/bft/tests/bft_e2e.rs
@@ -25,7 +25,7 @@ use snarkos_node_bft::MAX_FETCH_TIMEOUT;
 use std::time::Duration;
 use tokio::time::sleep;
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[ignore = "long-running e2e test"]
 async fn test_state_coherence() {
     const N: u16 = 4;
@@ -95,7 +95,7 @@ async fn test_resync() {
     deadline!(Duration::from_secs(20), move || { network_clone.is_round_reached(RECOVERY_ROUND) });
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_quorum_threshold() {
     // Start N nodes but don't connect them.
     const N: u16 = 4;

--- a/node/bft/tests/bft_e2e.rs
+++ b/node/bft/tests/bft_e2e.rs
@@ -37,8 +37,6 @@ async fn test_state_coherence() {
             bft: true,
             connect_all: true,
             fire_transmissions: Some(TRANSMISSION_INTERVAL_MS),
-            // Set this to Some(0..=4) to see the logs.
-            log_level: Some(0),
             log_connections: true,
         })
     })
@@ -50,7 +48,7 @@ async fn test_state_coherence() {
     std::future::pending::<()>().await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[ignore = "fails"]
 async fn test_resync() {
     // Start N nodes, connect them and start the cannons for each.
@@ -62,8 +60,6 @@ async fn test_resync() {
             bft: true,
             connect_all: true,
             fire_transmissions: Some(TRANSMISSION_INTERVAL_MS),
-            // Set this to Some(0..=4) to see the logs.
-            log_level: Some(0),
             log_connections: false,
         })
     })
@@ -83,7 +79,6 @@ async fn test_resync() {
         bft: true,
         connect_all: false,
         fire_transmissions: None,
-        log_level: None,
         log_connections: false,
     });
     spare_network.start().await;
@@ -112,8 +107,6 @@ async fn test_quorum_threshold() {
             bft: true,
             connect_all: false,
             fire_transmissions: None,
-            // Set this to Some(0..=4) to see the logs.
-            log_level: None,
             log_connections: true,
         })
     })
@@ -158,7 +151,7 @@ async fn test_quorum_threshold() {
     deadline!(Duration::from_secs(20), move || { net.is_round_reached(TARGET_ROUND) });
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_quorum_break() {
     // Start N nodes, connect them and start the cannons for each.
     const N: u16 = 4;
@@ -169,8 +162,6 @@ async fn test_quorum_break() {
             bft: true,
             connect_all: true,
             fire_transmissions: Some(TRANSMISSION_INTERVAL_MS),
-            // Set this to Some(0..=4) to see the logs.
-            log_level: None,
             log_connections: true,
         })
     })
@@ -192,7 +183,8 @@ async fn test_quorum_break() {
     assert!(network.is_halted().await);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+/// Tests that the all validators agree on the same leader for every even round.
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_leader_election_consistency() {
     // The minimum and maximum rounds to check for leader consistency.
     // From manual experimentation, the minimum round that works is 4.
@@ -209,8 +201,6 @@ async fn test_leader_election_consistency() {
             bft: true,
             connect_all: true,
             fire_transmissions: Some(CANNON_INTERVAL_MS),
-            // Set this to Some(0..=4) to see the logs.
-            log_level: None,
             log_connections: true,
         })
     })
@@ -253,7 +243,7 @@ async fn test_leader_election_consistency() {
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[ignore = "run multiple times to see failure"]
 async fn test_transient_break() {
     // Start N nodes, connect them and start the cannons for each.
@@ -265,8 +255,6 @@ async fn test_transient_break() {
             bft: true,
             connect_all: true,
             fire_transmissions: Some(TRANSMISSION_INTERVAL_MS),
-            // Set this to Some(0..=4) to see the logs.
-            log_level: Some(6),
             log_connections: false,
         })
     })

--- a/node/bft/tests/bft_e2e.rs
+++ b/node/bft/tests/bft_e2e.rs
@@ -239,7 +239,7 @@ async fn test_leader_election_consistency() {
         println!("Found {} validators with a leader ({} out of sync)", leaders.len(), validators.len() - leaders.len());
 
         // Assert that all leaders are equal
-        assert!(leaders.iter().all_equal());
+        assert!(leaders.iter().all_equal(), "Leaders are not equal: {leaders:?} for round {target_round}");
     }
 }
 

--- a/node/bft/tests/common/primary.rs
+++ b/node/bft/tests/common/primary.rs
@@ -253,9 +253,10 @@ impl TestNetwork {
     pub async fn connect_validators(&self, first_id: u16, second_id: u16) {
         let first_validator = self.validators.get(&first_id).unwrap();
         let second_validator_ip = self.validators.get(&second_id).unwrap().primary.gateway().local_ip();
-        let _ = first_validator.primary.gateway().connect(second_validator_ip);
-        // Give the connection time to be established.
-        sleep(Duration::from_millis(100)).await;
+        let gateway = first_validator.primary.gateway();
+        let handle = gateway.connect(second_validator_ip).expect("connection attempt failed");
+        // Await the full TCP + handshake completion instead of relying on a fixed sleep.
+        handle.await.unwrap().expect("connecting validators failed");
     }
 
     // Connects all nodes to each other.

--- a/node/bft/tests/common/primary.rs
+++ b/node/bft/tests/common/primary.rs
@@ -16,7 +16,7 @@
 use crate::common::{
     CurrentNetwork,
     TranslucentLedgerService,
-    utils::{fire_unconfirmed_solutions, fire_unconfirmed_transactions, initialize_logger},
+    utils::{fire_unconfirmed_solutions, fire_unconfirmed_transactions},
 };
 
 use snarkos_account::Account;
@@ -78,8 +78,6 @@ pub struct TestNetworkConfig {
     pub connect_all: bool,
     /// If `Some(i)` is set, the cannons will fire every `i` milliseconds.
     pub fire_transmissions: Option<u64>,
-    /// The log level to use for the test.
-    pub log_level: Option<u8>,
     /// If this is set to `true`, the number of connections is logged every 5 seconds.
     pub log_connections: bool,
 }
@@ -139,10 +137,6 @@ impl TestNetwork {
     // Creates a new test network with the given configuration.
     pub fn new(config: TestNetworkConfig) -> Self {
         let mut rng = TestRng::default();
-
-        if let Some(log_level) = config.log_level {
-            initialize_logger(log_level);
-        }
 
         let (accounts, committee) = new_test_committee(config.num_nodes, &mut rng);
         let bonded_balances: IndexMap<_, _> = committee

--- a/node/bft/tests/common/primary.rs
+++ b/node/bft/tests/common/primary.rs
@@ -22,7 +22,7 @@ use crate::common::{
 use snarkos_account::Account;
 use snarkos_node_bft::{
     BFT,
-    MAX_BATCH_DELAY_IN_MS,
+    MAX_BATCH_DELAY,
     MEMORY_POOL_PORT,
     Primary,
     helpers::{PrimarySender, Storage, init_primary_channels},
@@ -317,7 +317,7 @@ impl TestNetwork {
     // Checks if all the nodes have stopped progressing.
     pub async fn is_halted(&self) -> bool {
         let halt_round = self.validators.values().map(|v| v.primary.current_round()).max().unwrap();
-        sleep(Duration::from_millis(MAX_BATCH_DELAY_IN_MS * 2)).await;
+        sleep(MAX_BATCH_DELAY * 2).await;
         self.validators.values().all(|v| v.primary.current_round() <= halt_round)
     }
 

--- a/node/bft/tests/narwhal_e2e.rs
+++ b/node/bft/tests/narwhal_e2e.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 use deadline::deadline;
 use tokio::time::sleep;
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 #[ignore = "long-running e2e test"]
 async fn test_state_coherence() {
     const N: u16 = 4;
@@ -36,8 +36,6 @@ async fn test_state_coherence() {
             bft: false,
             connect_all: true,
             fire_transmissions: Some(TRANSMISSION_INTERVAL_MS),
-            // Set this to Some(0..=4) to see the logs.
-            log_level: Some(0),
             log_connections: true,
         })
     })
@@ -52,7 +50,7 @@ async fn test_state_coherence() {
     std::future::pending::<()>().await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_quorum_threshold() {
     // Start N nodes but don't connect them.
     const N: u16 = 4;
@@ -64,8 +62,6 @@ async fn test_quorum_threshold() {
             bft: false,
             connect_all: false,
             fire_transmissions: None,
-            // Set this to Some(0..=4) to see the logs.
-            log_level: None,
             log_connections: true,
         })
     })
@@ -110,7 +106,7 @@ async fn test_quorum_threshold() {
     deadline!(Duration::from_secs(20), move || { net.is_round_reached(TARGET_ROUND) });
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_quorum_break() {
     // Start N nodes, connect them and start the cannons for each.
     const N: u16 = 4;
@@ -121,8 +117,6 @@ async fn test_quorum_break() {
             bft: false,
             connect_all: true,
             fire_transmissions: Some(TRANSMISSION_INTERVAL_MS),
-            // Set this to Some(0..=4) to see the logs.
-            log_level: None,
             log_connections: true,
         })
     })
@@ -144,7 +138,7 @@ async fn test_quorum_break() {
     assert!(network.is_halted().await);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_storage_coherence() {
     // Start N nodes, connect them and start the cannons for each.
     const N: u16 = 4;
@@ -155,8 +149,6 @@ async fn test_storage_coherence() {
             bft: false,
             connect_all: true,
             fire_transmissions: Some(TRANSMISSION_INTERVAL_MS),
-            // Set this to Some(0..=4) to see the logs.
-            log_level: None,
             log_connections: true,
         })
     })

--- a/node/bft/tests/narwhal_e2e.rs
+++ b/node/bft/tests/narwhal_e2e.rs
@@ -17,7 +17,7 @@
 mod common;
 
 use crate::common::primary::{TestNetwork, TestNetworkConfig};
-use snarkos_node_bft::MAX_FETCH_TIMEOUT_IN_MS;
+use snarkos_node_bft::MAX_FETCH_TIMEOUT;
 
 use std::time::Duration;
 
@@ -77,7 +77,7 @@ async fn test_quorum_threshold() {
     // Start the cannons for node 0.
     network.fire_transmissions_at(0, TRANSMISSION_INTERVAL_MS);
 
-    sleep(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS)).await;
+    sleep(MAX_FETCH_TIMEOUT).await;
 
     // Check each node is still at round 1.
     for validator in network.validators.values() {
@@ -88,7 +88,7 @@ async fn test_quorum_threshold() {
     network.connect_validators(0, 1).await;
     network.fire_transmissions_at(1, TRANSMISSION_INTERVAL_MS);
 
-    sleep(Duration::from_millis(MAX_FETCH_TIMEOUT_IN_MS)).await;
+    sleep(MAX_FETCH_TIMEOUT).await;
 
     // Check each node is still at round 1.
     for validator in network.validators.values() {

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -510,6 +510,8 @@ impl<N: Network> Consensus<N> {
         // This loop wakes up either when a block is committed (signaled via notify) or after a timeout.
         // When a block is committed, the BFT workers have freed capacity for more transmissions.
         // The timeout serves as a fallback for startup or idle periods when blocks are not being produced.
+        //
+        // TODO(kaimast): wake up the loop after a proposal is created, not only when a block commits.
         let self_ = self.clone();
         self.spawn(async move {
             loop {

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -65,7 +65,10 @@ use lru::LruCache;
 #[cfg(not(feature = "locktick"))]
 use parking_lot::{Mutex, RwLock};
 use std::{future::Future, net::SocketAddr, num::NonZeroUsize, sync::Arc, time::Duration};
-use tokio::{sync::oneshot, task::JoinHandle};
+use tokio::{
+    sync::{Notify, oneshot},
+    task::JoinHandle,
+};
 
 #[cfg(feature = "metrics")]
 use std::collections::HashMap;
@@ -113,6 +116,8 @@ pub struct Consensus<N: Network> {
     ping: Arc<Ping<N>>,
     /// The block sync logic.
     block_sync: Arc<BlockSync<N>>,
+    /// Notifies when a block is committed, and relays it to the primary.
+    block_commit_notify: Arc<Notify>,
 }
 
 impl<N: Network> Consensus<N> {
@@ -163,6 +168,7 @@ impl<N: Network> Consensus<N> {
             transmissions_tracker: Default::default(),
             handles: Default::default(),
             ping: ping.clone(),
+            block_commit_notify: Arc::new(Notify::new()),
         };
 
         info!("Starting the consensus instance...");
@@ -501,13 +507,17 @@ impl<N: Network> Consensus<N> {
 
         // Process the unconfirmed transactions in the memory pool.
         //
-        // TODO (kaimast): This shouldn't happen periodically but only when new batches/blocks are accepted
-        // by the BFT layer, after which the worker's ready queue may have capacity for more transactions/solutions.
+        // This loop wakes up either when a block is committed (signaled via notify) or after a timeout.
+        // When a block is committed, the BFT workers have freed capacity for more transmissions.
+        // The timeout serves as a fallback for startup or idle periods when blocks are not being produced.
         let self_ = self.clone();
         self.spawn(async move {
             loop {
-                // Sleep briefly.
-                tokio::time::sleep(Duration::from_millis(MAX_BATCH_DELAY_IN_MS)).await;
+                // Wait for either a block commit notification or timeout.
+                tokio::select! {
+                    _ = self_.block_commit_notify.notified() => {}
+                    _ = tokio::time::sleep(Duration::from_millis(MAX_BATCH_DELAY_IN_MS)) => {}
+                }
                 // Process the unconfirmed transactions in the memory pool.
                 if let Err(err) = self_.process_unconfirmed_transactions().await {
                     warn!("{}", flatten_error(err.context("Cannot process unconfirmed transactions")));
@@ -541,6 +551,9 @@ impl<N: Network> Consensus<N> {
         if result.is_err() {
             // On failure, reinsert the transmissions into the memory pool.
             self.reinsert_transmissions(transmissions).await;
+        } else {
+            // On success, notify that the BFT workers have freed capacity for more transmissions.
+            self.block_commit_notify.notify_one();
         }
         // Send the callback **after** advancing to the next block.
         // Note: We must await the block to be advanced before sending the callback.

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -542,24 +542,29 @@ impl<N: Network> Consensus<N> {
         transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
         callback: oneshot::Sender<Result<bool>>,
     ) {
-        let recv_instant = std::time::Instant::now();
         // Try to advance to the next block.
         let self_ = self.clone();
         let transmissions_ = transmissions.clone();
         let result = spawn_blocking! { self_.try_advance_to_next_block(subdag, transmissions_).with_context(|| "Unable to advance to the next block") };
-        let total_elapsed = recv_instant.elapsed();
-        trace!("process_bft_subdag total (incl. spawn_blocking queue): {:.3}s", total_elapsed.as_secs_f64());
 
         // If the block failed to advance, reinsert the transmissions into the memory pool.
-        if result.is_err() {
-            // On failure, reinsert the transmissions into the memory pool.
-            self.reinsert_transmissions(transmissions).await;
-        } else {
-            // On success, notify that the BFT workers have freed capacity for more transmissions.
-            self.block_commit_notify.notify_one();
+        match result {
+            Ok(true) => {
+                // On success, notify that the BFT workers have freed capacity for more transmissions.
+                self.block_commit_notify.notify_one();
+            }
+            Ok(false) | Err(_) => {
+                if let Err(err) = self.reinsert_transmissions(transmissions).await {
+                    error!(
+                        "{}",
+                        flatten_error(
+                            err.context("Failed to reinsert transmissions after unsuccessful block advancement")
+                        )
+                    );
+                }
+            }
         }
-        // Send the callback **after** advancing to the next block.
-        // Note: We must await the block to be advanced before sending the callback.
+
         callback.send(result).ok();
     }
 
@@ -567,7 +572,7 @@ impl<N: Network> Consensus<N> {
     ///
     /// # Returns
     /// - `Ok(true)` if the ledger was advanced to the next block.
-    /// - `Ok(false)` if the block may be valide but the ledger already advanced.
+    /// - `Ok(false)` if the block may be valid but the ledger already advanced.
     /// - `Err(anyhow::Error)` for incorrect blocks and any other error.
     fn try_advance_to_next_block(
         &self,
@@ -681,27 +686,29 @@ impl<N: Network> Consensus<N> {
 
             // If telemetry is enabled, update participation scores.
             #[cfg(feature = "telemetry")]
-            match latest_committee {
-                Ok(latest_committee) => {
-                    // Retrieve the latest participation scores.
-                    let participation_scores = self
-                        .bft()
-                        .primary()
-                        .gateway()
-                        .validator_telemetry()
-                        .get_participation_scores(&latest_committee);
+            {
+                match latest_committee {
+                    Ok(latest_committee) => {
+                        // Retrieve the latest participation scores.
+                        let participation_scores = self
+                            .bft()
+                            .primary()
+                            .gateway()
+                            .validator_telemetry()
+                            .get_participation_scores(&latest_committee);
 
-                    // Log the participation scores.
-                    for (address, participation_score) in participation_scores {
-                        metrics::histogram_label(
-                            metrics::consensus::VALIDATOR_PARTICIPATION,
-                            "validator_address",
-                            address.to_string(),
-                            participation_score,
-                        )
+                        // Log the participation scores.
+                        for (address, participation_score) in participation_scores {
+                            metrics::histogram_label(
+                                metrics::consensus::VALIDATOR_PARTICIPATION,
+                                "validator_address",
+                                address.to_string(),
+                                participation_score,
+                            )
+                        }
                     }
+                    Err(err) => warn!("{}", flatten_error(err.context("Failed to get latest committee for telemetry"))),
                 }
-                Err(err) => warn!("{}", flatten_error(err.context("Failed to get latest committee for telemetry"))),
             }
         }
 
@@ -709,14 +716,14 @@ impl<N: Network> Consensus<N> {
     }
 
     /// Reinserts the given transmissions into the memory pool.
-    async fn reinsert_transmissions(&self, transmissions: IndexMap<TransmissionID<N>, Transmission<N>>) {
+    async fn reinsert_transmissions(&self, transmissions: IndexMap<TransmissionID<N>, Transmission<N>>) -> Result<()> {
         // Iterate over the transmissions.
         for (transmission_id, transmission) in transmissions.into_iter() {
             // Reinsert the transmission into the memory pool.
             match self.reinsert_transmission(transmission_id, transmission).await {
                 Ok(true) => {}
                 Ok(false) => debug!(
-                    "Unable to reinsert transmission {}.{} into the memory pool. Already exists.",
+                    "Unable to reinsert transmission {}:{} into the memory pool. Already exists.",
                     fmt_id(transmission_id),
                     fmt_id(transmission_id.checksum().unwrap_or_default()).dimmed()
                 ),
@@ -730,6 +737,8 @@ impl<N: Network> Consensus<N> {
                 }
             }
         }
+
+        Ok(())
     }
 
     /// Reinserts the given transmission into the memory pool.

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -27,7 +27,7 @@ extern crate snarkos_node_metrics as metrics;
 use snarkos_account::Account;
 use snarkos_node_bft::{
     BFT,
-    MAX_BATCH_DELAY_IN_MS,
+    MAX_BATCH_DELAY,
     Primary,
     helpers::{
         ConsensusReceiver,
@@ -64,7 +64,7 @@ use locktick::parking_lot::{Mutex, RwLock};
 use lru::LruCache;
 #[cfg(not(feature = "locktick"))]
 use parking_lot::{Mutex, RwLock};
-use std::{future::Future, net::SocketAddr, num::NonZeroUsize, sync::Arc, time::Duration};
+use std::{future::Future, net::SocketAddr, num::NonZeroUsize, sync::Arc};
 use tokio::{
     sync::{Notify, oneshot},
     task::JoinHandle,
@@ -516,7 +516,7 @@ impl<N: Network> Consensus<N> {
                 // Wait for either a block commit notification or timeout.
                 tokio::select! {
                     _ = self_.block_commit_notify.notified() => {}
-                    _ = tokio::time::sleep(Duration::from_millis(MAX_BATCH_DELAY_IN_MS)) => {}
+                    _ = tokio::time::sleep(MAX_BATCH_DELAY) => {}
                 }
                 // Process the unconfirmed transactions in the memory pool.
                 if let Err(err) = self_.process_unconfirmed_transactions().await {
@@ -542,10 +542,13 @@ impl<N: Network> Consensus<N> {
         transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
         callback: oneshot::Sender<Result<bool>>,
     ) {
+        let recv_instant = std::time::Instant::now();
         // Try to advance to the next block.
         let self_ = self.clone();
         let transmissions_ = transmissions.clone();
         let result = spawn_blocking! { self_.try_advance_to_next_block(subdag, transmissions_).with_context(|| "Unable to advance to the next block") };
+        let total_elapsed = recv_instant.elapsed();
+        trace!("process_bft_subdag total (incl. spawn_blocking queue): {:.3}s", total_elapsed.as_secs_f64());
 
         // If the block failed to advance, reinsert the transmissions into the memory pool.
         if result.is_err() {
@@ -581,10 +584,18 @@ impl<N: Network> Consensus<N> {
         // Create the candidate next block.
         let ledger_update = self.ledger.begin_ledger_update()?;
 
-        let block = match ledger_update
-            .prepare_advance_to_next_quorum_block(subdag, transmissions)
-            .and_then(|block| ledger_update.check_next_block(block))
-        {
+        let prepare_instant = std::time::Instant::now();
+        let block = match ledger_update.prepare_advance_to_next_quorum_block(subdag, transmissions) {
+            Ok(block) => block,
+            Err(err) => return Err(err.into_anyhow()),
+        };
+        let prepare_elapsed = prepare_instant.elapsed();
+        trace!("prepare_advance_to_next_quorum_block took {:.3}s", prepare_elapsed.as_secs_f64());
+        #[cfg(feature = "metrics")]
+        metrics::histogram(metrics::consensus::PREPARE_ADVANCE_SECS, prepare_elapsed.as_secs_f64());
+
+        let check_instant = std::time::Instant::now();
+        let block = match ledger_update.check_next_block(block) {
             Ok(block) => block,
             Err(CheckBlockError::BlockAlreadyExists { .. }) => {
                 debug!("The given block hash already exists in the ledger");
@@ -600,11 +611,20 @@ impl<N: Network> Consensus<N> {
             }
             Err(err) => return Err(err.into_anyhow()),
         };
+        let check_elapsed = check_instant.elapsed();
+        trace!("check_next_block took {:.3}s", check_elapsed.as_secs_f64());
+        #[cfg(feature = "metrics")]
+        metrics::histogram(metrics::consensus::CHECK_NEXT_BLOCK_SECS, check_elapsed.as_secs_f64());
 
         let block_height = block.height();
 
         // Advance to the next block.
+        let advance_instant = std::time::Instant::now();
         ledger_update.advance_to_next_block(&block)?;
+        let advance_elapsed = advance_instant.elapsed();
+        trace!("advance_to_next_block took {:.3}s", advance_elapsed.as_secs_f64());
+        #[cfg(feature = "metrics")]
+        metrics::histogram(metrics::consensus::ADVANCE_TO_NEXT_BLOCK_SECS, advance_elapsed.as_secs_f64());
 
         #[cfg(feature = "telemetry")]
         // Fetch the latest committee.

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -555,16 +555,7 @@ impl<N: Network> Consensus<N> {
                 // On success, notify that the BFT workers have freed capacity for more transmissions.
                 self.block_commit_notify.notify_one();
             }
-            Ok(false) | Err(_) => {
-                if let Err(err) = self.reinsert_transmissions(transmissions).await {
-                    error!(
-                        "{}",
-                        flatten_error(
-                            err.context("Failed to reinsert transmissions after unsuccessful block advancement")
-                        )
-                    );
-                }
-            }
+            Ok(false) | Err(_) => self.reinsert_transmissions(transmissions).await,
         }
 
         callback.send(result).ok();
@@ -725,7 +716,7 @@ impl<N: Network> Consensus<N> {
     }
 
     /// Reinserts the given transmissions into the memory pool.
-    async fn reinsert_transmissions(&self, transmissions: IndexMap<TransmissionID<N>, Transmission<N>>) -> Result<()> {
+    async fn reinsert_transmissions(&self, transmissions: IndexMap<TransmissionID<N>, Transmission<N>>) {
         // Iterate over the transmissions.
         for (transmission_id, transmission) in transmissions.into_iter() {
             // Reinsert the transmission into the memory pool.
@@ -746,8 +737,6 @@ impl<N: Network> Consensus<N> {
                 }
             }
         }
-
-        Ok(())
     }
 
     /// Reinserts the given transmission into the memory pool.

--- a/node/metrics/src/names.rs
+++ b/node/metrics/src/names.rs
@@ -99,6 +99,12 @@ pub mod consensus {
     pub const COMMITTED_CERTIFICATES: &str = "snarkos_consensus_committed_certificates_total";
     pub const BLOCK_LATENCY: &str = "snarkos_consensus_block_latency_secs";
     pub const BLOCK_LAG: &str = "snarkos_consensus_block_lag_ms";
+    /// Time spent in prepare_advance_to_next_quorum_block (block construction).
+    pub const PREPARE_ADVANCE_SECS: &str = "snarkos_consensus_prepare_advance_secs";
+    /// Time spent in check_next_block.
+    pub const CHECK_NEXT_BLOCK_SECS: &str = "snarkos_consensus_check_next_block_secs";
+    /// Time spent in advance_to_next_block (ledger write).
+    pub const ADVANCE_TO_NEXT_BLOCK_SECS: &str = "snarkos_consensus_advance_to_next_block_secs";
     pub const UNCONFIRMED_TRANSACTIONS: &str = "snarkos_consensus_unconfirmed_transactions_total";
     pub const UNCONFIRMED_SOLUTIONS: &str = "snarkos_consensus_unconfirmed_solutions_total";
     pub const TRANSMISSION_LATENCY: &str = "snarkos_consensus_transmission_latency";

--- a/node/router/tests/cleanups.rs
+++ b/node/router/tests/cleanups.rs
@@ -97,6 +97,12 @@ async fn test_connection_cleanups() {
     // Register final heap use.
     let heap_after_loop = PEAK_ALLOC.current_usage();
 
-    // Final heap use should equal that after the first connection.
-    assert_eq!(heap_after_one_conn.unwrap(), heap_after_loop);
+    // Final heap use should be close to that after the first connection.
+    // We allow up to 1 KiB of growth to accommodate small per-task allocations that
+    // tokio's runtime retains internally across connections (e.g. sharded queue state).
+    let heap_growth = heap_after_loop.saturating_sub(heap_after_one_conn.unwrap());
+    assert!(
+        heap_growth <= 1024,
+        "heap grew by {heap_growth} bytes after {NUM_CONNECTIONS} connections — possible memory leak"
+    );
 }

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -17,6 +17,7 @@ use crate::{
     helpers::{PeerPair, PrepareSyncRequest, SyncRequest},
     locators::BlockLocators,
 };
+use futures::future::BoxFuture;
 use snarkos_node_bft_ledger_service::{BeginLedgerUpdateError, LedgerService};
 use snarkos_node_router::messages::DataBlocks;
 use snarkos_node_sync_communication_service::CommunicationService;
@@ -29,6 +30,7 @@ use snarkvm::{
 };
 
 use anyhow::{Context, Result, anyhow, bail, ensure};
+use futures::FutureExt;
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 #[cfg(feature = "locktick")]
@@ -228,6 +230,9 @@ pub struct BlockSync<N: Network> {
 
     /// Tracks failed requests that need to be re-issued.
     failed_requests: Mutex<FailedRequests<N::BlockHash>>,
+
+    /// Condition variable that wakes up waiting tasks when the node is synced.
+    synced_notify: Notify,
 }
 
 impl<N: Network> BlockSync<N> {
@@ -248,6 +253,7 @@ impl<N: Network> BlockSync<N> {
             metrics: Default::default(),
             prepare_requests_lock: Default::default(),
             failed_requests: Default::default(),
+            synced_notify: Default::default(),
         }
     }
 
@@ -255,6 +261,9 @@ impl<N: Network> BlockSync<N> {
     /// or block request has been fully processed (either successfully or unsuccessfully).
     ///
     /// Used by the outgoing task.
+    ///
+    /// # Concurrency
+    /// Only one task can wait on this at a time.
     pub async fn wait_for_peer_update(&self) {
         self.peer_notify.notified().await
     }
@@ -262,6 +271,9 @@ impl<N: Network> BlockSync<N> {
     /// Blocks until there is a new response to a block request.
     ///
     /// Used by the incoming task.
+    ///
+    /// # Concurrency
+    /// Only one task can wait on this at a time.
     pub async fn wait_for_block_responses(&self) {
         self.response_notify.notified().await
     }
@@ -270,6 +282,56 @@ impl<N: Network> BlockSync<N> {
     #[inline]
     pub fn is_block_synced(&self) -> bool {
         self.sync_state.read().is_block_synced()
+    }
+
+    /// This futures blocks until the node is synced.
+    ///
+    /// # Concurrency
+    /// Multiple tasks can wait on this at the same time safely.
+    pub async fn wait_for_synced(&self) {
+        loop {
+            let mut fut = std::pin::pin!(self.synced_notify.notified());
+
+            {
+                let sync_state = self.sync_state.read();
+                if sync_state.is_block_synced() {
+                    return;
+                }
+
+                // Register this task as waiting before dropping the lock.
+                fut.as_mut().enable();
+            }
+
+            fut.await;
+        }
+    }
+
+    /// Similar as [`Self::wait_for_synced`] but returns `None` if the node is already synced.
+    /// Otherwise, it will return a future that behaves like `wait_for_synced`.
+    ///
+    /// # Concurrency
+    /// * This method is atomic, unlike calling `is_synced` and `wait_for_synced` sequentially.
+    /// * Multiple tasks can wait on this at the same time safely.
+    pub fn wait_for_synced_if_syncing(&self) -> Option<BoxFuture<()>> {
+        let mut notified = Box::pin(self.synced_notify.notified());
+
+        {
+            let sync_state = self.sync_state.read();
+            if sync_state.is_block_synced() {
+                return None;
+            }
+
+            // Register this task as waiting before dropping the lock.
+            notified.as_mut().enable();
+        }
+
+        Some(
+            async move {
+                notified.await;
+                self.wait_for_synced().await;
+            }
+            .boxed(),
+        )
     }
 
     /// Returns the number of blocks the node is behind the greatest peer height,
@@ -865,11 +927,22 @@ impl<N: Network> BlockSync<N> {
         }
 
         // -- Finally, update sync state and notify the sync loop about the change. --
-        if let Some(greatest_peer_height) = self.locators.read().values().map(|l| l.latest_locator_height()).max() {
-            self.sync_state.write().set_greatest_peer_height(greatest_peer_height);
+        let is_synced = if let Some(greatest_peer_height) =
+            self.locators.read().values().map(|l| l.latest_locator_height()).max()
+        {
+            let mut sync_state = self.sync_state.write();
+            sync_state.set_greatest_peer_height(greatest_peer_height);
+            sync_state.is_block_synced()
         } else {
             error!("Got new block locators but greatest peer height is zero.");
+            false
+        };
+
+        // For the unlikely case a peer's height gets lowered.
+        if is_synced {
+            self.synced_notify.notify_waiters();
         }
+
         // Even if the greatest peer height did not change, we still received new block locators
         // that the sync loop might need to proceed.
         self.peer_notify.notify_one();
@@ -893,12 +966,25 @@ impl<N: Network> BlockSync<N> {
         // Remove all block requests to the peer.
         self.remove_block_requests_to_peer(peer_ip);
 
-        // Update sync state, because the greatest peer height may have decreased.
-        if let Some(greatest_peer_height) = self.locators.read().values().map(|l| l.latest_locator_height()).max() {
-            self.sync_state.write().set_greatest_peer_height(greatest_peer_height);
-        } else {
-            // There are no more peers left.
-            self.sync_state.write().clear_greatest_peer_height();
+        let synced = {
+            // Do not lock sync state and locators at the same time.
+            let max_height = self.locators.read().values().map(|l| l.latest_locator_height()).max();
+            let mut sync_state = self.sync_state.write();
+
+            // Update sync state, because the greatest peer height may have decreased.
+            if let Some(greatest_peer_height) = max_height {
+                sync_state.set_greatest_peer_height(greatest_peer_height);
+            } else {
+                // There are no more peers left.
+                sync_state.clear_greatest_peer_height();
+            }
+
+            sync_state.is_block_synced()
+        };
+
+        // For the case where the maximum peer height gets lowered.
+        if synced {
+            self.synced_notify.notify_waiters();
         }
 
         // Notify the sync loop that something changed.
@@ -1109,14 +1195,18 @@ impl<N: Network> BlockSync<N> {
     /// This is a no-op if `new_height` is equal or less to the current sync height.
     pub fn set_sync_height(&self, new_height: u32) {
         // Scope state lock to avoid locking state and metrics at the same time.
-        let fully_synced = {
+        let (synced, fully_synced) = {
             let mut state = self.sync_state.write();
             state.set_sync_height(new_height);
-            !state.can_issue_new_block_requests()
+            (state.is_block_synced(), !state.can_issue_new_block_requests())
         };
 
         if fully_synced {
             self.metrics.mark_fully_synced();
+        }
+
+        if synced {
+            self.synced_notify.notify_waiters();
         }
     }
 
@@ -1690,6 +1780,7 @@ mod tests {
             common_ancestors: RwLock::new(sync.common_ancestors.read().clone()),
             requests: RwLock::new(sync.requests.read().clone()),
             sync_state: RwLock::new(sync.sync_state.read().clone()),
+            synced_notify: Notify::new(),
             advance_with_sync_blocks_lock: Default::default(),
             metrics: Default::default(),
             prepare_requests_lock: Default::default(),


### PR DESCRIPTION
This PR changes the batch creation task, to trigger on certain events, instead of only periodically. The goal is to avoid cases where a node is not ready to propose and then waits another MIN_BATCH_DELAY (1s) instead of only for the relevant conditions. It also ensures that the batch delay timer is reset whenever the node advances.

The most important changes in this PR are in `Primary::start_handlers` and the new `proposal_task.rs` module. The [README](https://github.com/ProvableHQ/snarkOS/pull/4149/changes#diff-88224c24f5c0399890a8698944fe09ebd9245fabce5e2e9d04a44695d98aa211) details when the batch creation task is woken up.

## Overview of Changes
The major change of this PR is to only have proposals occur in a single location -- the proposal task. It gets woken up on specific events, such as timer expiration or receiving sufficient certificates for a round.
Unlike before, where it woke up every second and retired independent of round advancement, it now correctly resets timers after advancing rounds. 

**Minor Changes**
* [6167485](https://github.com/ProvableHQ/snarkOS/pull/4190/commits/6167485d5abeb4c947c1f05551b7fc57a002eb30) changes some of the time constants to use `Duration`. This avoids the potential for incorrect conversion of these constants
* [cefe21b](https://github.com/ProvableHQ/snarkOS/pull/4190/commits/cefe21b96c6e4041fd1b711739d7359f7642fffc) moves the proposal logic to a dedicated `proposal_task` module. This enables unit testing its behavior and when it will be woken up.

## Testing
End-to-end stress tests passed:
<img width="599" height="293" alt="Screenshot 2026-03-30 at 5 08 16 PM" src="https://github.com/user-attachments/assets/b42f702e-9433-4188-92b5-894ecfd58fa7" />
