### PR TITLE
Introduce hotswapping prod committee for dev committee

### DIFF
--- a/.ci/test_dev_on_prod_restart.sh
+++ b/.ci/test_dev_on_prod_restart.sh
@@ -180,6 +180,12 @@ function copy_setup_ledger() {
   cp -r "$source" ledger-1
   cp -r "$source" ledger-2
   cp -r "$source" ledger-3
+
+  # Clear any state cached by a previous test run (proposal cache, dev committee state, etc.).
+  # The ledger we just copied is fresh, so any persisted dev state must be regenerated from it.
+  for i in $(seq 0 $((NUM_DEV_NODES - 1))); do
+    snarkos clean "--dev=${i}" "--network=0"
+  done
 }
 
 function start_dev_nodes() {
@@ -188,10 +194,10 @@ function start_dev_nodes() {
 
   for i in $(seq 0 $((NUM_DEV_NODES - 1))); do
     log "Starting dev node ${i}"
-    DEV_COMMITTEE_NUM_VALIDATORS=${NUM_DEV_NODES} snarkos start --nodisplay --validator --ledger-storage "ledger-${i}" --node-data-storage "node-data-${i}" --dev "${i}" \
+    snarkos start --nodisplay --validator --ledger-storage "ledger-${i}" --node-data-storage "node-data-${i}" --dev "${i}" \
       --no-dev-txs --nocdn --dev-num-validators "${NUM_DEV_NODES}" --verbosity 2 \
       --allow-external-peers --logfile "dev_logs/val-${i}.txt" --dev-on-prod &
-    DEV_PIDS[$i]=$!
+    DEV_PIDS[i]=$!
     sleep 1
   done
 }
@@ -226,12 +232,8 @@ wait_for_height_advance "$REST_PORT" "$DEV_ADVANCE_BLOCKS" "$DEV_MAX_WAIT" "dev-
 log "Step 5: Gracefully stop all dev nodes"
 graceful_stop_all_dev_nodes
 
-# TODO: encountering the following warnings when stopping and starting all dev nodes:
-# - WARN "Cannot propose a batch for round 32 - the latest proposal cache round is 34"
-# - WARN "Failed to load stored certificate 1936933304208994.. from proposal cache — Previous certificates for a batch in round 32 did not reach quorum threshold (gc = 0)"
-# - WARN "Failed to load stored certificate 8429685712854720.. from proposal cache — Failed to fetch missing transmissions and previous certificates for round 33 from '127.0.0.1:0 — Unable to fetch batch certificate 1936933304208994661214537875451736804168699382028485722463302790461889223166field (failed to send request)"
-# log "Step 6: Restart all dev nodes and wait for +${DEV_ADVANCE_BLOCKS} blocks"
-# start_dev_nodes
-# wait_for_height_advance "$REST_PORT" "$DEV_ADVANCE_BLOCKS" "$DEV_MAX_WAIT" "dev-network-second-run"
+log "Step 6: Restart all dev nodes and wait for +${DEV_ADVANCE_BLOCKS} blocks"
+start_dev_nodes
+wait_for_height_advance "$REST_PORT" "$DEV_ADVANCE_BLOCKS" "$DEV_MAX_WAIT" "dev-network-second-run"
 
 log "SUCCESS: Completed dev-on-prod restart flow"

--- a/.ci/test_dev_on_prod_restart.sh
+++ b/.ci/test_dev_on_prod_restart.sh
@@ -16,7 +16,7 @@ REST_PORT=3030
 NUM_DEV_NODES=4
 SETUP_ADVANCE_BLOCKS=5
 DEV_ADVANCE_BLOCKS=10
-SETUP_MAX_WAIT=20
+SETUP_MAX_WAIT=40
 DEV_MAX_WAIT=100
 
 BOOTSTRAP_PID=""
@@ -188,7 +188,7 @@ function start_dev_nodes() {
 
   for i in $(seq 0 $((NUM_DEV_NODES - 1))); do
     log "Starting dev node ${i}"
-    DEV_COMMITTEE_NUM_VALIDATORS=${NUM_DEV_NODES} ~/programs/snarkOS/target/debug/snarkos start --nodisplay --validator --ledger-storage "ledger-${i}" --node-data-storage "node-data-${i}" --dev "${i}" \
+    DEV_COMMITTEE_NUM_VALIDATORS=${NUM_DEV_NODES} snarkos start --nodisplay --validator --ledger-storage "ledger-${i}" --node-data-storage "node-data-${i}" --dev "${i}" \
       --no-dev-txs --nocdn --dev-num-validators "${NUM_DEV_NODES}" --verbosity 2 \
       --allow-external-peers --logfile "dev_logs/val-${i}.txt" --dev-on-prod &
     DEV_PIDS[$i]=$!
@@ -205,9 +205,7 @@ require_cmd curl
 require_cmd cargo
 require_cmd tar
 
-log "Downloading and building latest snarkOS release binary for setup node..."
-download_and_build_latest_snarkos
-SNARKOS_SETUP_BIN="$SNARKOS_RELEASE_BIN"
+SNARKOS_SETUP_BIN="snarkos"
 log "Using setup binary: ${SNARKOS_SETUP_BIN}"
 
 log "Step 1: Start production node and wait for +${SETUP_ADVANCE_BLOCKS} blocks"

--- a/.ci/test_dev_on_prod_restart.sh
+++ b/.ci/test_dev_on_prod_restart.sh
@@ -20,19 +20,7 @@ SETUP_MAX_WAIT=40
 DEV_MAX_WAIT=100
 
 BOOTSTRAP_PID=""
-declare -a DEV_PIDS=()
 SNARKOS_SETUP_BIN="snarkos"
-
-function get_height() {
-  local port="$1"
-  local result
-  result=$(curl -s --max-time 2 "http://${localhost}:${port}/v2/${NETWORK_NAME}/block/height/latest" || true)
-  if is_integer "$result"; then
-    echo "$result"
-  else
-    echo ""
-  fi
-}
 
 function wait_for_node_ready() {
   local port="$1"
@@ -42,7 +30,7 @@ function wait_for_node_ready() {
 
   while (( $(elapsed_since "$start") < timeout )); do
     local height
-    height=$(get_height "$port")
+    height=$(get_block_height_by_port "$port" "$NETWORK_NAME" 2)
     if [ -n "$height" ]; then
       log "Node on port ${port} is ready at height ${height}"
       return 0
@@ -64,7 +52,7 @@ function wait_for_height_advance() {
   wait_for_node_ready "$port" "$timeout"
 
   local start_height
-  start_height=$(get_height "$port")
+  start_height=$(get_block_height_by_port "$port" "$NETWORK_NAME" 2)
   if [ -z "$start_height" ]; then
     log "${label}: failed to read initial block height from port ${port}"
     return 1
@@ -78,7 +66,7 @@ function wait_for_height_advance() {
   log "${label}: waiting for height to advance by ${advance_by} blocks (${start_height} -> ${target_height})"
   while (( $(elapsed_since "$start_time") < timeout )); do
     local current_height
-    current_height=$(get_height "$port")
+    current_height=$(get_block_height_by_port "$port" "$NETWORK_NAME" 2)
     if [ -n "$current_height" ] && (( current_height >= target_height )); then
       log "${label}: reached target height ${current_height} (>= ${target_height})"
       return 0
@@ -99,63 +87,13 @@ function wait_for_height_advance() {
   done
 
   local final_height
-  final_height=$(get_height "$port")
+  final_height=$(get_block_height_by_port "$port" "$NETWORK_NAME" 2)
   log "${label}: timed out waiting for height advance (final height: ${final_height:-unavailable}, target: ${target_height})"
   return 1
 }
 
-function wait_for_pid_exit() {
-  local pid="$1"
-  local timeout="$2"
-  local start
-  start=$(now)
-  while (( $(elapsed_since "$start") < timeout )); do
-    if ! kill -0 "$pid" 2>/dev/null; then
-      return 0
-    fi
-    sleep 1
-  done
-  return 1
-}
-
-function graceful_stop_pid() {
-  local pid="$1"
-  local label="$2"
-
-  if [ -z "$pid" ]; then
-    return 0
-  fi
-
-  if ! kill -0 "$pid" 2>/dev/null; then
-    return 0
-  fi
-
-  log "Stopping ${label} (pid=${pid}) with SIGINT"
-  kill -INT "$pid" 2>/dev/null || true
-  if wait_for_pid_exit "$pid" 60; then
-    return 0
-  fi
-
-  log "${label} did not exit after SIGINT; sending SIGTERM"
-  kill -TERM "$pid" 2>/dev/null || true
-  if wait_for_pid_exit "$pid" 20; then
-    return 0
-  fi
-
-  log "${label} did not exit after SIGTERM; sending SIGKILL"
-  kill -KILL "$pid" 2>/dev/null || true
-  wait "$pid" 2>/dev/null || true
-}
-
-function graceful_stop_all_dev_nodes() {
-  for i in "${!DEV_PIDS[@]}"; do
-    graceful_stop_pid "${DEV_PIDS[$i]}" "dev-node-${i}"
-  done
-  DEV_PIDS=()
-}
-
 function cleanup() {
-  graceful_stop_all_dev_nodes
+  stop_nodes
   graceful_stop_pid "$BOOTSTRAP_PID" "setup-node"
 }
 
@@ -190,14 +128,14 @@ function copy_setup_ledger() {
 
 function start_dev_nodes() {
   mkdir -p dev_logs
-  DEV_PIDS=()
+  PIDS=()
 
   for i in $(seq 0 $((NUM_DEV_NODES - 1))); do
     log "Starting dev node ${i}"
     snarkos start --nodisplay --validator --ledger-storage "ledger-${i}" --node-data-storage "node-data-${i}" --dev "${i}" \
       --no-dev-txs --nocdn --dev-num-validators "${NUM_DEV_NODES}" --verbosity 2 \
       --allow-external-peers --logfile "dev_logs/val-${i}.txt" --dev-on-prod &
-    DEV_PIDS[i]=$!
+    PIDS[i]=$!
     sleep 1
   done
 }
@@ -230,7 +168,7 @@ log "Step 4: Wait until dev network advances by +${DEV_ADVANCE_BLOCKS} blocks"
 wait_for_height_advance "$REST_PORT" "$DEV_ADVANCE_BLOCKS" "$DEV_MAX_WAIT" "dev-network-first-run"
 
 log "Step 5: Gracefully stop all dev nodes"
-graceful_stop_all_dev_nodes
+stop_nodes
 
 log "Step 6: Restart all dev nodes and wait for +${DEV_ADVANCE_BLOCKS} blocks"
 start_dev_nodes

--- a/.ci/test_dev_on_prod_restart.sh
+++ b/.ci/test_dev_on_prod_restart.sh
@@ -92,8 +92,15 @@ function wait_for_height_advance() {
   return 1
 }
 
+function graceful_stop_all_dev_nodes() {
+  for i in "${!PIDS[@]}"; do
+    graceful_stop_pid "${PIDS[$i]}" "dev-node-${i}"
+  done
+  PIDS=()
+}
+
 function cleanup() {
-  stop_nodes
+  graceful_stop_all_dev_nodes
   graceful_stop_pid "$BOOTSTRAP_PID" "setup-node"
 }
 
@@ -168,7 +175,7 @@ log "Step 4: Wait until dev network advances by +${DEV_ADVANCE_BLOCKS} blocks"
 wait_for_height_advance "$REST_PORT" "$DEV_ADVANCE_BLOCKS" "$DEV_MAX_WAIT" "dev-network-first-run"
 
 log "Step 5: Gracefully stop all dev nodes"
-stop_nodes
+graceful_stop_all_dev_nodes
 
 log "Step 6: Restart all dev nodes and wait for +${DEV_ADVANCE_BLOCKS} blocks"
 start_dev_nodes

--- a/.ci/test_dev_on_prod_restart.sh
+++ b/.ci/test_dev_on_prod_restart.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "${BASH_VERSINFO[0]}" -lt 5 ]; then
+  echo "Error: This script requires bash version 5.0 or higher."
+  exit 1
+fi
+
+# shellcheck source=SCRIPTDIR/utils.sh
+. ./.ci/utils.sh
+
+network_id=0
+NETWORK_NAME=$(get_network_name "$network_id")
+REST_PORT=3030
+NUM_DEV_NODES=4
+SETUP_ADVANCE_BLOCKS=5
+DEV_ADVANCE_BLOCKS=10
+SETUP_MAX_WAIT=20
+DEV_MAX_WAIT=100
+
+BOOTSTRAP_PID=""
+declare -a DEV_PIDS=()
+SNARKOS_SETUP_BIN="snarkos"
+
+function get_height() {
+  local port="$1"
+  local result
+  result=$(curl -s --max-time 2 "http://${localhost}:${port}/v2/${NETWORK_NAME}/block/height/latest" || true)
+  if is_integer "$result"; then
+    echo "$result"
+  else
+    echo ""
+  fi
+}
+
+function wait_for_node_ready() {
+  local port="$1"
+  local timeout="$2"
+  local start
+  start=$(now)
+
+  while (( $(elapsed_since "$start") < timeout )); do
+    local height
+    height=$(get_height "$port")
+    if [ -n "$height" ]; then
+      log "Node on port ${port} is ready at height ${height}"
+      return 0
+    fi
+    log "Sleeping for 2 seconds before retrying to get height"
+    sleep 2
+  done
+
+  log "Timed out waiting for node on port ${port} to become ready"
+  return 1
+}
+
+function wait_for_height_advance() {
+  local port="$1"
+  local advance_by="$2"
+  local timeout="$3"
+  local label="$4"
+
+  wait_for_node_ready "$port" "$timeout"
+
+  local start_height
+  start_height=$(get_height "$port")
+  if [ -z "$start_height" ]; then
+    log "${label}: failed to read initial block height from port ${port}"
+    return 1
+  fi
+
+  local target_height=$((start_height + advance_by))
+  local start_time
+  start_time=$(now)
+  local last_log_time=0
+
+  log "${label}: waiting for height to advance by ${advance_by} blocks (${start_height} -> ${target_height})"
+  while (( $(elapsed_since "$start_time") < timeout )); do
+    local current_height
+    current_height=$(get_height "$port")
+    if [ -n "$current_height" ] && (( current_height >= target_height )); then
+      log "${label}: reached target height ${current_height} (>= ${target_height})"
+      return 0
+    fi
+
+    local elapsed
+    elapsed=$(elapsed_since "$start_time")
+    if (( elapsed - last_log_time >= 15 )); then
+      if [ -n "$current_height" ]; then
+        log "${label}: current height ${current_height}, target ${target_height}"
+      else
+        log "${label}: waiting for REST endpoint on port ${port}"
+      fi
+      last_log_time=$elapsed
+    fi
+    log "Sleeping for 2 seconds before retrying to get height"
+    sleep 2
+  done
+
+  local final_height
+  final_height=$(get_height "$port")
+  log "${label}: timed out waiting for height advance (final height: ${final_height:-unavailable}, target: ${target_height})"
+  return 1
+}
+
+function wait_for_pid_exit() {
+  local pid="$1"
+  local timeout="$2"
+  local start
+  start=$(now)
+  while (( $(elapsed_since "$start") < timeout )); do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+function graceful_stop_pid() {
+  local pid="$1"
+  local label="$2"
+
+  if [ -z "$pid" ]; then
+    return 0
+  fi
+
+  if ! kill -0 "$pid" 2>/dev/null; then
+    return 0
+  fi
+
+  log "Stopping ${label} (pid=${pid}) with SIGINT"
+  kill -INT "$pid" 2>/dev/null || true
+  if wait_for_pid_exit "$pid" 60; then
+    return 0
+  fi
+
+  log "${label} did not exit after SIGINT; sending SIGTERM"
+  kill -TERM "$pid" 2>/dev/null || true
+  if wait_for_pid_exit "$pid" 20; then
+    return 0
+  fi
+
+  log "${label} did not exit after SIGTERM; sending SIGKILL"
+  kill -KILL "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+}
+
+function graceful_stop_all_dev_nodes() {
+  for i in "${!DEV_PIDS[@]}"; do
+    graceful_stop_pid "${DEV_PIDS[$i]}" "dev-node-${i}"
+  done
+  DEV_PIDS=()
+}
+
+function cleanup() {
+  graceful_stop_all_dev_nodes
+  graceful_stop_pid "$BOOTSTRAP_PID" "setup-node"
+}
+
+function start_setup_node() {
+  mkdir -p dev_logs
+  log "Starting production setup node: ${SNARKOS_SETUP_BIN} start --client --nodisplay"
+  "$SNARKOS_SETUP_BIN" start --client --nodisplay > "dev_logs/setup-client.txt" 2>&1 &
+  BOOTSTRAP_PID=$!
+  log "Started setup node (pid=${BOOTSTRAP_PID})"
+}
+
+function copy_setup_ledger() {
+  local source="${HOME}/.aleo/storage/ledger-0"
+  if [ ! -d "$source" ]; then
+    log "Missing source ledger at ${source}"
+    exit 1
+  fi
+
+  log "Copying setup ledger into local ledgers"
+  rm -rf ledger-0 ledger-1 ledger-2 ledger-3
+  cp -r "$source" ledger-0
+  cp -r "$source" ledger-1
+  cp -r "$source" ledger-2
+  cp -r "$source" ledger-3
+}
+
+function start_dev_nodes() {
+  mkdir -p dev_logs
+  DEV_PIDS=()
+
+  for i in $(seq 0 $((NUM_DEV_NODES - 1))); do
+    log "Starting dev node ${i}"
+    DEV_COMMITTEE_NUM_VALIDATORS=${NUM_DEV_NODES} ~/programs/snarkOS/target/debug/snarkos start --nodisplay --validator --ledger-storage "ledger-${i}" --node-data-storage "node-data-${i}" --dev "${i}" \
+      --no-dev-txs --nocdn --dev-num-validators "${NUM_DEV_NODES}" --verbosity 2 \
+      --allow-external-peers --logfile "dev_logs/val-${i}.txt" --dev-on-prod &
+    DEV_PIDS[$i]=$!
+    sleep 1
+  done
+}
+
+trap cleanup EXIT
+trap 'log "Error at line $LINENO while running: $BASH_COMMAND"' ERR
+
+init_log_dir
+require_cmd snarkos
+require_cmd curl
+require_cmd cargo
+require_cmd tar
+
+log "Downloading and building latest snarkOS release binary for setup node..."
+download_and_build_latest_snarkos
+SNARKOS_SETUP_BIN="$SNARKOS_RELEASE_BIN"
+log "Using setup binary: ${SNARKOS_SETUP_BIN}"
+
+log "Step 1: Start production node and wait for +${SETUP_ADVANCE_BLOCKS} blocks"
+start_setup_node
+wait_for_height_advance "$REST_PORT" "$SETUP_ADVANCE_BLOCKS" "$SETUP_MAX_WAIT" "setup-network"
+
+log "Step 2: Gracefully stop production node"
+graceful_stop_pid "$BOOTSTRAP_PID" "setup-node"
+BOOTSTRAP_PID=""
+
+log "Step 3: Copy production ledger and start 4 dev nodes"
+copy_setup_ledger
+start_dev_nodes
+
+log "Step 4: Wait until dev network advances by +${DEV_ADVANCE_BLOCKS} blocks"
+wait_for_height_advance "$REST_PORT" "$DEV_ADVANCE_BLOCKS" "$DEV_MAX_WAIT" "dev-network-first-run"
+
+log "Step 5: Gracefully stop all dev nodes"
+graceful_stop_all_dev_nodes
+
+# TODO: encountering the following warnings when stopping and starting all dev nodes:
+# - WARN "Cannot propose a batch for round 32 - the latest proposal cache round is 34"
+# - WARN "Failed to load stored certificate 1936933304208994.. from proposal cache — Previous certificates for a batch in round 32 did not reach quorum threshold (gc = 0)"
+# - WARN "Failed to load stored certificate 8429685712854720.. from proposal cache — Failed to fetch missing transmissions and previous certificates for round 33 from '127.0.0.1:0 — Unable to fetch batch certificate 1936933304208994661214537875451736804168699382028485722463302790461889223166field (failed to send request)"
+# log "Step 6: Restart all dev nodes and wait for +${DEV_ADVANCE_BLOCKS} blocks"
+# start_dev_nodes
+# wait_for_height_advance "$REST_PORT" "$DEV_ADVANCE_BLOCKS" "$DEV_MAX_WAIT" "dev-network-second-run"
+
+log "SUCCESS: Completed dev-on-prod restart flow"

--- a/.ci/utils.sh
+++ b/.ci/utils.sh
@@ -205,7 +205,53 @@ function log() {
 # Array to store PIDs of all node processes.
 declare -a PIDS
 
-# Stops all running processe in the given list.
+# Wait until the given PID is no longer running, or until timeout seconds elapse.
+# Returns 0 if the process exited, 1 on timeout.
+function wait_for_pid_exit() {
+  local pid="$1"
+  local timeout="$2"
+  local start
+  start=$(now)
+  while (( $(elapsed_since "$start") < timeout )); do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+# Stop a process with SIGINT, then SIGTERM, then SIGKILL if needed.
+function graceful_stop_pid() {
+  local pid="$1"
+  local label="$2"
+
+  if [ -z "$pid" ]; then
+    return 0
+  fi
+
+  if ! kill -0 "$pid" 2>/dev/null; then
+    return 0
+  fi
+
+  log "Stopping ${label} (pid=${pid}) with SIGINT"
+  kill -INT "$pid" 2>/dev/null || true
+  if wait_for_pid_exit "$pid" 60; then
+    return 0
+  fi
+
+  log "${label} did not exit after SIGINT; sending SIGTERM"
+  kill -TERM "$pid" 2>/dev/null || true
+  if wait_for_pid_exit "$pid" 20; then
+    return 0
+  fi
+
+  log "${label} did not exit after SIGTERM; sending SIGKILL"
+  kill -KILL "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+}
+
+# Stops all running processes in the given list (graceful shutdown per PID).
 function stop_nodes() {
   log "🚨 Cleaning up ${#PIDS[@]} process(es)…"
   for pid in "${PIDS[@]}"; do

--- a/.ci/utils.sh
+++ b/.ci/utils.sh
@@ -7,6 +7,9 @@
 # Ensures we use IPv4 localhost everywhere.
 localhost="127.0.0.1"
 
+# Tracked node PIDs (declared before any function so callers using `set -u` never see PIDS unbound).
+declare -a PIDS=()
+
 # How many cores should each node use?
 # (Should be half of the number of (v)CPUs)
 # NOTE: when you update this, update TASKSET1/2 as well.
@@ -201,9 +204,6 @@ function log() {
 ###########################################
 # Helper functions to set up and stop nodes 
 ###########################################
-
-# Array to store PIDs of all node processes.
-declare -a PIDS
 
 # Wait until the given PID is no longer running, or until timeout seconds elapse.
 # Returns 0 if the process exited, 1 on timeout.
@@ -921,20 +921,40 @@ function get_consensus_version {
   fi
 }
 
+# Latest block height from REST (port + network). Prints height or empty on failure; no logging.
+# Optional third argument: curl --max-time seconds (omit for no per-request timeout).
+function get_block_height_by_port() {
+  local port="$1"
+  local network_name="$2"
+  local max_time="${3-}"
+  local result
+  if [[ -n "$max_time" ]]; then
+    result=$(curl -s --max-time "$max_time" "http://$localhost:$port/v2/$network_name/block/height/latest" || true)
+  else
+    result=$(curl -s "http://$localhost:$port/v2/$network_name/block/height/latest" || true)
+  fi
+  if is_integer "$result"; then
+    echo "$result"
+  else
+    echo ""
+  fi
+}
+
 # Get the block height of the specified node
 function get_block_height {
   local node_index=$1
   local network_name=$2
+  local port
+  local result
 
   port=$((3030+node_index))
-  result=$(curl -s "http://$localhost:$port/v2/$network_name/block/height/latest")
+  result=$(get_block_height_by_port "$port" "$network_name")
 
-  if ! is_integer "$result"; then
+  if [[ -z "$result" ]]; then
     log "❌ Failed to retrieve block height for node #${node_index}"
     return 1
-  else
-    echo "$result"
-    return 0
   fi
+  echo "$result"
+  return 0
 }
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -816,7 +816,7 @@ workflows:
           filters:
             branches:
               only:
-                - ci/reenable-check-logs
+                - test_fixed_dev_committee
                 - canary
                 - testnet
                 - mainnet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -589,6 +589,23 @@ jobs:
           command: |
             ./.ci/test_devnet.sh
 
+  dev-on-prod-restart-test:
+    executor: rust-docker
+    resource_class: << pipeline.parameters.xlarge >>
+    steps:
+      - checkout
+      - setup_environment:
+          cache_key: v4.2.0-rust-1.88.0-dev-on-prod-restart-test-cache
+      - install_snarkos
+      - run:
+          name: "Run dev-on-prod restart test"
+          timeout: 40m
+          no_output_timeout: 15m
+          command: |
+            ./.ci/test_dev_on_prod_restart.sh
+      - clear_environment:
+          cache_key: v4.2.0-rust-1.88.0-dev-on-prod-restart-test-cache
+
   chaotic-minority-reset-test:
     executor: ubuntu-vm
     resource_class: << pipeline.parameters.twoxlarge >>
@@ -793,8 +810,18 @@ workflows:
     jobs:
       - devnet-test
 
-  chaotic-devnet-workflow:
+  merge-devnet-workflow:
     jobs:
+      - dev-on-prod-restart-test:
+          filters:
+            branches:
+              only:
+                - ci/reenable-check-logs
+                - canary
+                - testnet
+                - mainnet
+                - staging
+
       - chaotic-minority-reset-test:
           filters:
             branches:
@@ -814,9 +841,6 @@ workflows:
                 - testnet
                 - mainnet
                 - staging
-
-  upgrade-workflow:
-    jobs:
       - upgrade-test:
           filters:
             branches:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4853,6 +4853,7 @@ version = "4.6.0"
 dependencies = [
  "aleo-std",
  "anyhow",
+ "cfg-if",
  "colored 3.1.1",
  "indexmap 2.14.0",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4801,6 +4801,7 @@ dependencies = [
  "locktick",
  "parking_lot",
  "rand 0.10.1",
+ "rand_chacha 0.10.0",
  "rayon",
  "snarkos-node-metrics",
  "snarkos-utilities",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -305,7 +305,7 @@ serial = [
 ]
 test_targets = [ "snarkos-cli/test_targets" ]
 test_consensus_heights = [ "snarkos-cli/test_consensus_heights" ]
-test_network = [ "snarkos-cli/test_network" ]
+test_network = [ "snarkos-cli/test_network", "snarkos-node/test_network" ]
 tokio_console = [ "snarkos-cli/tokio_console" ]
 
 [dependencies.clap]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,9 @@ features = ["git2"]
 [workspace.dependencies.bytes]
 version = "1"
 
+[workspace.dependencies.cfg-if]
+version = "1"
+
 [workspace.dependencies.clap]
 version = "4.5"
 default-features = false

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -295,7 +295,7 @@ pub struct Start {
     pub dev_bonded_balances: Option<BondedBalances>,
 
     /// If development mode is enabled, specify whether to run the node on a production ledger.
-    #[clap(long, group = "dev_flags", default_value_t = false)]
+    #[clap(long, group = "dev_flags", requires = "dev_num_validators", default_value_t = false)]
     pub dev_on_prod: bool,
 
     /// If the flag is set, the node will attempt to automatically migrate the node data to the new format.
@@ -683,10 +683,9 @@ impl Start {
             println!("{}", crate::helpers::welcome_message());
         }
 
-        // Check if we are running with the lower coinbase and proof targets. This should only be
-        // allowed in --dev mode and should not be allowed in mainnet mode.
-        if cfg!(feature = "test_network") && self.dev.is_none() {
-            bail!("The 'test_network' feature is enabled, but the '--dev' flag is not set");
+        // Only allow dev mode if we built with the 'test_network' feature.
+        if self.dev.is_some() && cfg!(not(feature = "test_network")) {
+            bail!("The 'dev' flag is set, but the 'test_network' feature is not enabled");
         }
 
         // Parse the trusted peers to connect to.
@@ -848,6 +847,9 @@ impl Start {
             }
         };
 
+        // Determine the number of validators for the committee hotswap.
+        let dev_num_validators_for_committee_hotswap = self.dev_on_prod.then_some(self.dev_num_validators);
+
         // TODO(kaimast): start the display earlier and show sync progress.
         if !self.nodisplay && cdn.is_some() {
             println!("🪧 The terminal UI will not start until the node has finished syncing from the CDN. If this step takes too long, consider restarting with `--nodisplay`.");
@@ -858,7 +860,7 @@ impl Start {
 
         // Initialize the node.
         let node = match node_type {
-            NodeType::Validator => Node::new_validator(node_ip, self.bft, rest_ip, self.rest_rps, account, &trusted_peers, &trusted_validators, genesis, cdn, storage_mode, node_data_dir, self.trusted_peers_only, self.auto_db_checkpoints.clone(), dev_txs, self.dev, signal_handler.clone()).await,
+            NodeType::Validator => Node::new_validator(node_ip, self.bft, rest_ip, self.rest_rps, account, &trusted_peers, &trusted_validators, genesis, cdn, storage_mode, node_data_dir, self.trusted_peers_only, self.auto_db_checkpoints.clone(), dev_txs, self.dev, dev_num_validators_for_committee_hotswap, signal_handler.clone()).await,
             NodeType::Prover => Node::new_prover(node_ip, account, &trusted_peers, genesis, node_data_dir, self.trusted_peers_only, self.dev, signal_handler.clone()).await,
             NodeType::Client => Node::new_client(node_ip, rest_ip, self.rest_rps, account, &trusted_peers, genesis, cdn, storage_mode, node_data_dir, self.trusted_peers_only, self.auto_db_checkpoints.clone(), self.dev, signal_handler.clone()).await,
             NodeType::BootstrapClient => Node::new_bootstrap_client(node_ip, account, *genesis.header(), self.dev).await,

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -287,12 +287,16 @@ pub struct Start {
     pub dev_num_clients: Option<u16>,
 
     /// If development mode is enabled, specify whether node 0 should generate traffic to drive the network.
-    #[clap(long, group = "dev_flag")]
+    #[clap(long, group = "dev_flags")]
     pub no_dev_txs: bool,
 
     /// If development mode is enabled, specify the custom bonded balances as a JSON object.
     #[clap(long, group = "dev_flags")]
     pub dev_bonded_balances: Option<BondedBalances>,
+
+    /// If development mode is enabled, specify whether to run the node on a production ledger.
+    #[clap(long, group = "dev_flags", default_value_t = false)]
+    pub dev_on_prod: bool,
 
     /// If the flag is set, the node will attempt to automatically migrate the node data to the new format.
     #[clap(long)]
@@ -533,7 +537,7 @@ impl Start {
     /// Returns an alternative genesis block if the node is in development mode.
     /// Otherwise, returns the actual genesis block.
     fn parse_genesis<N: Network>(&self) -> Result<Block<N>> {
-        if self.dev.is_some() {
+        if self.dev.is_some() && !self.dev_on_prod {
             // Determine the number of genesis committee members.
             let num_committee_members = self.dev_num_validators;
             ensure!(

--- a/cli/src/helpers/dev.rs
+++ b/cli/src/helpers/dev.rs
@@ -20,10 +20,8 @@ use snarkvm::{console::network::Network, prelude::PrivateKey};
 use anyhow::Result;
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
+pub use snarkos_utilities::DEVELOPMENT_MODE_RNG_SEED;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
-
-/// The development mode RNG seed.
-pub const DEVELOPMENT_MODE_RNG_SEED: u64 = 1234567890u64;
 
 /// The development mode number of genesis committee members.
 pub const DEVELOPMENT_MODE_NUM_GENESIS_COMMITTEE_MEMBERS: u16 = 4;

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -56,6 +56,7 @@ serial = [
   "snarkos-node-bft/serial"
 ]
 test = []
+test_network = [ "snarkos-node-bft/test_network", "snarkos-node-consensus/test_network" ]
 
 [dependencies.aleo-std]
 workspace = true

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -56,7 +56,7 @@ serial = [
   "snarkos-node-bft/serial"
 ]
 test = []
-test_network = [ "snarkos-node-bft/test_network", "snarkos-node-consensus/test_network" ]
+test_network = [ "snarkos-node-bft/test_network", "snarkos-node-consensus/test_network", "snarkos-utilities/test_network" ]
 
 [dependencies.aleo-std]
 workspace = true

--- a/node/bft/Cargo.toml
+++ b/node/bft/Cargo.toml
@@ -47,6 +47,9 @@ test = [
   "snarkos-node-bft-ledger-service/test",
   "snarkos-node-bft-storage-service/test"
 ]
+test_network = [
+  "snarkos-node-bft-ledger-service/test_network",
+]
 serial = [
   "snarkos-node-metrics/serial",
   "snarkos-node-bft-ledger-service/serial"
@@ -94,6 +97,9 @@ optional = true
 workspace = true
 
 [dependencies.rand]
+workspace = true
+
+[dependencies.rand_chacha]
 workspace = true
 
 [dependencies.rayon]

--- a/node/bft/ledger-service/Cargo.toml
+++ b/node/bft/ledger-service/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 
 [features]
 default = [ ]
-ledger = [ "parking_lot", "rand", "rayon", "tokio", "tracing" ]
+ledger = [ "parking_lot", "rand", "rand_chacha", "rayon", "tokio", "tracing" ]
 ledger-write = [ ]
 locktick = [
   "dep:locktick",
@@ -33,6 +33,7 @@ serial = [
   "snarkvm/serial"
 ]
 test = [ "mock", "translucent" ]
+test_network = [ ]
 translucent = [ "ledger" ]
 
 [dependencies.anyhow]
@@ -62,6 +63,10 @@ workspace = true
 optional = true
 
 [dependencies.rand]
+workspace = true
+optional = true
+
+[dependencies.rand_chacha]
 workspace = true
 optional = true
 

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -68,6 +68,10 @@ pub struct CoreLedgerService<N: Network, C: ConsensusStorage<N>> {
     latest_leader: Arc<RwLock<Option<(u64, Address<N>)>>>,
     stoppable: Arc<dyn Stoppable>,
     update_lock: Arc<Mutex<()>>,
+    #[cfg(feature = "test_network")]
+    dev_start_round: Option<u64>,
+    #[cfg(feature = "test_network")]
+    dev_num_validators: Option<String>,
 }
 
 /// A transactional update to the ledger.
@@ -136,10 +140,46 @@ impl<N: Network, C: ConsensusStorage<N>> CoreLedgerService<N, C> {
     pub fn new(ledger: Ledger<N, C>, stoppable: Arc<dyn Stoppable>) -> Self {
         // Initialize the block height metric.
         #[cfg(feature = "metrics")]
-        {
-            metrics::gauge(metrics::bft::HEIGHT, ledger.latest_block().height() as f64);
+        metrics::gauge(metrics::bft::HEIGHT, ledger.latest_block().height() as f64);
+        #[cfg(feature = "test_network")]
+        let dev_num_validators = std::env::var("DEV_COMMITTEE_NUM_VALIDATORS").ok();
+        #[cfg(feature = "test_network")]
+        let dev_start_round = dev_num_validators.is_some().then_some(ledger.latest_round());
+        Self {
+            ledger,
+            latest_leader: Default::default(),
+            stoppable,
+            update_lock: Default::default(),
+            #[cfg(feature = "test_network")]
+            dev_start_round,
+            #[cfg(feature = "test_network")]
+            dev_num_validators,
         }
-        Self { ledger, latest_leader: Default::default(), stoppable, update_lock: Default::default() }
+    }
+
+    /// Returns the deterministic dev committee for rounds at or after the hotswap start.
+    #[cfg(feature = "test_network")]
+    fn dev_committee_for_round(&self, round: u64) -> Result<Option<Committee<N>>> {
+        let dev_num_validators = self.dev_num_validators.as_ref().expect("DEV_COMMITTEE_NUM_VALIDATORS is not set");
+        let dev_num_validators = dev_num_validators.parse::<u16>()?;
+        let dev_start_round = self.dev_start_round.as_ref().expect("DEV_COMMITTEE_NUM_VALIDATORS is not set");
+        if round < *dev_start_round {
+            return Ok(None);
+        }
+
+        use rand::SeedableRng;
+        let mut rng = rand_chacha::ChaChaRng::seed_from_u64(snarkos_utilities::DEVELOPMENT_MODE_RNG_SEED);
+        let dev_keys = (0..dev_num_validators)
+            .map(|_| snarkvm::console::account::PrivateKey::<N>::new(&mut rng))
+            .collect::<Result<Vec<_>>>()?;
+        let members = dev_keys
+            .iter()
+            .map(Address::<N>::try_from)
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .map(|address| (address, (snarkvm::ledger::committee::MIN_VALIDATOR_STAKE, true, 0)))
+            .collect::<IndexMap<_, _>>();
+        Ok(Some(Committee::new(*dev_start_round, members)?))
     }
 }
 
@@ -234,6 +274,15 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
 
     /// Returns the current committee.
     fn current_committee(&self) -> Result<Committee<N>> {
+        #[cfg(feature = "test_network")]
+        {
+            if let Some(dev_start_round) = self.dev_start_round {
+                if let Some(dev_committee) = self.dev_committee_for_round(dev_start_round)? {
+                    return Ok(dev_committee);
+                }
+            }
+        }
+
         self.ledger.latest_committee()
     }
 
@@ -247,6 +296,13 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
 
     /// Returns the committee lookback for the given round.
     fn get_committee_lookback_for_round(&self, round: u64) -> Result<Committee<N>> {
+        #[cfg(feature = "test_network")]
+        {
+            if let Some(dev_committee) = self.dev_committee_for_round(round)? {
+                return Ok(dev_committee);
+            }
+        }
+
         // Get the round number for the previous committee. Note, we subtract 2 from odd rounds,
         // because committees are updated in even rounds.
         let previous_round = match round.is_multiple_of(2) {
@@ -259,6 +315,12 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
 
         // Retrieve the committee for the committee lookback round.
         self.get_committee_for_round(committee_lookback_round)
+    }
+
+    /// Returns the deterministic hotswapped dev committee for the given round, if active.
+    #[cfg(feature = "test_network")]
+    fn dev_committee_for_round(&self, round: u64) -> Result<Option<Committee<N>>> {
+        CoreLedgerService::dev_committee_for_round(self, round)
     }
 
     /// Returns `true` if the ledger contains the given certificate ID in block history.

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -15,6 +15,8 @@
 
 use crate::{BeginLedgerUpdateError, LedgerService, LedgerUpdateService, fmt_id, spawn_blocking};
 
+#[cfg(feature = "test_network")]
+use snarkos_utilities::NodeDataDir;
 use snarkos_utilities::Stoppable;
 
 use snarkvm::{
@@ -139,29 +141,60 @@ impl<N: Network, C: ConsensusStorage<N>> CoreLedgerService<N, C> {
         // Initialize the block height metric.
         #[cfg(feature = "metrics")]
         metrics::gauge(metrics::bft::HEIGHT, ledger.latest_block().height() as f64);
-        #[cfg(feature = "test_network")]
-        let dev_committee = Self::build_dev_committee(ledger.latest_round())
-            .expect("Failed to build dev committee from DEV_COMMITTEE_NUM_VALIDATORS");
+
+        Self::new_inner(ledger, stoppable, None)
+    }
+
+    /// Initializes a new core ledger service that persists hotswapped dev committee state to disk.
+    ///
+    /// This variant should be used by long-running nodes (e.g. validators) that may be restarted,
+    /// so that the deterministic dev committee's starting round remains stable across runs.
+    #[cfg(feature = "test_network")]
+    pub fn new_dev(
+        ledger: Ledger<N, C>,
+        stoppable: Arc<dyn Stoppable>,
+        dev_committee_config: Option<(NodeDataDir, u16)>,
+    ) -> Self {
+        // Initialize the block height metric.
+        #[cfg(feature = "metrics")]
+        metrics::gauge(metrics::bft::HEIGHT, ledger.latest_block().height() as f64);
+        // Build the deterministic dev committee.
+        let dev_committee = dev_committee_config.map(|(node_data_dir, dev_num_validators)| {
+            Self::build_dev_committee(ledger.latest_round(), node_data_dir, dev_num_validators)
+                .expect("Failed to build dev committee")
+        });
+        Self::new_inner(ledger, stoppable, dev_committee)
+    }
+
+    /// Initializes the core ledger service.
+    fn new_inner(ledger: Ledger<N, C>, stoppable: Arc<dyn Stoppable>, _dev_committee: Option<Committee<N>>) -> Self {
         Self {
             ledger,
             latest_leader: Default::default(),
             stoppable,
             update_lock: Default::default(),
             #[cfg(feature = "test_network")]
-            dev_committee,
+            dev_committee: _dev_committee,
         }
     }
 
-    /// Builds the deterministic dev committee from `DEV_COMMITTEE_NUM_VALIDATORS`, if set.
+    /// Builds the deterministic dev committee with `dev_num_validators` members, if requested.
     ///
-    /// Returns `Ok(None)` when the env var is unset, otherwise returns a committee whose
-    /// starting round is `start_round`.
+    /// Returns `Ok(None)` when `dev_num_validators` is `None`, otherwise returns a committee
+    /// whose starting round is anchored to the round at which the dev committee was first
+    /// activated.
+    ///
+    /// The starting round is persisted to disk on first activation and re-read
+    /// on subsequent invocations. This keeps the committee's identity (and
+    /// therefore the certificates that reference it) consistent across
+    /// restarts.
     #[cfg(feature = "test_network")]
-    fn build_dev_committee(start_round: u64) -> Result<Option<Committee<N>>> {
-        let Some(dev_num_validators) = std::env::var("DEV_COMMITTEE_NUM_VALIDATORS").ok() else {
-            return Ok(None);
-        };
-        let dev_num_validators = dev_num_validators.parse::<u16>()?;
+    fn build_dev_committee(
+        default_start_round: u64,
+        node_data_dir: NodeDataDir,
+        dev_num_validators: u16,
+    ) -> Result<Committee<N>> {
+        let start_round = Self::load_or_init_dev_committee_start_round(node_data_dir, default_start_round)?;
 
         use rand::SeedableRng;
         let mut rng = rand_chacha::ChaChaRng::seed_from_u64(snarkos_utilities::DEVELOPMENT_MODE_RNG_SEED);
@@ -175,7 +208,53 @@ impl<N: Network, C: ConsensusStorage<N>> CoreLedgerService<N, C> {
             .into_iter()
             .map(|address| (address, (snarkvm::ledger::committee::MIN_VALIDATOR_STAKE, true, 0)))
             .collect::<IndexMap<_, _>>();
-        Ok(Some(Committee::new(start_round, members)?))
+        Committee::new(start_round, members)
+    }
+
+    /// Reads the persisted dev committee starting round from disk if it exists and is consistent
+    /// with `default_start_round`; otherwise writes the default to disk and returns it.
+    #[cfg(feature = "test_network")]
+    fn load_or_init_dev_committee_start_round(node_data_dir: NodeDataDir, default_start_round: u64) -> Result<u64> {
+        let path = node_data_dir.dev_committee_state_path();
+        let path_str = path.display();
+        // If the dev committee state file exists, read it and parse the starting round.
+        if path.exists() {
+            let contents = std::fs::read_to_string(&path)
+                .map_err(|err| anyhow::anyhow!("Failed to read dev committee state from {path_str} - {err}"))?;
+            let start_round = contents.trim().parse::<u64>().map_err(|err| {
+                anyhow::anyhow!("Failed to parse dev committee state at {path_str} ({contents}) - {err}",)
+            })?;
+
+            if start_round > default_start_round {
+                bail!(
+                    "Stale dev committee starting round {start_round} at {path_str} (current ledger round is {default_start_round})"
+                );
+            }
+
+            tracing::info!("Loaded the dev committee starting round {start_round} from {path_str}");
+            Ok(start_round)
+        // If the dev committee state file does not exist, write the default starting round to it.
+        } else {
+            Self::write_dev_committee_start_round(&path, default_start_round)?;
+            tracing::info!("Persisted the dev committee starting round {default_start_round} to {path_str}");
+            Ok(default_start_round)
+        }
+    }
+
+    /// Writes the given `start_round` to the dev committee state file at `path`, creating the
+    /// parent directory if needed.
+    #[cfg(feature = "test_network")]
+    fn write_dev_committee_start_round(path: &std::path::Path, start_round: u64) -> Result<()> {
+        if let Some(parent) = path.parent()
+            && !parent.exists()
+        {
+            std::fs::create_dir_all(parent).map_err(|err| {
+                anyhow::anyhow!("Failed to create dev committee state directory {} - {err}", parent.display())
+            })?;
+        }
+        std::fs::write(path, start_round.to_string())
+            .map_err(|err| anyhow::anyhow!("Failed to write dev committee state to {} - {err}", path.display()))?;
+        Ok(())
     }
 
     /// Returns the deterministic dev committee for rounds at or after the hotswap start.

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -69,9 +69,7 @@ pub struct CoreLedgerService<N: Network, C: ConsensusStorage<N>> {
     stoppable: Arc<dyn Stoppable>,
     update_lock: Arc<Mutex<()>>,
     #[cfg(feature = "test_network")]
-    dev_start_round: Option<u64>,
-    #[cfg(feature = "test_network")]
-    dev_num_validators: Option<u16>,
+    dev_committee: Option<Committee<N>>,
 }
 
 /// A transactional update to the ledger.
@@ -142,33 +140,32 @@ impl<N: Network, C: ConsensusStorage<N>> CoreLedgerService<N, C> {
         #[cfg(feature = "metrics")]
         metrics::gauge(metrics::bft::HEIGHT, ledger.latest_block().height() as f64);
         #[cfg(feature = "test_network")]
-        let dev_num_validators = std::env::var("DEV_COMMITTEE_NUM_VALIDATORS").ok().map(|s| s.parse::<u16>().unwrap());
-        #[cfg(feature = "test_network")]
-        let dev_start_round = dev_num_validators.is_some().then_some(ledger.latest_round());
+        let dev_committee = Self::build_dev_committee(ledger.latest_round())
+            .expect("Failed to build dev committee from DEV_COMMITTEE_NUM_VALIDATORS");
         Self {
             ledger,
             latest_leader: Default::default(),
             stoppable,
             update_lock: Default::default(),
             #[cfg(feature = "test_network")]
-            dev_start_round,
-            #[cfg(feature = "test_network")]
-            dev_num_validators,
+            dev_committee,
         }
     }
 
-    /// Returns the deterministic dev committee for rounds at or after the hotswap start.
+    /// Builds the deterministic dev committee from `DEV_COMMITTEE_NUM_VALIDATORS`, if set.
+    ///
+    /// Returns `Ok(None)` when the env var is unset, otherwise returns a committee whose
+    /// starting round is `start_round`.
     #[cfg(feature = "test_network")]
-    fn dev_committee_for_round(&self, round: u64) -> Result<Option<Committee<N>>> {
-        let dev_num_validators = self.dev_num_validators.as_ref().expect("DEV_COMMITTEE_NUM_VALIDATORS is not set");
-        let dev_start_round = self.dev_start_round.as_ref().expect("DEV_COMMITTEE_NUM_VALIDATORS is not set");
-        if round < *dev_start_round {
+    fn build_dev_committee(start_round: u64) -> Result<Option<Committee<N>>> {
+        let Some(dev_num_validators) = std::env::var("DEV_COMMITTEE_NUM_VALIDATORS").ok() else {
             return Ok(None);
-        }
+        };
+        let dev_num_validators = dev_num_validators.parse::<u16>()?;
 
         use rand::SeedableRng;
         let mut rng = rand_chacha::ChaChaRng::seed_from_u64(snarkos_utilities::DEVELOPMENT_MODE_RNG_SEED);
-        let dev_keys = (0..*dev_num_validators)
+        let dev_keys = (0..dev_num_validators)
             .map(|_| snarkvm::console::account::PrivateKey::<N>::new(&mut rng))
             .collect::<Result<Vec<_>>>()?;
         let members = dev_keys
@@ -178,7 +175,19 @@ impl<N: Network, C: ConsensusStorage<N>> CoreLedgerService<N, C> {
             .into_iter()
             .map(|address| (address, (snarkvm::ledger::committee::MIN_VALIDATOR_STAKE, true, 0)))
             .collect::<IndexMap<_, _>>();
-        Ok(Some(Committee::new(*dev_start_round, members)?))
+        Ok(Some(Committee::new(start_round, members)?))
+    }
+
+    /// Returns the deterministic dev committee for rounds at or after the hotswap start.
+    #[cfg(feature = "test_network")]
+    fn dev_committee_for_round(&self, round: u64) -> Result<Option<Committee<N>>> {
+        let Some(dev_committee) = self.dev_committee.as_ref() else {
+            return Ok(None);
+        };
+        if round < dev_committee.starting_round() {
+            return Ok(None);
+        }
+        Ok(Some(dev_committee.clone()))
     }
 }
 
@@ -275,10 +284,8 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
     fn current_committee(&self) -> Result<Committee<N>> {
         #[cfg(feature = "test_network")]
         {
-            if let Some(dev_start_round) = self.dev_start_round {
-                if let Some(dev_committee) = self.dev_committee_for_round(dev_start_round)? {
-                    return Ok(dev_committee);
-                }
+            if let Some(dev_committee) = self.dev_committee.as_ref() {
+                return Ok(dev_committee.clone());
             }
         }
 

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -71,7 +71,7 @@ pub struct CoreLedgerService<N: Network, C: ConsensusStorage<N>> {
     #[cfg(feature = "test_network")]
     dev_start_round: Option<u64>,
     #[cfg(feature = "test_network")]
-    dev_num_validators: Option<String>,
+    dev_num_validators: Option<u16>,
 }
 
 /// A transactional update to the ledger.
@@ -142,7 +142,7 @@ impl<N: Network, C: ConsensusStorage<N>> CoreLedgerService<N, C> {
         #[cfg(feature = "metrics")]
         metrics::gauge(metrics::bft::HEIGHT, ledger.latest_block().height() as f64);
         #[cfg(feature = "test_network")]
-        let dev_num_validators = std::env::var("DEV_COMMITTEE_NUM_VALIDATORS").ok();
+        let dev_num_validators = std::env::var("DEV_COMMITTEE_NUM_VALIDATORS").ok().map(|s| s.parse::<u16>().unwrap());
         #[cfg(feature = "test_network")]
         let dev_start_round = dev_num_validators.is_some().then_some(ledger.latest_round());
         Self {
@@ -161,7 +161,6 @@ impl<N: Network, C: ConsensusStorage<N>> CoreLedgerService<N, C> {
     #[cfg(feature = "test_network")]
     fn dev_committee_for_round(&self, round: u64) -> Result<Option<Committee<N>>> {
         let dev_num_validators = self.dev_num_validators.as_ref().expect("DEV_COMMITTEE_NUM_VALIDATORS is not set");
-        let dev_num_validators = dev_num_validators.parse::<u16>()?;
         let dev_start_round = self.dev_start_round.as_ref().expect("DEV_COMMITTEE_NUM_VALIDATORS is not set");
         if round < *dev_start_round {
             return Ok(None);
@@ -169,7 +168,7 @@ impl<N: Network, C: ConsensusStorage<N>> CoreLedgerService<N, C> {
 
         use rand::SeedableRng;
         let mut rng = rand_chacha::ChaChaRng::seed_from_u64(snarkos_utilities::DEVELOPMENT_MODE_RNG_SEED);
-        let dev_keys = (0..dev_num_validators)
+        let dev_keys = (0..*dev_num_validators)
             .map(|_| snarkvm::console::account::PrivateKey::<N>::new(&mut rng))
             .collect::<Result<Vec<_>>>()?;
         let members = dev_keys

--- a/node/bft/ledger-service/src/traits.rs
+++ b/node/bft/ledger-service/src/traits.rs
@@ -118,6 +118,12 @@ pub trait LedgerService<N: Network>: std::fmt::Debug + Send + Sync {
     /// Returns the committee lookback for the given round.
     fn get_committee_lookback_for_round(&self, round: u64) -> Result<Committee<N>>;
 
+    /// Returns the deterministic hotswapped dev committee for the given round, if active.
+    #[cfg(feature = "test_network")]
+    fn dev_committee_for_round(&self, _round: u64) -> Result<Option<Committee<N>>> {
+        Ok(None)
+    }
+
     /// Returns `true` if the ledger contains the given certificate ID.
     fn contains_certificate(&self, certificate_id: &Field<N>) -> Result<bool>;
 

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -828,6 +828,7 @@ impl<N: Network> Storage<N> {
         block: &Block<N>,
         certificate: BatchCertificate<N>,
         unconfirmed_transactions: &HashMap<N::TransactionID, Transaction<N>>,
+        trusted_ledger_certificate: bool,
     ) -> Result<()> {
         // Skip if the certificate round is below the GC round.
         let gc_round = self.gc_round();
@@ -912,8 +913,14 @@ impl<N: Network> Storage<N> {
             certificate.transmission_ids().len()
         );
 
-        self.insert_certificate(certificate, missing_transmissions, aborted_transmissions)
-            .with_context(|| format!("Failed to insert certificate '{certificate_id}' from block {}", block.height()))
+        if trusted_ledger_certificate {
+            self.insert_certificate_atomic(certificate, aborted_transmissions, missing_transmissions);
+            Ok(())
+        } else {
+            self.insert_certificate(certificate, missing_transmissions, aborted_transmissions).with_context(|| {
+                format!("Failed to insert certificate '{certificate_id}' from block {}", block.height())
+            })
+        }
     }
 }
 

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -573,6 +573,15 @@ impl<N: Network> proposal_task::BatchPropose for Primary<N> {
             if previous_committee_lookback.is_quorum_threshold_reached(&authors) {
                 is_ready = true;
             }
+            #[cfg(feature = "test_network")]
+            {
+                // If we are using a hotswapped dev committee, use simplified checks to more easily advance.
+                if let Some(dev_committee) = self.ledger.dev_committee_for_round(previous_round)? {
+                    if round <= dev_committee.starting_round() {
+                        is_ready = true;
+                    }
+                }
+            }
         }
         // If the batch is not ready to be proposed, return early.
         if !is_ready {

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -430,8 +430,16 @@ impl<N: Network> Sync<N> {
                 // Iterate over the certificates.
                 for certificates in subdag.values().cloned() {
                     cfg_into_iter!(certificates).try_for_each(|certificate| {
+                        // The block was already verified when it was added to the
+                        // ledger, so we do not have to re-check its certificates here.
+                        let trusted_ledger_certificate = true;
                         self.storage
-                            .sync_certificate_with_block(block, certificate, &unconfirmed_transactions, true)
+                            .sync_certificate_with_block(
+                                block,
+                                certificate,
+                                &unconfirmed_transactions,
+                                trusted_ledger_certificate,
+                            )
                             .with_context(|| format!("Failed to sync certificate with block {}", block.height()))
                     })?;
                 }
@@ -690,8 +698,15 @@ impl<N: Network> Sync<N> {
         for certificates in subdag.values() {
             cfg_into_iter!(certificates.clone()).try_for_each(|certificate| -> Result<()> {
                 // Sync the batch certificate with the block.
+                // Make sure to perform full verification of the certificate here.
+                let trusted_ledger_certificate = false;
                 self.storage
-                    .sync_certificate_with_block(block, certificate.clone(), &unconfirmed_transactions, false)
+                    .sync_certificate_with_block(
+                        block,
+                        certificate.clone(),
+                        &unconfirmed_transactions,
+                        trusted_ledger_certificate,
+                    )
                     .with_context(|| format!("Failed to sync certificate with block {}", block.height()))
             })?;
         }

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -431,7 +431,7 @@ impl<N: Network> Sync<N> {
                 for certificates in subdag.values().cloned() {
                     cfg_into_iter!(certificates).try_for_each(|certificate| {
                         self.storage
-                            .sync_certificate_with_block(block, certificate, &unconfirmed_transactions)
+                            .sync_certificate_with_block(block, certificate, &unconfirmed_transactions, true)
                             .with_context(|| format!("Failed to sync certificate with block {}", block.height()))
                     })?;
                 }
@@ -691,7 +691,7 @@ impl<N: Network> Sync<N> {
             cfg_into_iter!(certificates.clone()).try_for_each(|certificate| -> Result<()> {
                 // Sync the batch certificate with the block.
                 self.storage
-                    .sync_certificate_with_block(block, certificate.clone(), &unconfirmed_transactions)
+                    .sync_certificate_with_block(block, certificate.clone(), &unconfirmed_transactions, false)
                     .with_context(|| format!("Failed to sync certificate with block {}", block.height()))
             })?;
         }

--- a/node/consensus/Cargo.toml
+++ b/node/consensus/Cargo.toml
@@ -34,11 +34,15 @@ serial = [
   "snarkos-node-metrics/serial",
   "snarkvm/serial"
 ]
+test_network = [ ]
 
 [dependencies.aleo-std]
 workspace = true
 
 [dependencies.anyhow]
+workspace = true
+
+[dependencies.cfg_if]
 workspace = true
 
 [dependencies.colored]

--- a/node/consensus/Cargo.toml
+++ b/node/consensus/Cargo.toml
@@ -42,7 +42,7 @@ workspace = true
 [dependencies.anyhow]
 workspace = true
 
-[dependencies.cfg_if]
+[dependencies.cfg-if]
 workspace = true
 
 [dependencies.colored]

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -57,6 +57,7 @@ use snarkvm::{
 
 use aleo_std::StorageMode;
 use anyhow::{Context, Result};
+use cfg_if::cfg_if;
 use colored::Colorize;
 use indexmap::IndexMap;
 #[cfg(feature = "locktick")]
@@ -593,7 +594,20 @@ impl<N: Network> Consensus<N> {
         metrics::histogram(metrics::consensus::PREPARE_ADVANCE_SECS, prepare_elapsed.as_secs_f64());
 
         let check_instant = std::time::Instant::now();
-        let block = match ledger_update.check_next_block(block) {
+        cfg_if! {
+            if #[cfg(feature = "test_network")] {
+                // If we are using a hotswapped dev committee, skip checking the block.
+                let result = if self.ledger.dev_committee_for_round(block.round())?.is_some() {
+                    Ok(block)
+                } else {
+                    ledger_update.check_next_block(block)
+                };
+            } else {
+                let result = ledger_update.check_next_block(block);
+            }
+        }
+
+        let block = match result {
             Ok(block) => block,
             Err(CheckBlockError::BlockAlreadyExists { .. }) => {
                 debug!("The given block hash already exists in the ledger");
@@ -609,6 +623,7 @@ impl<N: Network> Consensus<N> {
             }
             Err(err) => return Err(err.into_anyhow()),
         };
+
         let check_elapsed = check_instant.elapsed();
         trace!("check_next_block took {:.3}s", check_elapsed.as_secs_f64());
         #[cfg(feature = "metrics")]

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -98,6 +98,7 @@ impl<N: Network> Node<N> {
         auto_db_checkpoints: Option<PathBuf>,
         dev_txs: bool,
         dev: Option<u16>,
+        dev_num_validators_for_committee_hotswap: Option<u16>,
         signal_handler: Arc<SignalHandler>,
     ) -> Result<Self> {
         let validator = Arc::new(
@@ -116,6 +117,7 @@ impl<N: Network> Node<N> {
                 trusted_peers_only,
                 dev_txs,
                 dev,
+                dev_num_validators_for_committee_hotswap,
                 signal_handler,
             )
             .await?,

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -92,6 +92,8 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
         trusted_peers_only: bool,
         dev_txs: bool,
         dev: Option<u16>,
+        #[cfg(feature = "test_network")] dev_num_validators_for_committee_hotswap: Option<u16>,
+        #[cfg(not(feature = "test_network"))] _dev_num_validators_for_committee_hotswap: Option<u16>,
         signal_handler: Arc<SignalHandler>,
     ) -> Result<Self> {
         // Initialize the ledger.
@@ -104,7 +106,20 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
         .with_context(|| "Failed to initialize the ledger")?;
 
         // Initialize the ledger service.
+        #[cfg(not(feature = "test_network"))]
         let ledger_service = Arc::new(CoreLedgerService::new(ledger.clone(), signal_handler.clone()));
+        #[cfg(feature = "test_network")]
+        // Initialize the ledger service with a deterministic dev committee.
+        let ledger_service = if let Some(dev_num_validators) = dev_num_validators_for_committee_hotswap {
+            Arc::new(CoreLedgerService::new_dev(
+                ledger.clone(),
+                signal_handler.clone(),
+                Some((node_data_dir.clone(), dev_num_validators)),
+            ))
+        // Initialize the ledger service without a deterministic dev committee.
+        } else {
+            Arc::new(CoreLedgerService::new_dev(ledger.clone(), signal_handler.clone(), None))
+        };
 
         // Initialize the node router.
         let router = Router::new(
@@ -544,6 +559,7 @@ mod tests {
             node_data_dir,
             false,
             dev_txs,
+            None,
             None,
             SignalHandler::new(None),
         )

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -518,7 +518,7 @@ mod tests {
         let dev_txs = true;
 
         // Initialize an (insecure) fixed RNG.
-        let mut rng = ChaChaRng::seed_from_u64(1234567890u64);
+        let mut rng = ChaChaRng::seed_from_u64(snarkos_utilities::DEVELOPMENT_MODE_RNG_SEED);
         // Initialize the account.
         let account = Account::<CurrentNetwork>::new(&mut rng).unwrap();
         // Initialize a new VM.

--- a/node/tests/common/node.rs
+++ b/node/tests/common/node.rs
@@ -74,6 +74,7 @@ pub async fn validator() -> Validator<CurrentNetwork, ConsensusMemory<CurrentNet
         false, // This test requires validators to connect to peers.
         false, // No dev traffic in production mode.
         None,
+        None, // No dev committee hotswap in production mode.
         SignalHandler::new(None),
     )
     .await

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -16,6 +16,9 @@ categories = [ "cryptography", "cryptography::cryptocurrencies", "os" ]
 license = "Apache-2.0"
 edition = "2024"
 
+[features]
+test_network = [ ]
+
 [dependencies.anyhow]
 workspace = true
 

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -23,3 +23,6 @@ pub use node_data::*;
 
 mod callback_handle;
 pub use callback_handle::CallbackHandle;
+
+/// Seed used for deterministic RNG in development mode.
+pub const DEVELOPMENT_MODE_RNG_SEED: u64 = 1234567890u64;

--- a/utilities/src/node_data.rs
+++ b/utilities/src/node_data.rs
@@ -28,6 +28,10 @@ pub const LEGACY_ROUTER_PEER_CACHE_FILE: &str = "cached_router_peers";
 /// The filename of the proposal cache.
 pub const CURRENT_PROPOSAL_CACHE_FILE: &str = "current-proposal-cache";
 
+/// The filename used to persist the hotswapped dev committee's starting round.
+#[cfg(feature = "test_network")]
+pub const DEV_COMMITTEE_STATE_FILE: &str = "dev-committee-state";
+
 /// The filename of the JWT secret for a given address.
 pub fn jwt_secret_file<D: std::fmt::Display>(address: &D) -> PathBuf {
     PathBuf::from(format!("jwt_secret_{address}.txt"))
@@ -90,6 +94,12 @@ impl NodeDataDir {
     /// The location to store the current proposal cache.
     pub fn current_proposal_cache_path(&self) -> PathBuf {
         self.path.join(CURRENT_PROPOSAL_CACHE_FILE)
+    }
+
+    /// The location used to persist the hotswapped dev committee's starting round.
+    #[cfg(feature = "test_network")]
+    pub fn dev_committee_state_path(&self) -> PathBuf {
+        self.path.join(DEV_COMMITTEE_STATE_FILE)
     }
 
     /// The location to store the JWT secret for a given address.


### PR DESCRIPTION
## Motivation

E2E test would be more robust if we manage to fully replicate our production state and environment.

One blocker to this end is that snarkOS currently tightly couples ledger state and consensus. More concretely: a dev committee is not authorized to produce new blocks on top of production ledger state. This PR changes this by supporting hotswapping of a ledger without too many code changes through the use of a `DEV_COMMITTEE_NUM_VALIDATORS` environment variable and a `--dev-on-prod` flag. The relevant codepaths are compile-guarded by the `test_network` feature. I didn't introduce a new compilation feature to keep our testing environment simple.

The new settings enable the use of a production genesis block and disable checks on certificates. In order to avoid mutilating snarkVM, the entire call to `check_next_block` is skipped.

## Test Plan

- [x] New CI script passes
- [x] Prerelease tests passed