### PR TITLE
[Fix] Allow 0400 permissions for key files

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -13,4 +13,6 @@ ignore = [
   "RUSTSEC-2026-0002",
   # TODO remove once we migrate away from bincode, or it becomes maintained again.
   "RUSTSEC-2025-0141",
+  # TODO remove once termwiz/terminfo update to phf 0.13+, which drops the rand 0.8 dependency.
+  "RUSTSEC-2026-0097",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -168,7 +168,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -737,7 +737,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1495,7 +1495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4092,7 +4092,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4151,7 +4151,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6044,7 +6044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6281,7 +6281,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7374,7 +7374,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -973,14 +973,20 @@ impl Start {
     }
 }
 
+/// Checks whether a file can only be read/written by the owner. It also allows more restrictive permissions, where only the owner can read it.
 fn check_permissions(path: &PathBuf) -> Result<(), snarkvm::prelude::Error> {
     #[cfg(target_family = "unix")]
     {
         use std::os::unix::fs::PermissionsExt;
         ensure!(path.exists(), "The file '{path:?}' does not exist");
         crate::check_parent_permissions(path)?;
+
         let permissions = path.metadata()?.permissions().mode();
-        ensure!(permissions & 0o777 == 0o600, "The file {path:?} must be readable only by the owner (0600)");
+        ensure!(
+            matches!(permissions & 0o777, 0o400 | 0o600),
+            "The file {} must be readable and writable only by the owner (0600)",
+            path.display()
+        );
     }
     Ok(())
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -34,6 +34,7 @@ use std::{
     path::Path,
 };
 
+/// Checks whether the parent directory of a file can only be read and modified by the owner.
 #[cfg(unix)]
 pub fn check_parent_permissions<T: AsRef<Path>>(path: T) -> Result<()> {
     use anyhow::{bail, ensure};
@@ -41,7 +42,11 @@ pub fn check_parent_permissions<T: AsRef<Path>>(path: T) -> Result<()> {
 
     if let Some(parent) = path.as_ref().parent() {
         let permissions = parent.metadata()?.permissions().mode();
-        ensure!(permissions & 0o777 == 0o700, "The folder {parent:?} must be readable only by the owner (0700)");
+        ensure!(
+            permissions & 0o777 == 0o700,
+            "The folder {} must be readable and writeable only by the owner (0700)",
+            parent.display()
+        );
     } else {
         let path = path.as_ref();
         bail!("Parent does not exist for path={}", path.display());

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -44,7 +44,16 @@ use anyhow::{Result, bail};
 use locktick::parking_lot::RwLock;
 #[cfg(not(feature = "locktick"))]
 use parking_lot::RwLock;
-use std::{cmp, collections::HashMap, fs, net::SocketAddr, path::{Path, PathBuf}, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    cmp,
+    collections::HashMap,
+    fs,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
 use tokio::task;
 
 /// The number of blocks between automatic database checkpoints.
@@ -456,7 +465,10 @@ impl<N: Network> Node<N> {
 #[cfg(test)]
 mod tests {
     use super::existing_startup_checkpoint_height;
-    use std::{fs, time::{SystemTime, UNIX_EPOCH}};
+    use std::{
+        fs,
+        time::{SystemTime, UNIX_EPOCH},
+    };
 
     #[test]
     fn seeds_last_checkpoint_height_when_startup_checkpoint_directory_exists() {


### PR DESCRIPTION
snarkOS currently requires key files to have `0600` permissions, but `0400` should be allowed as well. The PR also corrects the associated error messages.

Additionally, this PR fixes the `cargo-workflow` by correcting formatting in one file and adding an exception for [`RUSTSEC-2026-0097`](https://rustsec.org/advisories/RUSTSEC-2026-0097). The latter is not an issue for us as we do not use a custom logger that calls into `rand`. 