### PR TITLE
[Fix] Properly handle late-arriving signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -168,7 +168,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -243,9 +243,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -253,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -580,21 +580,15 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -662,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -684,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -737,7 +731,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -900,9 +894,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpubits"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -1070,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.87+curl-8.19.0"
+version = "0.4.88+curl-8.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a460380f0ef783703dcbe909107f39c162adeac050d73c850055118b5b6327"
+checksum = "644816de6547255eff4e491a1dda1c19b7237f00b62a61e6e64859ce4f2906d0"
 dependencies = [
  "cc",
  "libc",
@@ -1080,7 +1074,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1262,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
@@ -1338,15 +1332,15 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.16"
+version = "0.17.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91bbdd377139884fafcad8dc43a760a3e1e681aa26db910257fa6535b70e1829"
+checksum = "54fb064faabbee66e1fc8e5c5a9458d4269dc2d8b638fe86a425adb2510d1a96"
 dependencies = [
  "der 0.8.0",
- "digest 0.11.2",
+ "digest 0.11.3",
  "elliptic-curve",
  "rfc6979",
- "signature 3.0.0-rc.10",
+ "signature 3.0.0",
  "zeroize",
 ]
 
@@ -1383,14 +1377,14 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.30"
+version = "0.14.0-rc.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7a0bfd012613a7bcfe02cbfccf2b846e9ef9e1bccb641c48d461253cfb034d"
+checksum = "cda94f31325c4275e9706adecbb6f0650dee2f904c915a98e3d81adaaaa757aa"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "crypto-common 0.2.1",
- "digest 0.11.2",
+ "digest 0.11.3",
  "hybrid-array",
  "rand_core 0.10.1",
  "rustcrypto-ff",
@@ -1495,7 +1489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1855,9 +1849,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1976,7 +1970,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2069,9 +2063,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "subtle",
  "typenum",
@@ -2336,9 +2330,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2410,16 +2404,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is-docker"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2461,27 +2445,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote 1.0.45",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2515,9 +2504,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2542,9 +2531,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-rc.8"
+version = "0.14.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2c6c227649d5ec80eaae541f1736232641a0bcdb3062a52b34edb42054158"
+checksum = "1b382cbfd43caf55991a93850ce538aa1aa67bb264af367d22dfe7937c4e997d"
 dependencies = [
  "cpubits",
  "ecdsa",
@@ -2589,9 +2578,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
@@ -3085,9 +3074,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
-version = "5.3.3"
+version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
 dependencies = [
  "is-wsl",
  "libc",
@@ -3096,15 +3085,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3134,9 +3122,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -3315,7 +3303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3342,18 +3330,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -3623,9 +3611,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
 ]
@@ -3923,9 +3911,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4002,20 +3990,20 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.4.0"
+version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
 dependencies = [
  "libc",
  "rtoolbox",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rtoolbox"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327b72899159dfae8060c51a1f6aebe955245bcd9cc4997eed0f623caea022e4"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -4092,14 +4080,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4125,9 +4113,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4135,9 +4123,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -4151,7 +4139,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4162,9 +4150,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4417,9 +4405,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4436,9 +4424,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4476,7 +4464,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4537,11 +4525,11 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.10"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
  "rand_core 0.10.1",
 ]
 
@@ -4550,6 +4538,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -4574,9 +4578,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -4949,6 +4953,7 @@ dependencies = [
  "indexmap 2.14.0",
  "jsonwebtoken",
  "locktick",
+ "lru",
  "once_cell",
  "parking_lot",
  "rand 0.10.1",
@@ -6044,7 +6049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6281,7 +6286,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6365,14 +6370,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "test-log-macros"
-version = "0.2.19"
+name = "test-log-core"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be35209fd0781c5401458ab66e4f98accf63553e8fae7425503e92fdd319783b"
+checksum = "37d4d41320b48bc4a211a9021678fcc0c99569b594ea31c93735b8e517102b4c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9beb9249a81e430dffd42400a49019bcf548444f1968ff23080a625de0d4d320"
+dependencies = [
+ "syn 2.0.117",
+ "test-log-core",
 ]
 
 [[package]]
@@ -6547,9 +6562,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -6668,7 +6683,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -6738,9 +6753,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
@@ -6751,7 +6766,6 @@ dependencies = [
  "http-body-util",
  "http-range-header",
  "httpdate",
- "iri-string",
  "mime",
  "mime_guess",
  "percent-encoding",
@@ -6762,6 +6776,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -6893,9 +6908,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -7043,9 +7058,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",
@@ -7116,11 +7131,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -7129,14 +7144,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7147,9 +7162,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7157,9 +7172,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote 1.0.45",
  "wasm-bindgen-macro-support",
@@ -7167,9 +7182,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -7180,9 +7195,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -7223,9 +7238,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7243,18 +7258,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7374,7 +7389,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7455,15 +7470,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -7496,21 +7502,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -7548,12 +7539,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -7566,12 +7551,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7581,12 +7560,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7614,12 +7587,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7629,12 +7596,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7650,12 +7611,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7665,12 +7620,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7692,9 +7641,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"
@@ -7704,6 +7653,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -65,7 +65,7 @@ use snarkvm::{
         narwhal::{BatchCertificate, BatchHeader, Data, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
     },
-    prelude::{ConsensusVersion, committee::Committee},
+    prelude::{ConsensusVersion, Signature, committee::Committee},
     utilities::flatten_error,
 };
 
@@ -94,8 +94,46 @@ use std::{
 use tokio::sync::RwLock as TRwLock;
 use tokio::{sync::Notify, task::JoinHandle};
 
-/// A helper type to keep track of the latest proposed batch.
-pub(crate) type ProposedBatch<N> = RwLock<Option<Proposal<N>>>;
+/// The state of the primary's batch proposal.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ProposedBatchState<N: Network> {
+    /// No batch is currently being proposed.
+    None,
+    /// A batch is being proposed and awaiting signatures.
+    Certifying(Box<Proposal<N>>),
+    /// A batch has reached quorum and is being inserted into storage.
+    /// Carries the batch ID so late-arriving signatures can be recognized and silently dropped.
+    Certified(Field<N>),
+}
+
+impl<N: Network> Default for ProposedBatchState<N> {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+impl<N: Network> ProposedBatchState<N> {
+    /// Returns `true` if the primary has no active batch proposal.
+    pub fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+
+    /// Returns `true` if a batch is currently being proposed (awaiting signatures).
+    pub fn is_proposed(&self) -> bool {
+        matches!(self, Self::Certifying(_))
+    }
+
+    /// Returns a reference to the in-progress proposal, or `None` if not in the `Certifying` state.
+    pub fn as_proposal(&self) -> Option<&Proposal<N>> {
+        match self {
+            Self::Certifying(p) => Some(p.as_ref()),
+            _ => None,
+        }
+    }
+}
+
+/// A helper type to keep track of the state of the primary's batch proposal.
+pub type ProposedBatch<N> = RwLock<ProposedBatchState<N>>;
 
 /// This callback trait allows listening to changes in the Primary, such as round advancement.
 /// This is implemented by [`BFT`].
@@ -225,7 +263,10 @@ impl<N: Network> Primary<N> {
                         proposal_cache.into();
 
                     *self.latest_proposal_timestamp.write().await = Some((latest_certificate_round, now()));
-                    *self.proposed_batch.write() = proposed_batch;
+                    *self.proposed_batch.write() = match proposed_batch {
+                        Some(p) => ProposedBatchState::Certifying(Box::new(p)),
+                        None => ProposedBatchState::None,
+                    };
                     *self.signed_proposals.write() = signed_proposals;
 
                     // Update the storage with the pending certificates.
@@ -456,46 +497,55 @@ impl<N: Network> proposal_task::BatchPropose for Primary<N> {
             return Ok(false);
         }
 
-        // If there is a batch being proposed already,
-        // rebroadcast the batch header to the non-signers, and return early.
-        if let Some(proposal) = &*self.proposed_batch.read() {
-            // Ensure that the storage is caught up to the proposal before proceeding to rebroadcast this.
-            if round < proposal.round()
-                || proposal
-                    .batch_header()
-                    .previous_certificate_ids()
-                    .iter()
-                    .any(|id| !self.storage.contains_certificate(*id))
-            {
-                warn!(
-                    "Cannot propose a batch for round {} - the current storage (round {round}) is not caught up to the proposed batch.",
-                    proposal.round(),
-                );
+        // If there is a batch being proposed or certified already, handle accordingly.
+        match &*self.proposed_batch.read() {
+            ProposedBatchState::Certifying(proposal) => {
+                // Ensure that the storage is caught up to the proposal before proceeding to rebroadcast this.
+                if round < proposal.round()
+                    || proposal
+                        .batch_header()
+                        .previous_certificate_ids()
+                        .iter()
+                        .any(|id| !self.storage.contains_certificate(*id))
+                {
+                    warn!(
+                        "Cannot propose a batch for round {} - the current storage (round {round}) is not caught up to the proposed batch.",
+                        proposal.round(),
+                    );
+                    return Ok(false);
+                }
+                // Construct the event.
+                // TODO(ljedrz): the BatchHeader should be serialized only once in advance before being sent to non-signers.
+                let event = Event::BatchPropose(proposal.batch_header().clone().into());
+                // Iterate through the non-signers.
+                for address in proposal.nonsigners(&self.ledger.get_committee_lookback_for_round(proposal.round())?) {
+                    // Resolve the address to the peer IP.
+                    match self.gateway.resolver().read().get_peer_ip_for_address(address) {
+                        // Resend the batch proposal to the validator for signing.
+                        Some(peer_ip) => {
+                            let (gateway, event_, round) = (self.gateway.clone(), event.clone(), proposal.round());
+                            tokio::spawn(async move {
+                                debug!("Resending batch proposal for round {round} to peer '{peer_ip}'");
+                                // Resend the batch proposal to the peer.
+                                if gateway.send(peer_ip, event_).await.is_none() {
+                                    warn!("Failed to resend batch proposal for round {round} to peer '{peer_ip}'");
+                                }
+                            });
+                        }
+                        None => continue,
+                    }
+                }
+                debug!("Proposed batch for round {} is still valid", proposal.round());
                 return Ok(false);
             }
-            // Construct the event.
-            // TODO(ljedrz): the BatchHeader should be serialized only once in advance before being sent to non-signers.
-            let event = Event::BatchPropose(proposal.batch_header().clone().into());
-            // Iterate through the non-signers.
-            for address in proposal.nonsigners(&self.ledger.get_committee_lookback_for_round(proposal.round())?) {
-                // Resolve the address to the peer IP.
-                match self.gateway.resolver().read().get_peer_ip_for_address(address) {
-                    // Resend the batch proposal to the validator for signing.
-                    Some(peer_ip) => {
-                        let (gateway, event_, round) = (self.gateway.clone(), event.clone(), proposal.round());
-                        tokio::spawn(async move {
-                            debug!("Resending batch proposal for round {round} to peer '{peer_ip}'");
-                            // Resend the batch proposal to the peer.
-                            if gateway.send(peer_ip, event_).await.is_none() {
-                                warn!("Failed to resend batch proposal for round {round} to peer '{peer_ip}'");
-                            }
-                        });
-                    }
-                    None => continue,
-                }
+            // A batch is being certified; wait until it completes before proposing another.
+            ProposedBatchState::Certified(_) => {
+                debug!("Cannot propose a batch for round {round} - a batch is currently being certified");
+                return Ok(false);
             }
-            debug!("Proposed batch for round {} is still valid", proposal.round());
-            return Ok(false);
+            ProposedBatchState::None => {
+                // No batch in progress, so it is save to propose a new one.
+            }
         }
 
         #[cfg(feature = "metrics")]
@@ -755,8 +805,8 @@ impl<N: Network> proposal_task::BatchPropose for Primary<N> {
 
         // Broadcast the batch to all validators for signing.
         self.gateway.broadcast(Event::BatchPropose(batch_header.into()));
-        // Store the proposal.
-        *self.proposed_batch.write() = Some(proposal);
+        // Store the proposal in memory.
+        *self.proposed_batch.write() = ProposedBatchState::Certifying(Box::new(proposal));
         // Record the wall-clock time at which the batch was proposed.
         #[cfg(feature = "metrics")]
         {
@@ -1060,6 +1110,105 @@ impl<N: Network> Primary<N> {
         Ok(())
     }
 
+    /// Attempts to add a peer's `signature` for `batch_id` to the current proposal.
+    ///
+    /// Consumes `state` and always returns the (possibly updated) state alongside a result so that
+    /// the caller can restore it unconditionally, keeping `proposed_batch` consistent even on the
+    /// error path.
+    ///
+    /// # Returns
+    /// * `(Ok(Some(proposal)), Certified(id))` — quorum reached; caller should certify.
+    /// * `(Ok(None), <restored state>)` — signature accepted or silently dropped; nothing to do.
+    /// * `(Err(e), <restored state>)` — signature rejected; caller should propagate the error.
+    fn add_signature_to_batch(
+        &self,
+        state: ProposedBatchState<N>,
+        peer_ip: SocketAddr,
+        batch_id: Field<N>,
+        signature: Signature<N>,
+    ) -> (Result<Option<Proposal<N>>>, ProposedBatchState<N>) {
+        match state {
+            ProposedBatchState::Certifying(mut proposal) if proposal.batch_id() == batch_id => {
+                // This signature is for our currently active proposal.
+                // Use an inner closure to keep `?` ergonomics while returning a tuple.
+                let inner: Result<bool> = (|| {
+                    let committee_lookback = self.ledger.get_committee_lookback_for_round(proposal.round())?;
+                    let Some(signer) = self.gateway.resolve_to_aleo_addr(peer_ip) else {
+                        bail!("Signature is from a disconnected validator");
+                    };
+                    let new_signature = proposal.add_signature(signer, signature, &committee_lookback)?;
+                    if new_signature {
+                        info!("Received a batch signature for round {} from '{peer_ip}'", proposal.round());
+                        Ok(proposal.is_quorum_threshold_reached(&committee_lookback))
+                    } else {
+                        debug!(
+                            "Received duplicated signature from '{peer_ip}' for batch \
+                                {batch_id} in round {round}",
+                            round = proposal.round()
+                        );
+                        Ok(false)
+                    }
+                })();
+                match inner {
+                    Ok(true) => {
+                        let certified_id = proposal.batch_id();
+                        (Ok(Some(*proposal)), ProposedBatchState::Certified(certified_id))
+                    }
+                    Ok(false) => (Ok(None), ProposedBatchState::Certifying(proposal)),
+                    Err(e) => (Err(e), ProposedBatchState::Certifying(proposal)),
+                }
+            }
+            ProposedBatchState::Certifying(proposal) => {
+                // Certifying a different proposal — check if batch_id is already in storage.
+                if self.storage.contains_batch(batch_id) {
+                    debug!(
+                        "Primary is safely skipping a batch signature from {peer_ip} for \
+                            round {} - batch is already certified",
+                        proposal.round()
+                    );
+                    (Ok(None), ProposedBatchState::Certifying(proposal))
+                } else {
+                    let expected_id = proposal.batch_id();
+                    let round = proposal.round();
+                    (
+                        Err(anyhow!("Unknown batch ID '{batch_id}', expected '{expected_id}' for round {round}")),
+                        ProposedBatchState::Certifying(proposal),
+                    )
+                }
+            }
+            ProposedBatchState::Certified(id) if id == batch_id => {
+                // Quorum already reached; late-arriving signature is harmless.
+                debug!(
+                    "Skipping batch signature from {peer_ip} for batch '{batch_id}' - \
+                        already received sufficient signatures"
+                );
+                (Ok(None), ProposedBatchState::Certified(id))
+            }
+            ProposedBatchState::Certified(id) => {
+                let result = if self.storage.contains_batch(batch_id) {
+                    // This is most likely not malicious, but could indicate connectivity issues.
+                    warn!("Received signature for an older batch {batch_id}");
+                    Ok(None)
+                } else {
+                    Err(anyhow!("Unknown batch ID '{batch_id}'"))
+                };
+
+                (result, ProposedBatchState::Certified(id))
+            }
+            ProposedBatchState::None => {
+                let result = if self.storage.contains_batch(batch_id) {
+                    // This is most likely not malicious, but could indicate connectivity issues.
+                    warn!("Received signature for an older batch {batch_id}");
+                    Ok(None)
+                } else {
+                    Err(anyhow!("Unknown batch ID '{batch_id}'"))
+                };
+
+                (result, ProposedBatchState::None)
+            }
+        }
+    }
+
     /// Processes a batch signature from a peer.
     ///
     /// This method performs the following steps:
@@ -1097,60 +1246,11 @@ impl<N: Network> Primary<N> {
         let Some(proposal) = spawn_blocking!({
             // Acquire the write lock.
             let mut proposed_batch = self_.proposed_batch.write();
-            // Add the signature to the batch, and determine if the batch is ready to be certified.
-            match proposed_batch.as_mut() {
-                Some(proposal) => {
-                    // Ensure the batch ID matches the currently proposed batch ID.
-                    if proposal.batch_id() != batch_id {
-                        match self_.storage.contains_batch(batch_id) {
-                            // If this batch was already certified, return early.
-                            true => {
-                                debug!(
-                                    "Primary is safely skipping a a batch signature from {peer_ip} for round {} - batch is already certified",
-                                    proposal.round()
-                                );
-                                return Ok(None);
-                            }
-                            // If the batch ID is unknown, return an error.
-                            false => bail!(
-                                "Unknown batch ID '{batch_id}', expected '{}' for round {}",
-                                proposal.batch_id(),
-                                proposal.round()
-                            ),
-                        }
-                    }
-                    // Retrieve the committee lookback for the round.
-                    let committee_lookback = self_.ledger.get_committee_lookback_for_round(proposal.round())?;
-                    // Retrieve the address of the validator.
-                    let Some(signer) = self_.gateway.resolve_to_aleo_addr(peer_ip) else {
-                        bail!("Signature is from a disconnected validator");
-                    };
-                    // Add the signature to the batch.
-                    let new_signature = proposal.add_signature(signer, signature, &committee_lookback)?;
 
-                    if new_signature {
-                        info!("Received a batch signature for round {} from '{peer_ip}'", proposal.round());
-                        // Check if the batch is ready to be certified.
-                        if !proposal.is_quorum_threshold_reached(&committee_lookback) {
-                            // If the batch is not ready to be certified, return early.
-                            return Ok(None);
-                        }
-                    } else {
-                        debug!(
-                            "Received duplicated signature from '{peer_ip}' for batch {batch_id} in round {round}",
-                            round = proposal.round()
-                        );
-                        return Ok(None);
-                    }
-                }
-                // There is no proposed batch, so return early.
-                None => return Ok(None),
-            };
-            // Retrieve the batch proposal, clearing the proposed batch.
-            match proposed_batch.take() {
-                Some(proposal) => Ok(Some(proposal)),
-                None => Ok(None),
-            }
+            let (result, new_state) =
+                self_.add_signature_to_batch(std::mem::take(&mut *proposed_batch), peer_ip, batch_id, signature);
+            *proposed_batch = new_state;
+            result
         })?
         else {
             return Ok(());
@@ -1590,15 +1690,16 @@ impl<N: Network> Primary<N> {
     /// Checks if the proposed batch is expired, and clears the proposed batch if it has expired.
     fn check_proposed_batch_for_expiration(&self) -> Result<()> {
         // Check if the proposed batch is timed out or stale.
-        let is_expired = match self.proposed_batch.read().as_ref() {
-            Some(proposal) => proposal.round() < self.current_round(),
-            None => false,
+        // A batch being certified is not considered expired.
+        let is_expired = match &*self.proposed_batch.read() {
+            ProposedBatchState::Certifying(proposal) => proposal.round() < self.current_round(),
+            _ => false,
         };
         // If the batch is expired, clear the proposed batch.
         if is_expired {
             // Reset the proposed batch.
-            let proposal = self.proposed_batch.write().take();
-            if let Some(proposal) = proposal {
+            let old = std::mem::replace(&mut *self.proposed_batch.write(), ProposedBatchState::None);
+            if let ProposedBatchState::Certifying(proposal) = old {
                 debug!("Cleared expired proposal for round {}", proposal.round());
                 self.reinsert_transmissions_into_workers(proposal.into_transmissions())?;
             }
@@ -1616,7 +1717,7 @@ impl<N: Network> Primary<N> {
                 // Update to the next round in storage.
                 fast_forward_round = self.storage.increment_to_next_round(fast_forward_round)?;
                 // Clear the proposed batch.
-                *self.proposed_batch.write() = None;
+                *self.proposed_batch.write() = ProposedBatchState::None;
             }
         }
 
@@ -1664,10 +1765,10 @@ impl<N: Network> Primary<N> {
             bail!("Primary is on round {current_round}, and no longer signing for round {batch_round}")
         }
         // Check if the primary is still signing for the batch round.
-        if let Some(signing_round) = self.proposed_batch.read().as_ref().map(|proposal| proposal.round())
-            && signing_round > batch_round
+        if let ProposedBatchState::Certifying(proposal) = &*self.proposed_batch.read()
+            && proposal.round() > batch_round
         {
-            bail!("Our primary at round {signing_round} is no longer signing for round {batch_round}")
+            bail!("Our primary at round {} is no longer signing for round {batch_round}", proposal.round())
         }
         Ok(())
     }
@@ -1734,6 +1835,10 @@ impl<N: Network> Primary<N> {
         let (storage, certificate_) = (self.storage.clone(), certificate.clone());
         spawn_blocking!(storage.insert_certificate(certificate_, transmissions, Default::default()))?;
         debug!("Stored a batch certificate for round {}", certificate.round());
+        // The batch is now in storage, so late-arriving signatures can find it via contains_batch.
+        // Transition from Certified back to None.
+        *self.proposed_batch.write() = ProposedBatchState::None;
+
         // If a BFT sender was provided, send the certificate to the BFT.
         if let Some(cb) = self.primary_callback.get() {
             // Await the callback to continue.
@@ -2063,7 +2168,13 @@ impl<N: Network> Primary<N> {
         self.handles.lock().drain(..).for_each(|handle| handle.abort());
         // Save the current proposal cache to disk.
         let proposal_cache = {
-            let proposal = self.proposed_batch.write().take();
+            // Only persist a Certifying batch; a Certified batch will appear in pending_certificates.
+            // Note: it is guaranteed that there are no concurrent accesses to `proposed_batch` as all
+            // background tasks already terminated at this point.
+            let proposal = match std::mem::replace(&mut *self.proposed_batch.write(), ProposedBatchState::None) {
+                ProposedBatchState::Certifying(p) => Some(*p),
+                _ => None,
+            };
             let signed_proposals = self.signed_proposals.read().clone();
             let latest_round = proposal
                 .as_ref()
@@ -2248,7 +2359,7 @@ mod tests {
             if account.address() == primary.gateway.account().address() {
                 continue;
             }
-            let batch_id = primary.proposed_batch.read().as_ref().unwrap().batch_id();
+            let batch_id = primary.proposed_batch.read().as_proposal().unwrap().batch_id();
             let signature = account.sign(&[batch_id], rng).unwrap();
             signatures.push((*socket_addr, BatchSignature::new(batch_id, signature)));
         }
@@ -2376,7 +2487,7 @@ mod tests {
 
         // Try to propose a batch again. This time, it should succeed.
         assert!(primary.propose_batch().await.is_ok());
-        assert!(primary.proposed_batch.read().is_some());
+        assert!(primary.proposed_batch.read().is_proposed());
     }
 
     #[tokio::test]
@@ -2389,7 +2500,7 @@ mod tests {
 
         // Try to propose a batch with no transmissions.
         assert!(primary.propose_batch().await.is_ok());
-        assert!(primary.proposed_batch.read().is_some());
+        assert!(primary.proposed_batch.read().is_proposed());
     }
 
     #[tokio::test]
@@ -2414,7 +2525,7 @@ mod tests {
 
         // Propose a batch again. This time, it should succeed.
         assert!(primary.propose_batch().await.is_ok());
-        assert!(primary.proposed_batch.read().is_some());
+        assert!(primary.proposed_batch.read().is_proposed());
     }
 
     #[tokio::test]
@@ -2481,7 +2592,7 @@ mod tests {
         assert!(primary.propose_batch().await.is_ok());
 
         // Check that the proposal only contains the new transmissions that were not in previous certificates.
-        let proposed_transmissions = primary.proposed_batch.read().as_ref().unwrap().transmissions().clone();
+        let proposed_transmissions = primary.proposed_batch.read().as_proposal().unwrap().transmissions().clone();
         assert_eq!(proposed_transmissions.len(), 2);
         assert!(proposed_transmissions.contains_key(&TransmissionID::Solution(solution_commitment, solution_checksum)));
         assert!(
@@ -2520,7 +2631,7 @@ mod tests {
         // Try to propose a batch again. This time, it should succeed.
         assert!(primary.propose_batch().await.is_ok());
         // Expect 2/5 transactions to be included in the proposal in addition to the solution.
-        assert_eq!(primary.proposed_batch.read().as_ref().unwrap().transmissions().len(), 3);
+        assert_eq!(primary.proposed_batch.read().as_proposal().unwrap().transmissions().len(), 3);
         // Check the transmissions were correctly drained from the workers.
         assert_eq!(primary.workers().iter().map(|worker| worker.transmissions().len()).sum::<usize>(), 3);
     }
@@ -2881,7 +2992,7 @@ mod tests {
 
         // Try to propose a batch again. This time, it should succeed.
         assert!(primary.propose_batch().await.is_ok());
-        assert!(primary.proposed_batch.read().is_some());
+        assert!(primary.proposed_batch.read().is_proposed());
     }
 
     #[tokio::test]
@@ -2906,12 +3017,12 @@ mod tests {
         );
 
         // Store the proposal on the primary.
-        *primary.proposed_batch.write() = Some(proposal);
+        *primary.proposed_batch.write() = ProposedBatchState::Certifying(Box::new(proposal));
 
         // Try to propose a batch will terminate early because the storage is behind the proposal.
         assert!(primary.propose_batch().await.is_ok());
-        assert!(primary.proposed_batch.read().is_some());
-        assert!(primary.proposed_batch.read().as_ref().unwrap().round() > primary.current_round());
+        assert!(primary.proposed_batch.read().is_proposed());
+        assert!(primary.proposed_batch.read().as_proposal().unwrap().round() > primary.current_round());
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -2934,7 +3045,7 @@ mod tests {
         );
 
         // Store the proposal on the primary.
-        *primary.proposed_batch.write() = Some(proposal);
+        *primary.proposed_batch.write() = ProposedBatchState::Certifying(Box::new(proposal));
 
         // Each committee member signs the batch.
         let signatures = peer_signatures_for_proposal(&primary, &accounts, &mut rng);
@@ -2975,7 +3086,7 @@ mod tests {
         );
 
         // Store the proposal on the primary.
-        *primary.proposed_batch.write() = Some(proposal);
+        *primary.proposed_batch.write() = ProposedBatchState::Certifying(Box::new(proposal));
 
         // Each committee member signs the batch.
         let signatures = peer_signatures_for_proposal(&primary, &accounts, &mut rng);
@@ -3013,7 +3124,7 @@ mod tests {
         );
 
         // Store the proposal on the primary.
-        *primary.proposed_batch.write() = Some(proposal);
+        *primary.proposed_batch.write() = ProposedBatchState::Certifying(Box::new(proposal));
 
         // Each committee member signs the batch.
         let signatures = peer_signatures_for_proposal(&primary, &accounts, &mut rng);
@@ -3051,7 +3162,7 @@ mod tests {
         );
 
         // Store the proposal on the primary.
-        *primary.proposed_batch.write() = Some(proposal);
+        *primary.proposed_batch.write() = ProposedBatchState::Certifying(Box::new(proposal));
 
         // Each committee member signs the batch.
         let signatures = peer_signatures_for_proposal(&primary, &accounts, &mut rng);
@@ -3064,6 +3175,143 @@ mod tests {
         assert!(!primary.storage.contains_certificate_in_round_from(round, primary.gateway.account().address()));
         // Check the round was incremented.
         assert_eq!(primary.current_round(), round);
+    }
+
+    // Tests that a late-arriving signature for a batch that is currently being certified
+    // (ProposedBatchState::Certified) is silently dropped without error.
+    // This exercises the race condition where proposed_batch.take() has been called but
+    // insert_certificate has not yet completed.
+    #[tokio::test]
+    async fn test_batch_signature_from_peer_batch_being_certified() {
+        let mut rng = TestRng::default();
+        let (primary, accounts) = primary_without_handlers(&mut rng);
+        map_account_addresses(&primary, &accounts);
+
+        // Create a valid proposal.
+        let round = 1;
+        let timestamp = now() + MIN_BATCH_DELAY.as_secs() as i64;
+        let proposal = create_test_proposal(
+            primary.gateway.account(),
+            primary.ledger.current_committee().unwrap(),
+            round,
+            Default::default(),
+            timestamp,
+            1,
+            &mut rng,
+        );
+        let batch_id = proposal.batch_id();
+
+        // Simulate the race: the batch has been taken for certification but not yet stored.
+        *primary.proposed_batch.write() = ProposedBatchState::Certified(batch_id);
+
+        // Send a late signature for the batch being certified.
+        let (socket_addr, account) =
+            accounts.iter().find(|(_, a)| a.address() != primary.gateway.account().address()).unwrap();
+        let signature = account.sign(&[batch_id], &mut rng).unwrap();
+        let batch_signature = BatchSignature::new(batch_id, signature);
+
+        // The signature should be accepted without error (silently dropped).
+        assert!(primary.process_batch_signature_from_peer(*socket_addr, batch_signature).await.is_ok());
+        // The batch state is unchanged (still BeingCertified — no new proposal was set).
+        assert!(matches!(&*primary.proposed_batch.read(), ProposedBatchState::Certified(id) if *id == batch_id));
+    }
+
+    // Tests that a signature for a completely unknown batch ID is rejected even when another
+    // batch is being certified. The BeingCertified state only suppresses errors for its own ID.
+    #[tokio::test]
+    async fn test_batch_signature_from_peer_unknown_id_while_certifying() {
+        let mut rng = TestRng::default();
+        let (primary, accounts) = primary_without_handlers(&mut rng);
+        map_account_addresses(&primary, &accounts);
+
+        // Create two proposals so we have two distinct batch IDs.
+        let round = 1;
+        let timestamp = now() + MIN_BATCH_DELAY.as_secs() as i64;
+        let proposal_a = create_test_proposal(
+            primary.gateway.account(),
+            primary.ledger.current_committee().unwrap(),
+            round,
+            Default::default(),
+            timestamp,
+            1,
+            &mut rng,
+        );
+        let proposal_b = create_test_proposal(
+            primary.gateway.account(),
+            primary.ledger.current_committee().unwrap(),
+            round,
+            Default::default(),
+            timestamp,
+            1,
+            &mut rng,
+        );
+        let batch_id_a = proposal_a.batch_id();
+        let batch_id_b = proposal_b.batch_id();
+        assert_ne!(batch_id_a, batch_id_b);
+
+        // Simulate certifying batch A.
+        *primary.proposed_batch.write() = ProposedBatchState::Certified(batch_id_a);
+
+        // Send a signature for batch B (a genuinely unknown ID).
+        let (socket_addr, account) =
+            accounts.iter().find(|(_, a)| a.address() != primary.gateway.account().address()).unwrap();
+        let signature = account.sign(&[batch_id_b], &mut rng).unwrap();
+        let batch_signature = BatchSignature::new(batch_id_b, signature);
+
+        // The signature is for a genuinely unknown ID — should be rejected with an error.
+        assert!(primary.process_batch_signature_from_peer(*socket_addr, batch_signature).await.is_err());
+    }
+
+    // Tests the "already certified" path: a signature arrives after the batch is fully in
+    // storage and the primary has moved on to a new proposal.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_batch_signature_from_peer_already_certified() {
+        let mut rng = TestRng::default();
+        let (primary, accounts) = primary_without_handlers(&mut rng);
+        map_account_addresses(&primary, &accounts);
+
+        // Create and certify a batch so it lands in storage.
+        let round = 1;
+        let timestamp = now() + MIN_BATCH_DELAY.as_secs() as i64;
+        let old_proposal = create_test_proposal(
+            primary.gateway.account(),
+            primary.ledger.current_committee().unwrap(),
+            round,
+            Default::default(),
+            timestamp,
+            1,
+            &mut rng,
+        );
+        let old_batch_id = old_proposal.batch_id();
+        *primary.proposed_batch.write() = ProposedBatchState::Certifying(Box::new(old_proposal));
+        let signatures = peer_signatures_for_proposal(&primary, &accounts, &mut rng);
+        for (socket_addr, signature) in signatures {
+            primary.process_batch_signature_from_peer(socket_addr, signature).await.unwrap();
+        }
+        // The batch is now in storage.
+        assert!(primary.storage.contains_certificate_in_round_from(round, primary.gateway.account().address()));
+
+        // Simulate a new proposal being active.
+        let new_proposal = create_test_proposal(
+            primary.gateway.account(),
+            primary.ledger.current_committee().unwrap(),
+            round,
+            Default::default(),
+            timestamp,
+            1,
+            &mut rng,
+        );
+        assert_ne!(new_proposal.batch_id(), old_batch_id);
+        *primary.proposed_batch.write() = ProposedBatchState::Certifying(Box::new(new_proposal));
+
+        // Send a late signature for the already-certified old batch.
+        let (socket_addr, account) =
+            accounts.iter().find(|(_, a)| a.address() != primary.gateway.account().address()).unwrap();
+        let signature = account.sign(&[old_batch_id], &mut rng).unwrap();
+        let batch_signature = BatchSignature::new(old_batch_id, signature);
+
+        // Should be silently accepted (already certified path).
+        assert!(primary.process_batch_signature_from_peer(*socket_addr, batch_signature).await.is_ok());
     }
 
     #[tokio::test]
@@ -3146,5 +3394,210 @@ mod tests {
             assert!(primary.storage.contains_transmission(aborted_transmission_id));
             assert!(primary.storage.get_transmission(aborted_transmission_id).is_none());
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // add_signature_to_batch
+    // -----------------------------------------------------------------------
+
+    /// State is `None` and the batch is not in storage — returns an error, state stays `None`.
+    #[test]
+    fn test_add_signature_to_batch_none_state() {
+        let mut rng = TestRng::default();
+        let (primary, accounts) = primary_without_handlers(&mut rng);
+
+        let peer_ip = accounts[1].0;
+        let batch_id = Field::rand(&mut rng);
+        let signature = accounts[1].1.sign(&[batch_id], &mut rng).unwrap();
+
+        let (result, new_state) =
+            primary.add_signature_to_batch(ProposedBatchState::None, peer_ip, batch_id, signature);
+
+        assert!(result.is_err());
+        assert_eq!(new_state, ProposedBatchState::None);
+    }
+
+    /// State is `Certified` with a matching batch ID — silently dropped, state restored.
+    #[test]
+    fn test_add_signature_to_batch_certified_matching_id() {
+        let mut rng = TestRng::default();
+        let (primary, accounts) = primary_without_handlers(&mut rng);
+
+        let peer_ip = accounts[1].0;
+        let batch_id = Field::rand(&mut rng);
+        let signature = accounts[1].1.sign(&[batch_id], &mut rng).unwrap();
+
+        let (result, new_state) =
+            primary.add_signature_to_batch(ProposedBatchState::Certified(batch_id), peer_ip, batch_id, signature);
+
+        assert!(result.unwrap().is_none());
+        assert_eq!(new_state, ProposedBatchState::Certified(batch_id));
+    }
+
+    /// State is `Certified` with a *different* batch ID — error returned, state becomes `None`.
+    #[test]
+    fn test_add_signature_to_batch_certified_different_id() {
+        let mut rng = TestRng::default();
+        let (primary, accounts) = primary_without_handlers(&mut rng);
+
+        let peer_ip = accounts[1].0;
+        let certified_id = Field::rand(&mut rng);
+        let other_id = Field::rand(&mut rng);
+        let signature = accounts[1].1.sign(&[other_id], &mut rng).unwrap();
+
+        let (result, new_state) =
+            primary.add_signature_to_batch(ProposedBatchState::Certified(certified_id), peer_ip, other_id, signature);
+
+        assert!(result.is_err());
+        assert_eq!(new_state, ProposedBatchState::Certified(certified_id));
+    }
+
+    /// State is `Certifying` for a *different* batch ID that **is already in storage** — silently
+    /// dropped, state restored.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_add_signature_to_batch_certifying_different_id_in_storage() {
+        let round = 1;
+        let mut rng = TestRng::default();
+        let (primary, accounts) = primary_without_handlers(&mut rng);
+        map_account_addresses(&primary, &accounts);
+
+        // Create a proposal owned by the primary.
+        let proposal = create_test_proposal(
+            primary.gateway.account(),
+            primary.ledger.current_committee().unwrap(),
+            round,
+            Default::default(),
+            now(),
+            0,
+            &mut rng,
+        );
+        let proposal_batch_id = proposal.batch_id();
+
+        // Create and store a *different* certificate so `contains_batch` returns true for it.
+        let (certificate, transmissions) =
+            create_batch_certificate(accounts[1].1.address(), &accounts, round, Default::default(), &mut rng);
+        let stored_batch_id = certificate.batch_id();
+        primary.storage.insert_certificate(certificate, transmissions, Default::default()).unwrap();
+
+        let peer_ip = accounts[1].0;
+        let signature = accounts[1].1.sign(&[stored_batch_id], &mut rng).unwrap();
+
+        let (result, new_state) = primary.add_signature_to_batch(
+            ProposedBatchState::Certifying(Box::new(proposal)),
+            peer_ip,
+            stored_batch_id,
+            signature,
+        );
+
+        assert!(result.unwrap().is_none());
+        // State is restored with the original proposal.
+        assert_eq!(new_state.as_proposal().unwrap().batch_id(), proposal_batch_id);
+    }
+
+    /// State is `Certifying` for a *different* batch ID that is **not in storage** — error
+    /// returned, state restored.
+    #[test]
+    fn test_add_signature_to_batch_certifying_different_id_unknown() {
+        let mut rng = TestRng::default();
+        let (primary, accounts) = primary_without_handlers(&mut rng);
+
+        let proposal = create_test_proposal(
+            primary.gateway.account(),
+            primary.ledger.current_committee().unwrap(),
+            1,
+            Default::default(),
+            now(),
+            0,
+            &mut rng,
+        );
+        let proposal_batch_id = proposal.batch_id();
+
+        let peer_ip = accounts[1].0;
+        let unknown_id = Field::rand(&mut rng);
+        let signature = accounts[1].1.sign(&[unknown_id], &mut rng).unwrap();
+
+        let (result, new_state) = primary.add_signature_to_batch(
+            ProposedBatchState::Certifying(Box::new(proposal)),
+            peer_ip,
+            unknown_id,
+            signature,
+        );
+
+        assert!(result.is_err());
+        assert_eq!(new_state.as_proposal().unwrap().batch_id(), proposal_batch_id);
+    }
+
+    /// Matching batch ID, valid signature, quorum **not yet** reached — state stays `Certifying`.
+    #[test]
+    fn test_add_signature_to_batch_certifying_matching_no_quorum() {
+        let mut rng = TestRng::default();
+        let (primary, accounts) = primary_without_handlers(&mut rng);
+        map_account_addresses(&primary, &accounts);
+
+        let proposal = create_test_proposal(
+            primary.gateway.account(),
+            primary.ledger.current_committee().unwrap(),
+            1,
+            Default::default(),
+            now(),
+            0,
+            &mut rng,
+        );
+        let batch_id = proposal.batch_id();
+
+        // Only one peer signs — not enough for quorum.
+        let peer_ip = accounts[1].0;
+        let signature = accounts[1].1.sign(&[batch_id], &mut rng).unwrap();
+
+        let (result, new_state) = primary.add_signature_to_batch(
+            ProposedBatchState::Certifying(Box::new(proposal)),
+            peer_ip,
+            batch_id,
+            signature,
+        );
+
+        assert!(result.unwrap().is_none());
+        assert_eq!(new_state.as_proposal().unwrap().batch_id(), batch_id);
+    }
+
+    /// Matching batch ID, all peers sign — quorum reached, proposal extracted and state becomes
+    /// `Certified`.
+    #[test]
+    fn test_add_signature_to_batch_certifying_matching_quorum_reached() {
+        let mut rng = TestRng::default();
+        let (primary, accounts) = primary_without_handlers(&mut rng);
+        map_account_addresses(&primary, &accounts);
+
+        let proposal = create_test_proposal(
+            primary.gateway.account(),
+            primary.ledger.current_committee().unwrap(),
+            1,
+            Default::default(),
+            now(),
+            0,
+            &mut rng,
+        );
+        let batch_id = proposal.batch_id();
+
+        // Add all peer signatures one by one until quorum is reached.
+        let peers: Vec<_> =
+            accounts.iter().filter(|(_, a)| a.address() != primary.gateway.account().address()).collect();
+        let mut state = ProposedBatchState::Certifying(Box::new(proposal));
+        let mut final_result = None;
+
+        for (peer_ip, peer_account) in &peers {
+            let signature = peer_account.sign(&[batch_id], &mut rng).unwrap();
+            let (result, new_state) = primary.add_signature_to_batch(state, *peer_ip, batch_id, signature);
+            state = new_state;
+            if result.as_ref().unwrap().is_some() {
+                final_result = Some(result);
+                break;
+            }
+        }
+
+        // Quorum must have been reached with the committee's peers.
+        let proposal = final_result.expect("quorum should be reached").unwrap().unwrap();
+        assert_eq!(proposal.batch_id(), batch_id);
+        assert_eq!(state, ProposedBatchState::Certified(batch_id));
     }
 }

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -19,6 +19,7 @@ use crate::{
     MAX_FETCH_TIMEOUT,
     MAX_WORKERS,
     ProposedBatch,
+    ProposedBatchState,
     Transport,
     events::{Event, TransmissionRequest, TransmissionResponse},
     helpers::{Pending, Ready, Storage, WorkerReceiver, fmt_id, max_redundant_requests},
@@ -188,7 +189,7 @@ impl<N: Network> Worker<N> {
         let transmission_id = transmission_id.into();
         // Check if the transmission ID exists in the ready queue, proposed batch, storage, or ledger.
         self.ready.read().contains(transmission_id)
-            || self.proposed_batch.read().as_ref().is_some_and(|p| p.contains_transmission(transmission_id))
+            || matches!(&*self.proposed_batch.read(), ProposedBatchState::Certifying(p) if p.contains_transmission(transmission_id))
             || self.storage.contains_transmission(transmission_id)
             || self.ledger.contains_transmission(&transmission_id).unwrap_or(false)
     }
@@ -207,9 +208,10 @@ impl<N: Network> Worker<N> {
             return Some(transmission);
         }
         // Check if the transmission ID exists in the proposed batch.
-        if let Some(transmission) =
-            self.proposed_batch.read().as_ref().and_then(|p| p.get_transmission(transmission_id))
-        {
+        if let Some(transmission) = match &*self.proposed_batch.read() {
+            ProposedBatchState::Certifying(p) => p.get_transmission(transmission_id),
+            _ => None,
+        } {
             return Some(transmission.clone());
         }
         None

--- a/node/bft/tests/common/utils.rs
+++ b/node/bft/tests/common/utils.rs
@@ -232,7 +232,7 @@ pub fn sample_worker<N: Network>(
     // Sample a gateway.
     let gateway = sample_gateway(account, storage.clone(), ledger.clone());
     // Sample a dummy proposed batch.
-    let proposed_batch = Arc::new(RwLock::new(None));
+    let proposed_batch = Arc::new(RwLock::new(Default::default()));
     // Construct the worker instance.
     Worker::new(id, Arc::new(gateway.clone()), storage.clone(), ledger, proposed_batch).unwrap()
 }


### PR DESCRIPTION
This PR fixes #4092 by introducing a `ProposedBatchState` enum that properly handles the different states of certification a new batch can be in. Requires #4190 to be merged first.

It also moves signatures handling to a dedicated `Primary::add_signature_to_batch` method and adds unit tests for it. The test coverage is almost a little excessive, but it is a critical part of the code and the tests only take about two seconds to run on my machine.