### PR TITLE
[Feat] Add new REST endpoint for solution limits

### DIFF
--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -186,7 +186,8 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route("/transaction/unconfirmed/{id}", get(Self::get_unconfirmed_transaction))
             .route("/transaction/broadcast", post(Self::transaction_broadcast))
 
-            // POST ../solution/broadcast
+            // GET and POST ../solution/..
+            .route("/solution/limits/{prover_address}", get(Self::get_solution_limits_for_prover))
             .route("/solution/broadcast", post(Self::solution_broadcast))
 
             // GET ../find/..

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -36,7 +36,6 @@ use std::{collections::HashMap, fs};
 
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
-
 use version::VersionInfo;
 
 #[cfg(feature = "history")]
@@ -1004,6 +1003,18 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         }
 
         Ok(ret)
+    }
+
+    /// GET /<network>/solution/limits/{prover_address}
+    pub(crate) async fn get_solution_limits_for_prover(
+        State(rest): State<Self>,
+        Path(prover_address): Path<Address<N>>,
+    ) -> Result<ErasedJson, RestError> {
+        Ok(ErasedJson::pretty(json!({
+            "is_limit_reached": rest.ledger.is_solution_limit_reached(&prover_address, 0),
+            "num_remaining_solutions": rest.ledger.num_remaining_solutions(&prover_address, 0),
+            "blocks_until_next_epoch": N::NUM_BLOCKS_PER_EPOCH.saturating_sub(rest.ledger.latest_height() % N::NUM_BLOCKS_PER_EPOCH),
+        })))
     }
 
     /// GET /{network}/program/{id}/mapping/{name}/{key}/history/{height}

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -1013,6 +1013,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         Ok(ErasedJson::pretty(json!({
             "is_limit_reached": rest.ledger.is_solution_limit_reached(&prover_address, 0),
             "num_remaining_solutions": rest.ledger.num_remaining_solutions(&prover_address, 0),
+            "latest_epoch_hash": rest.ledger.latest_epoch_hash()?,
             "blocks_until_next_epoch": N::NUM_BLOCKS_PER_EPOCH.saturating_sub(rest.ledger.latest_height() % N::NUM_BLOCKS_PER_EPOCH),
         })))
     }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

  This PR adds a new REST endpoint that exposes solution limit information for a given prover address, allowing provers and tooling to query their current solution limits without inspecting the chain directly.                                                                                                                                           
   
  ## Endpoint                                                                                                                                                                                            
                  
  `GET /<network>/solution/limits/{prover_address}`

  **Response:**
  ```json
  {
    "is_limit_reached": false,
    "num_remaining_solutions": 2,                                                                                                                                                                        
    "latest_epoch_hash": "ab1...",
    "blocks_until_next_epoch": 47                                                                                                                                                                        
  }                       
