### PR TITLE
Revert locktick comments required by prerelease infra

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -372,7 +372,7 @@ version = "2"
 opt-level = 3
 lto = "thin"
 incremental = true
-# uncomment the 2 lines below when building with the locktick feature.
+# uncomment the 2 lines below when building with the locktick feature or use the `release-locktick` profile
 # debug = "line-tables-only"
 # strip = "none"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -372,6 +372,9 @@ version = "2"
 opt-level = 3
 lto = "thin"
 incremental = true
+# uncomment the 2 lines below when building with the locktick feature.
+# debug = "line-tables-only"
+# strip = "none"
 
 [profile.release-locktick]
 inherits = "release"


### PR DESCRIPTION
## Motivation

Doing without this change requires a surprisingly large amount of refactors: https://github.com/ProvableHQ/snarkos-stress-testing/issues/447#issuecomment-4189485619

## Test Plan

Running `prerelease-v4.6.13`

