### PR TITLE
[Feat] Account for stake when determining request redundancy

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -373,6 +373,11 @@ impl<N: Network> Gateway<N> {
         self.dev
     }
 
+    /// Returns a reference to the ledger.
+    pub fn ledger(&self) -> &Arc<dyn LedgerService<N>> {
+        &self.ledger
+    }
+
     /// Returns the resolver.
     pub fn resolver(&self) -> &RwLock<Resolver<N>> {
         &self.resolver

--- a/node/bft/src/helpers/pending.rs
+++ b/node/bft/src/helpers/pending.rs
@@ -13,14 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::MAX_FETCH_TIMEOUT_IN_MS;
+use crate::{Gateway, MAX_FETCH_TIMEOUT_IN_MS};
 use snarkos_node_bft_ledger_service::LedgerService;
+use snarkos_node_network::PeerPoolHandling;
 use snarkvm::{
     console::network::{Network, consensus_config_value},
     prelude::Result,
 };
 
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 #[cfg(feature = "locktick")]
 use locktick::parking_lot::RwLock;
 #[cfg(not(feature = "locktick"))]
@@ -109,6 +110,13 @@ impl<T: Copy + Clone + PartialEq + Eq + Hash, V: Clone> Pending<T, V> {
     /// Returns the peer IPs for the specified `item`.
     pub fn get_peers(&self, item: impl Into<T>) -> Option<HashSet<SocketAddr>> {
         self.pending.read().get(&item.into()).map(|map| map.keys().cloned().collect())
+    }
+
+    /// Returns the peer IPs for the specified `item` who have received a request for it.
+    pub fn get_sent_peers(&self, item: impl Into<T>) -> Option<HashSet<SocketAddr>> {
+        self.pending.read().get(&item.into()).map(|map| {
+            map.iter().filter_map(|(addr, cbs)| cbs.iter().any(|(_, _, sent)| *sent).then_some(*addr)).collect()
+        })
     }
 
     /// Returns the number of pending callbacks for the specified `item`.
@@ -243,6 +251,31 @@ impl<T: Copy + Clone + PartialEq + Eq + Hash, V: Clone> Pending<T, V> {
             // Keep the item in the pending map only if there are callbacks left.
             !peer_map.is_empty()
         });
+    }
+
+    /// Ensures that the combined stake of the peers that have received the request is
+    /// greater than the redundancy threshold (33%).
+    pub fn request_stake_redundancy_reached<N: Network>(&self, gateway: &Gateway<N>, desired_item: T) -> Result<bool> {
+        let committee = match gateway.ledger().current_committee() {
+            Ok(c) => c,
+            Err(err) => {
+                bail!("Failed to get current committee: {err}");
+            }
+        };
+
+        let total_stake = committee.total_stake();
+        let pending_providers = self.get_sent_peers(desired_item);
+        let mut stake_of_providers = 0;
+        for addr in pending_providers.iter().flatten() {
+            let Some(aleo_addr) = gateway.resolve_to_aleo_addr(*addr) else { continue };
+            let individual_stake = committee.get_stake(aleo_addr);
+            stake_of_providers += individual_stake;
+            if stake_of_providers as f64 / total_stake as f64 > 0.33 {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
     }
 }
 

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -1020,9 +1020,13 @@ impl<N: Network> Sync<N> {
         let contains_peer_with_sent_request = self.pending.contains_peer_with_sent_request(certificate_id, peer_ip);
         // Determine the maximum number of redundant requests.
         let num_redundant_requests = max_redundant_requests(self.ledger.clone(), self.storage.current_round())?;
+        // Establish whether the peers who already got the request collectively hold sufficient stake.
+        let stake_redundancy_reached = self.pending.request_stake_redundancy_reached(&self.gateway, certificate_id)?;
         // Determine if we should send a certificate request to the peer.
-        // We send at most `num_redundant_requests` requests and each peer can only receive one request at a time.
-        let should_send_request = num_sent_requests < num_redundant_requests && !contains_peer_with_sent_request;
+        // Each peer can only receive one request at a time.
+        // We send at most `num_redundant_requests` requests, unless the stake redundancy factor hasn't been reached.
+        let should_send_request = !contains_peer_with_sent_request
+            && (num_sent_requests < num_redundant_requests || !stake_redundancy_reached);
 
         // Insert the certificate ID into the pending queue.
         self.pending.insert(certificate_id, peer_ip, Some((callback_sender, should_send_request)));

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -1021,12 +1021,12 @@ impl<N: Network> Sync<N> {
         // Determine the maximum number of redundant requests.
         let num_redundant_requests = max_redundant_requests(self.ledger.clone(), self.storage.current_round())?;
         // Establish whether the peers who already got the request collectively hold sufficient stake.
-        let stake_redundancy_reached = self.pending.request_stake_redundancy_reached(&self.gateway, certificate_id)?;
+        let stake_redundancy_reached = || self.pending.request_stake_redundancy_reached(&self.gateway, certificate_id);
         // Determine if we should send a certificate request to the peer.
         // Each peer can only receive one request at a time.
         // We send at most `num_redundant_requests` requests, unless the stake redundancy factor hasn't been reached.
         let should_send_request = !contains_peer_with_sent_request
-            && (num_sent_requests < num_redundant_requests || !stake_redundancy_reached);
+            && (num_sent_requests < num_redundant_requests || !stake_redundancy_reached()?);
 
         // Insert the certificate ID into the pending queue.
         self.pending.insert(certificate_id, peer_ip, Some((callback_sender, should_send_request)));

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -505,14 +505,14 @@ impl<N: Network> Worker<N> {
         let num_redundant_requests = max_redundant_requests(self.ledger.clone(), self.storage.current_round())?;
         // Establish whether the peers who already got the request collectively hold sufficient stake.
         #[cfg(test)]
-        let stake_redundancy_reached = true;
+        let stake_redundancy_reached = || Ok::<_, anyhow::Error>(true);
         #[cfg(not(test))]
-        let stake_redundancy_reached = self.pending.request_stake_redundancy_reached(&self.gateway, transmission_id)?;
+        let stake_redundancy_reached = || self.pending.request_stake_redundancy_reached(&self.gateway, transmission_id);
         // Determine if we should send a transmission request to the peer.
         // Each peer can only receive one request at a time.
         // We send at most `num_redundant_requests` requests, unless the stake redundancy factor hasn't been reached.
         let should_send_request = !contains_peer_with_sent_request
-            && (num_sent_requests < num_redundant_requests || !stake_redundancy_reached);
+            && (num_sent_requests < num_redundant_requests || !stake_redundancy_reached()?);
 
         // Insert the transmission ID into the pending queue.
         self.pending.insert(transmission_id, peer_ip, Some((callback_sender, should_send_request)));

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(not(test))]
+use crate::Gateway;
 use crate::{
     MAX_FETCH_TIMEOUT_IN_MS,
     MAX_WORKERS,
@@ -51,6 +53,9 @@ pub struct Worker<N: Network> {
     /// The worker ID.
     id: u8,
     /// The gateway.
+    #[cfg(not(test))]
+    gateway: Arc<Gateway<N>>,
+    #[cfg(test)]
     gateway: Arc<dyn Transport<N>>,
     /// The storage.
     storage: Storage<N>,
@@ -70,7 +75,8 @@ impl<N: Network> Worker<N> {
     /// Initializes a new worker instance.
     pub fn new(
         id: u8,
-        gateway: Arc<dyn Transport<N>>,
+        #[cfg(not(test))] gateway: Arc<Gateway<N>>,
+        #[cfg(test)] gateway: Arc<dyn Transport<N>>,
         storage: Storage<N>,
         ledger: Arc<dyn LedgerService<N>>,
         proposed_batch: Arc<ProposedBatch<N>>,
@@ -497,9 +503,16 @@ impl<N: Network> Worker<N> {
         let contains_peer_with_sent_request = self.pending.contains_peer_with_sent_request(transmission_id, peer_ip);
         // Determine the maximum number of redundant requests.
         let num_redundant_requests = max_redundant_requests(self.ledger.clone(), self.storage.current_round())?;
+        // Establish whether the peers who already got the request collectively hold sufficient stake.
+        #[cfg(test)]
+        let stake_redundancy_reached = true;
+        #[cfg(not(test))]
+        let stake_redundancy_reached = self.pending.request_stake_redundancy_reached(&self.gateway, transmission_id)?;
         // Determine if we should send a transmission request to the peer.
-        // We send at most `num_redundant_requests` requests and each peer can only receive one request at a time.
-        let should_send_request = num_sent_requests < num_redundant_requests && !contains_peer_with_sent_request;
+        // Each peer can only receive one request at a time.
+        // We send at most `num_redundant_requests` requests, unless the stake redundancy factor hasn't been reached.
+        let should_send_request = !contains_peer_with_sent_request
+            && (num_sent_requests < num_redundant_requests || !stake_redundancy_reached);
 
         // Insert the transmission ID into the pending queue.
         self.pending.insert(transmission_id, peer_ip, Some((callback_sender, should_send_request)));

--- a/node/bft/tests/components/worker.rs
+++ b/node/bft/tests/components/worker.rs
@@ -107,7 +107,7 @@ async fn test_resend_transmission_request() {
         // Ensure the peer IP is in the pending queue for the transmission ID.
         assert!(pending.contains_peer(transmission_id, peer_ip), "Missing a peer IP for transmission in the pending queue");
         // Ensure the number of sent requests is correct.
-        assert_eq!(pending.num_sent_requests(transmission_id), (1 + i).min(max_redundancy), "Incorrect number of sent requests for transmission");
+        assert_eq!(pending.num_sent_requests(transmission_id), (1 + i).min(max_redundancy + i), "Incorrect number of sent requests for transmission");
     }
 }
 
@@ -178,7 +178,7 @@ async fn test_flood_transmission_requests() {
         // Ensure the number of callbacks is correct.
         assert_eq!(pending.num_callbacks(transmission_id), max_redundancy + i, "Incorrect number of callbacks for transmission");
         // Ensure the number of sent requests is correct.
-        assert_eq!(pending.num_sent_requests(transmission_id), max_redundancy, "Incorrect number of sent requests for transmission");
+        assert_eq!(pending.num_sent_requests(transmission_id), max_redundancy + 1, "Incorrect number of sent requests for transmission");
     }
 
     // Ensure any further redundant requests are not sent when sending to new peers.
@@ -197,6 +197,6 @@ async fn test_flood_transmission_requests() {
         // Ensure the number of callbacks is correct.
         assert_eq!(pending.num_callbacks(transmission_id), max_redundancy + 6 + i, "Incorrect number of callbacks for transmission");
         // Ensure the number of sent requests is correct.
-        assert_eq!(pending.num_sent_requests(transmission_id), max_redundancy, "Incorrect number of sent requests for transmission");
+        assert_eq!(pending.num_sent_requests(transmission_id), max_redundancy + 1, "Incorrect number of sent requests for transmission");
     }
 }


### PR DESCRIPTION
This PR guards against a scenario where a BFT worker would only request certificates or transmissions from "weak" validators - in other words, it ensures that even if the maximum number of redundant requests has been sent, the collective stake of those who have received them is greater than 33%.

Closes https://github.com/ProvableHQ/snarkOS/issues/3857.