### PR TITLE
Rename `test_network` flag to `devnet`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -760,7 +760,7 @@ jobs:
       - run:
           name: Lint scripts
           command: |
-            shellcheck -x .ci/*.sh
+            shellcheck -x .ci/*.sh scripts/*.sh
       - clear_environment:
           cache_key: v4.2.0-rust-1.88.0-lint-scripts-cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ commands:
             CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 \
             CARGO_PROFILE_RELEASE_OPT_LEVEL=2 \
             CARGO_PROFILE_RELEASE_DEBUG=0 \
-            cargo install --locked --path . --features test_network
+            cargo install --locked --path . --features devnet
 
   setup_environment:
     description: "Setup testing environment"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -55,8 +55,8 @@ jobs:
           gcloud storage cp gs://ci_testdata/sync-ledger-val40-250-9ec2291c57.zip ledger.zip
           unzip ledger.zip
  
-      - name: Install snarkOS (test_network)
-        run: cargo install --path=. --locked --features=test_network
+      - name: Install snarkOS (devnet)
+        run: cargo install --path=. --locked --features=devnet
 
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data

--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,5 +1,5 @@
 [hooks]
-pre-commit = "cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo +nightly fmt --all -- --check"
+pre-commit = "./scripts/lint.sh"
 
 [logging]
 verbose = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,8 +309,10 @@ serial = [
 ]
 test_targets = [ "snarkos-cli/test_targets" ]
 test_consensus_heights = [ "snarkos-cli/test_consensus_heights" ]
-test_network = [ "snarkos-cli/test_network", "snarkos-node/test_network" ]
+devnet = [ "snarkos-cli/devnet", "snarkos-node/devnet" ]
 tokio_console = [ "snarkos-cli/tokio_console" ]
+# Deprecated alias for "devnet".
+test_network = [ "devnet" ]
 
 [dependencies.clap]
 workspace = true

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@
   * [6.1 Quick Start](#61-quick-start)
   * [6.2 Operations](#62-operations)
   * [6.3 Local Devnet](#63-local-devnet)
-  * [6.4 Feature Flags](#64-feature-flags)
-  * [6.5 Local Backups](#65-local-backups)
-* [7. Contributors](#7-contributors)
-* [8. License](#8-license)
+  * [6.4 Local Backups](#64-local-backups)
+* [7. Cargo Features](#7-cargo-features)
+* [8. Contributors](#8-contributors)
+* [9. License](#9-license)
 
 [comment]: <> (* [4. JSON-RPC Interface]&#40;#4-json-rpc-interface&#41;)
 [comment]: <> (* [5. Additional Information]&#40;#5-additional-information&#41;)
@@ -292,7 +292,7 @@ The following is an overview of all files that may be needed to be migrated.
 
 To run a node with custom settings, refer to the options and flags available in the `snarkOS` CLI.
 
-The full list of CLI flags and options can be viewed with `snarkos --help`:
+The available CLI flags and options can be viewed using `snarkos --help`:
 ```
 snarkOS 
 The Aleo Team <hello@aleo.org>
@@ -312,7 +312,8 @@ SUBCOMMANDS:
     update     Update snarkOS
 ```
 
-The following are the options for the `snarkos start` command:
+<details><summary>Full <code>snarkos start</code> list of command-line options/summary>
+
 ```
       --network <NETWORK>
           Specify the network ID of this node [options: 0 = mainnet, 1 = testnet, 2 = canary]
@@ -455,6 +456,8 @@ The following are the options for the `snarkos start` command:
           Print help (see a summary with '-h')
 ```
 
+</details>
+
 ## 6. Development Guide
 
 ### 6.1 Quick Start
@@ -587,22 +590,7 @@ To clean up the node storage, run:
 cargo run --release -- clean --dev <NODE_ID>
 ```
 
-## 6.4 Feature Flags
-
-By default, the metrics feature is turned on for some internal crates.
-
-* **history** -
-  Enables a /history REST endpoint.
-* **telemetry** -
-  Allows the node to upload telemetry data.
-* **cuda** -
-  Allows some operations to run on the (NVidia) GPU, instead of on the CPU. See [CUDA acceleration for provers](#optional-cuda-acceleration-for-provers) for install tips and current puzzle status.
-* **locktick** -
-  This feature turns on code for detecting deadlocks.
-* **test_targets** -
-  This feature allows the lowering of coinbase and proof targets for testing.
-
-## 6.5 Local Backups
+## 6.4 Local Backups
 
 The snarkOS node implementation uses rocksdb under the hood. By using its native checkpointing mechanism, you can create backups locally and efficiently. The backups leverage hard links on your filesystem, thereby incurring only a marginal amount of extra space. The aim of these local backups is for you to be able to recover quickly in case your node were to halt.
 
@@ -616,7 +604,56 @@ You can find a basic sample script in `scripts/backup.sh` which you can run as a
 
 You may want to change the `NETWORK`, `BASE_DIR`, `ENDPOINT` and `JWT` variables.
 
-## 7. Contributors
+## 7. Cargo Features
+
+snarkOS exposes a number of cargo features that toggle optional functionality at build time. They
+can be enabled by passing `--features <name>` (comma-separated) to `cargo build`, `cargo install`,
+or `cargo run`.
+
+By default, the `metrics` feature is enabled for some internal crates; all other features below
+are opt-in.
+
+### Production features
+
+* **history** —
+  Enables the `/history` REST endpoint, which exposes historical chain data.
+* **history-staking-rewards** —
+  Extends `history` with per-validator staking-reward records. Implies `history`.
+* **telemetry** —
+  Allows validators to upload participation telemetry. See
+  [Enable Validator Telemetry Metrics](#321-enable-validator-telemetry-metrics-optional).
+* **cuda** —
+  Runs select cryptographic operations on an NVIDIA GPU instead of the CPU. See
+  [CUDA acceleration for provers](#optional-cuda-acceleration-for-provers) for installation notes
+  and the current puzzle status.
+
+### Development and debugging features
+
+* **locktick** —
+  Compiles in instrumentation for detecting lock contention and potential deadlocks.
+* **tokio_console** —
+  Enables a [`tokio-console`](https://github.com/tokio-rs/console) subscriber for inspecting
+  async tasks at runtime.
+* **serial** —
+  Forces single-threaded execution in components that would otherwise use rayon/tokio
+  parallelism. Useful for deterministic debugging.
+
+### Testing features
+
+* **test_targets** —
+  Lowers the coinbase and proof targets so that puzzles can be solved quickly in tests.
+* **test_consensus_heights** —
+  Allows overriding consensus version heights via environment variables, so tests can exercise
+  upgrade paths without waiting for real mainnet heights.
+* **devnet** —
+  Enables development-only code paths used by local devnets: the `--dev` flag and dev-committee
+  hotswap support, deterministic account derivation, and snarkVM's `dev-print` output. Implies
+  `test_targets` and `test_consensus_heights`, so it is the most convenient way to build a node
+  for local testing.
+* **test_network** —
+  *Deprecated.* Alias for `devnet`.
+  
+## 8. Contributors
 Thank you for helping make snarkOS better!  
 [🧐 What do the emojis mean?](https://allcontributors.org/docs/en/emoji-key)
 
@@ -716,8 +753,8 @@ Thank you for helping make snarkOS better!
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome!
 
-## 8. License
+## 9. License
 
-We welcome all contributions to `snarkOS`. Please refer to the [license](#7-license) for the terms of contributions.
+We welcome all contributions to `snarkOS`. Please refer to the [license](#9-license) for the terms of contributions.
 
 [![License: GPL v3](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE.md)

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -39,8 +39,8 @@ cuda = [
 ]
 test_targets = [ "snarkvm/test_targets" ]
 test_consensus_heights = [ "snarkvm/test_consensus_heights" ]
-test_network = [
-  "test_targets", 
+devnet = [
+  "test_targets",
   "test_consensus_heights",
   "snarkvm/dev-print"
 ]

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -689,9 +689,9 @@ impl Start {
             println!("{}", crate::helpers::welcome_message());
         }
 
-        // Only allow dev mode if we built with the 'test_network' feature.
-        if self.dev.is_some() && cfg!(not(feature = "test_network")) {
-            bail!("The 'dev' flag is set, but the 'test_network' feature is not enabled");
+        // Only allow dev mode if we built with the 'devnet' feature.
+        if self.dev.is_some() && cfg!(not(feature = "devnet")) {
+            bail!("The 'dev' flag is set, but the 'devnet' feature is not enabled");
         }
 
         // Parse the trusted peers to connect to.

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -57,7 +57,7 @@ serial = [
   "snarkos-node-bft/serial"
 ]
 test = []
-test_network = [ "snarkos-node-bft/test_network", "snarkos-node-consensus/test_network", "snarkos-utilities/test_network" ]
+devnet = [ "snarkos-node-bft/devnet", "snarkos-node-consensus/devnet", "snarkos-utilities/devnet" ]
 
 [dependencies.aleo-std]
 workspace = true

--- a/node/bft/Cargo.toml
+++ b/node/bft/Cargo.toml
@@ -47,8 +47,8 @@ test = [
   "snarkos-node-bft-ledger-service/test",
   "snarkos-node-bft-storage-service/test"
 ]
-test_network = [
-  "snarkos-node-bft-ledger-service/test_network",
+devnet = [
+  "snarkos-node-bft-ledger-service/devnet",
 ]
 serial = [
   "snarkos-node-metrics/serial",

--- a/node/bft/ledger-service/Cargo.toml
+++ b/node/bft/ledger-service/Cargo.toml
@@ -33,7 +33,7 @@ serial = [
   "snarkvm/serial"
 ]
 test = [ "mock", "translucent" ]
-test_network = [ ]
+devnet = [ ]
 translucent = [ "ledger" ]
 
 [dependencies.anyhow]

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -15,7 +15,7 @@
 
 use crate::{BeginLedgerUpdateError, LedgerService, LedgerUpdateService, fmt_id, spawn_blocking};
 
-#[cfg(feature = "test_network")]
+#[cfg(feature = "devnet")]
 use snarkos_utilities::NodeDataDir;
 use snarkos_utilities::Stoppable;
 
@@ -70,7 +70,7 @@ pub struct CoreLedgerService<N: Network, C: ConsensusStorage<N>> {
     latest_leader: Arc<RwLock<Option<(u64, Address<N>)>>>,
     stoppable: Arc<dyn Stoppable>,
     update_lock: Arc<Mutex<()>>,
-    #[cfg(feature = "test_network")]
+    #[cfg(feature = "devnet")]
     dev_committee: Option<Committee<N>>,
 }
 
@@ -149,7 +149,7 @@ impl<N: Network, C: ConsensusStorage<N>> CoreLedgerService<N, C> {
     ///
     /// This variant should be used by long-running nodes (e.g. validators) that may be restarted,
     /// so that the deterministic dev committee's starting round remains stable across runs.
-    #[cfg(feature = "test_network")]
+    #[cfg(feature = "devnet")]
     pub fn new_dev(
         ledger: Ledger<N, C>,
         stoppable: Arc<dyn Stoppable>,
@@ -173,7 +173,7 @@ impl<N: Network, C: ConsensusStorage<N>> CoreLedgerService<N, C> {
             latest_leader: Default::default(),
             stoppable,
             update_lock: Default::default(),
-            #[cfg(feature = "test_network")]
+            #[cfg(feature = "devnet")]
             dev_committee: _dev_committee,
         }
     }
@@ -188,7 +188,7 @@ impl<N: Network, C: ConsensusStorage<N>> CoreLedgerService<N, C> {
     /// on subsequent invocations. This keeps the committee's identity (and
     /// therefore the certificates that reference it) consistent across
     /// restarts.
-    #[cfg(feature = "test_network")]
+    #[cfg(feature = "devnet")]
     fn build_dev_committee(
         default_start_round: u64,
         node_data_dir: NodeDataDir,
@@ -213,7 +213,7 @@ impl<N: Network, C: ConsensusStorage<N>> CoreLedgerService<N, C> {
 
     /// Reads the persisted dev committee starting round from disk if it exists and is consistent
     /// with `default_start_round`; otherwise writes the default to disk and returns it.
-    #[cfg(feature = "test_network")]
+    #[cfg(feature = "devnet")]
     fn load_or_init_dev_committee_start_round(node_data_dir: NodeDataDir, default_start_round: u64) -> Result<u64> {
         let path = node_data_dir.dev_committee_state_path();
         let path_str = path.display();
@@ -243,7 +243,7 @@ impl<N: Network, C: ConsensusStorage<N>> CoreLedgerService<N, C> {
 
     /// Writes the given `start_round` to the dev committee state file at `path`, creating the
     /// parent directory if needed.
-    #[cfg(feature = "test_network")]
+    #[cfg(feature = "devnet")]
     fn write_dev_committee_start_round(path: &std::path::Path, start_round: u64) -> Result<()> {
         if let Some(parent) = path.parent()
             && !parent.exists()
@@ -258,7 +258,7 @@ impl<N: Network, C: ConsensusStorage<N>> CoreLedgerService<N, C> {
     }
 
     /// Returns the deterministic dev committee for rounds at or after the hotswap start.
-    #[cfg(feature = "test_network")]
+    #[cfg(feature = "devnet")]
     fn dev_committee_for_round(&self, round: u64) -> Result<Option<Committee<N>>> {
         let Some(dev_committee) = self.dev_committee.as_ref() else {
             return Ok(None);
@@ -361,7 +361,7 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
 
     /// Returns the current committee.
     fn current_committee(&self) -> Result<Committee<N>> {
-        #[cfg(feature = "test_network")]
+        #[cfg(feature = "devnet")]
         {
             if let Some(dev_committee) = self.dev_committee.as_ref() {
                 return Ok(dev_committee.clone());
@@ -381,7 +381,7 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
 
     /// Returns the committee lookback for the given round.
     fn get_committee_lookback_for_round(&self, round: u64) -> Result<Committee<N>> {
-        #[cfg(feature = "test_network")]
+        #[cfg(feature = "devnet")]
         {
             if let Some(dev_committee) = self.dev_committee_for_round(round)? {
                 return Ok(dev_committee);
@@ -403,7 +403,7 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
     }
 
     /// Returns the deterministic hotswapped dev committee for the given round, if active.
-    #[cfg(feature = "test_network")]
+    #[cfg(feature = "devnet")]
     fn dev_committee_for_round(&self, round: u64) -> Result<Option<Committee<N>>> {
         CoreLedgerService::dev_committee_for_round(self, round)
     }

--- a/node/bft/ledger-service/src/traits.rs
+++ b/node/bft/ledger-service/src/traits.rs
@@ -119,7 +119,7 @@ pub trait LedgerService<N: Network>: std::fmt::Debug + Send + Sync {
     fn get_committee_lookback_for_round(&self, round: u64) -> Result<Committee<N>>;
 
     /// Returns the deterministic hotswapped dev committee for the given round, if active.
-    #[cfg(feature = "test_network")]
+    #[cfg(feature = "devnet")]
     fn dev_committee_for_round(&self, _round: u64) -> Result<Option<Committee<N>>> {
         Ok(None)
     }

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -627,7 +627,7 @@ impl<N: Network> proposal_task::BatchPropose for Primary<N> {
             if previous_committee_lookback.is_quorum_threshold_reached(&authors) {
                 is_ready = true;
             }
-            #[cfg(feature = "test_network")]
+            #[cfg(feature = "devnet")]
             {
                 // If we are using a hotswapped dev committee, use simplified checks to more easily advance.
                 if let Some(dev_committee) = self.ledger.dev_committee_for_round(previous_round)? {

--- a/node/consensus/Cargo.toml
+++ b/node/consensus/Cargo.toml
@@ -34,7 +34,7 @@ serial = [
   "snarkos-node-metrics/serial",
   "snarkvm/serial"
 ]
-test_network = [ ]
+devnet = [ ]
 
 [dependencies.aleo-std]
 workspace = true

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -595,7 +595,7 @@ impl<N: Network> Consensus<N> {
 
         let check_instant = std::time::Instant::now();
         cfg_if! {
-            if #[cfg(feature = "test_network")] {
+            if #[cfg(feature = "devnet")] {
                 // If we are using a hotswapped dev committee, skip checking the block.
                 let result = if self.ledger.dev_committee_for_round(block.round())?.is_some() {
                     Ok(block)

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -93,8 +93,8 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
         dev_txs: bool,
         dev: Option<u16>,
         _slipstream_configs: &[std::path::PathBuf],
-        #[cfg(feature = "test_network")] dev_num_validators_for_committee_hotswap: Option<u16>,
-        #[cfg(not(feature = "test_network"))] _dev_num_validators_for_committee_hotswap: Option<u16>,
+        #[cfg(feature = "devnet")] dev_num_validators_for_committee_hotswap: Option<u16>,
+        #[cfg(not(feature = "devnet"))] _dev_num_validators_for_committee_hotswap: Option<u16>,
         signal_handler: Arc<SignalHandler>,
     ) -> Result<Self> {
         // Initialize the ledger.
@@ -118,9 +118,9 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
         }
 
         // Initialize the ledger service.
-        #[cfg(not(feature = "test_network"))]
+        #[cfg(not(feature = "devnet"))]
         let ledger_service = Arc::new(CoreLedgerService::new(ledger.clone(), signal_handler.clone()));
-        #[cfg(feature = "test_network")]
+        #[cfg(feature = "devnet")]
         // Initialize the ledger service with a deterministic dev committee.
         let ledger_service = if let Some(dev_num_validators) = dev_num_validators_for_committee_hotswap {
             Arc::new(CoreLedgerService::new_dev(

--- a/scripts/chaotic-network-runner.sh
+++ b/scripts/chaotic-network-runner.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # ==========================================
 # CONFIGURATION

--- a/scripts/delay-network.sh
+++ b/scripts/delay-network.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Set strict mode and IFS to catch unset vars, pipeline failures and whitespace issues.
 set -euo pipefail

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -37,8 +37,8 @@ if [[ $build_binary == "y" ]]; then
   enable_telemetry=${enable_telemetry:-y}
 
   # Ask the user for additional crate features (comma-separated)
-  read -p "Enter crate features to enable (comma separated, default: test_network): " crate_features
-  crate_features=${crate_features:-test_network}
+  read -p "Enter crate features to enable (comma separated, default: devnet): " crate_features
+  crate_features=${crate_features:-devnet}
 
   # Build command
   build_cmd="cargo install --locked --path ."

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ -n "$TMUX" ]]; then
   echo "Detected nested tmux session. Try again after unsetting \$TMUX, e.g., using \`unset TMUX\` in bash."
@@ -6,23 +6,23 @@ if [[ -n "$TMUX" ]]; then
 fi
 
 # Read the total number of validators from the user or use a default value of 4
-read -p "Enter the total number of validators (default: 4): " total_validators
+read -r -p "Enter the total number of validators (default: 4): " total_validators
 total_validators=${total_validators:-4}
 
 # Read the total number of clients from the user or use a default value of 2
-read -p "Enter the total number of clients (default: 2): " total_clients
+read -r -p "Enter the total number of clients (default: 2): " total_clients
 total_clients=${total_clients:-2}
 
 # Read the network ID from user or use a default value of 1
-read -p "Enter the network ID (mainnet = 0, testnet = 1, canary = 2) (default: 1): " network_id
+read -r -p "Enter the network ID (mainnet = 0, testnet = 1, canary = 2) (default: 1): " network_id
 network_id=${network_id:-1}
 
 # Ask the user if they want to run 'cargo install --locked --path .' or use a pre-installed binary
-read -p "Do you want to run 'cargo install --locked --path .' to build the binary? (y/n, default: y): " build_binary
+read -r -p "Do you want to run 'cargo install --locked --path .' to build the binary? (y/n, default: y): " build_binary
 build_binary=${build_binary:-y}
 
 # Ask the user whether to clear the existing ledger history
-read -p "Do you want to clear the existing ledger history? (y/n, default: n): " clear_ledger
+read -r -p "Do you want to clear the existing ledger history? (y/n, default: n): " clear_ledger
 clear_ledger=${clear_ledger:-n}
 
 # Log verbosity is set to 1 (DEBUG) by default.
@@ -33,11 +33,11 @@ binary_path=""
 
 if [[ $build_binary == "y" ]]; then
   # Ask the user if they want to enable validator telemetry
-  read -p "Do you want to enable validator telemetry? (y/n, default: y): " enable_telemetry
+  read -r -p "Do you want to enable validator telemetry? (y/n, default: y): " enable_telemetry
   enable_telemetry=${enable_telemetry:-y}
 
   # Ask the user for additional crate features (comma-separated)
-  read -p "Enter crate features to enable (comma separated, default: devnet): " crate_features
+  read -r -p "Enter crate features to enable (comma separated, default: devnet): " crate_features
   crate_features=${crate_features:-devnet}
 
   # Build command
@@ -63,7 +63,7 @@ if [[ $build_binary == "y" ]]; then
   eval "$build_cmd" || exit 1
 else
   # Ask the user whether to use a custom relative path
-  read -p "Do you want to run snarkos from a relative path? (e.g. ./target/debug/, defaults to the installed binary): " binary_path
+  read -r -p "Do you want to run snarkos from a relative path? (e.g. ./target/debug/, defaults to the installed binary): " binary_path
   binary_path=${binary_path:-""}
 fi
 
@@ -91,8 +91,7 @@ log_dir=".logs-$(date +"%Y%m%d%H%M%S")"
 mkdir -p "$log_dir"
 
 # Create a new tmux session named "devnet"
-tmux new-session -d -s "devnet" -n "validator-0"
-if [[ $? -ne 0 ]]; then
+if ! tmux new-session -d -s "devnet" -n "validator-0"; then
   echo "Failed to create new TMUX session."
   exit 1
 fi
@@ -105,6 +104,8 @@ if [ -z "$index_offset" ]; then
 fi
 
 # Generate validator indices from 0 to (total_validators - 1)
+# (mapfile would be cleaner but is unavailable on the bash 3.2 shipped with macOS)
+# shellcheck disable=SC2207
 validator_indices=($(seq 0 $((total_validators - 1))))
 
 # Loop through the list of validator indices and create a new window for each
@@ -117,7 +118,7 @@ for validator_index in "${validator_indices[@]}"; do
 
   if [ "$validator_index" -ne 0 ]; then
     # We don't need to create a window for the first validator because the tmux session already starts with one window.
-    tmux new-window -t "devnet:$window_index" -n $name
+    tmux new-window -t "devnet:$window_index" -n "$name"
   fi
 
   # Send the command to start the validator to the new window and capture output to the log file
@@ -126,6 +127,7 @@ done
 
 if [ "$total_clients" -ne 0 ]; then
   # Generate client indices from 0 to (total_clients - 1)
+  # shellcheck disable=SC2207
   client_indices=($(seq 0 $((total_clients - 1))))
 
   # Loop through the list of client indices and create a new window for each
@@ -137,7 +139,7 @@ if [ "$total_clients" -ne 0 ]; then
     window_index=$((client_index + total_validators + index_offset))
 
     # Create a new window with a unique name
-    tmux new-window -t "devnet:$window_index" -n $name
+    tmux new-window -t "devnet:$window_index" -n "$name"
 
     # Send the command to start the client to the new window and capture output to the log file
     tmux send-keys -t "devnet:$window_index" "${binary_path}snarkos start --nodisplay --network $network_id --dev $window_index --dev-num-validators $total_validators --client --logfile $log_file  --verbosity $verbosity" C-m

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Runs the same lints as CI: clippy, rustfmt, and shellcheck.
+# Invoked by the rusty-hook pre-commit hook (see .rusty-hook.toml).
+
+set -e
+
+echo "Running clippy..."
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+echo "Checking rustfmt..."
+cargo +nightly fmt --all -- --check
+
+if command -v shellcheck >/dev/null; then
+  echo "Running shellcheck..."
+  shellcheck -x .ci/*.sh scripts/*.sh
+else
+  echo "warning: shellcheck not installed, skipping script lint (CI will still run it)"
+fi

--- a/scripts/run-core-client.sh
+++ b/scripts/run-core-client.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# USAGE examples: 
-  # CLI with env vars: PEERS=“validator_ip:4130,core_client_ip_1:4130,core_client_ip_2:4130,core_client_ip_3:4130,outer_client_ip_1:4130,... ./run-core-client.sh
+# USAGE examples:
+  # CLI with env vars: PEERS="validator_ip:4130,core_client_ip_1:4130,core_client_ip_2:4130,core_client_ip_3:4130,outer_client_ip_1:4130,..." ./run-core-client.sh
   # CLI with prompts for vars:  ./run-core-client.sh
 
 # If the env var PEERS is not set, prompt for it
 if [ -z "${PEERS}" ]
 then
-  read -r -p "Enter the peers (comma-separated) (e.g., “validator_ip:4130,core_client_ip_1:4130,core_client_ip_2:4130,core_client_ip_3:4130,outer_client_ip_1:4130,...): "
+  read -r -p "Enter the peers (comma-separated) (e.g., \"validator_ip:4130,core_client_ip_1:4130,core_client_ip_2:4130,core_client_ip_3:4130,outer_client_ip_1:4130,...\"): "
   PEERS=$REPLY
 fi
 
@@ -17,9 +17,9 @@ then
   exit 1
 fi
 
-COMMAND='cargo run --release -- start --nodisplay --client --node 0.0.0.0:4130 --peers ${PEERS} --verbosity 1 --norest'
+COMMAND="cargo run --release -- start --nodisplay --client --node 0.0.0.0:4130 --peers ${PEERS} --verbosity 1 --norest"
 
-for word in $*;
+for word in "$@";
 do
   COMMAND="${COMMAND} ${word}"
 done

--- a/scripts/run-outer-client.sh
+++ b/scripts/run-outer-client.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # USAGE examples: 
   # CLI with env vars: PEERS=core_client_ip_1:4130,core_client_ip_2:4130,core_client_ip_3:4130,outer_client_ip_1:4130,... ./run-outer-client.sh
@@ -17,7 +17,7 @@ else
   COMMAND="cargo run --release -- start --nodisplay --client --node 0.0.0.0:4130 --peers ${PEERS} --verbosity 1 --rest 0.0.0.0:3030"
 fi
 
-for word in $*;
+for word in "$@";
 do
   COMMAND="${COMMAND} ${word}"
 done

--- a/scripts/run-prover.sh
+++ b/scripts/run-prover.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # USAGE examples:
   # CLI with env vars: PROVER_PRIVATE_KEY=APrivateKey1...  ./run-prover.sh
   # CLI with prompts for vars:  ./run-prover.sh

--- a/scripts/run-validator.sh
+++ b/scripts/run-validator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # USAGE examples:
   # CLI with env vars: VALIDATOR_PRIVATE_KEY=APrivateKey1... PEERS=core_client_ip_1:4130,core_client_ip_2:4130,... VALIDATORS=validator_ip_1:5000,validator_ip_2:5000,... ./run-validator.sh
   # CLI with prompts for vars:  ./run-validator.sh
@@ -43,7 +43,7 @@ then
 fi
 
 # Ask the user if they want to enable validator telemetry
-read -p "Do you want to enable validator telemetry? (y/n, default: y): " enable_telemetry
+read -r -p "Do you want to enable validator telemetry? (y/n, default: y): " enable_telemetry
 enable_telemetry=${enable_telemetry:-y}
 
 # Start building the base command
@@ -57,7 +57,7 @@ fi
 # Add the arguments after the '--'
 COMMAND+=" -- start --nodisplay --validator --bft 0.0.0.0:5000 --node 0.0.0.0:4130 --peers ${PEERS} --validators ${VALIDATORS} --norest --private-key ${VALIDATOR_PRIVATE_KEY}"
 
-for word in $*;
+for word in "$@";
 do
   COMMAND="${COMMAND} ${word}"
 done

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -17,7 +17,7 @@ license = "Apache-2.0"
 edition = "2024"
 
 [features]
-test_network = [ ]
+devnet = [ ]
 
 [dependencies.anyhow]
 workspace = true

--- a/utilities/src/node_data.rs
+++ b/utilities/src/node_data.rs
@@ -29,7 +29,7 @@ pub const LEGACY_ROUTER_PEER_CACHE_FILE: &str = "cached_router_peers";
 pub const CURRENT_PROPOSAL_CACHE_FILE: &str = "current-proposal-cache";
 
 /// The filename used to persist the hotswapped dev committee's starting round.
-#[cfg(feature = "test_network")]
+#[cfg(feature = "devnet")]
 pub const DEV_COMMITTEE_STATE_FILE: &str = "dev-committee-state";
 
 /// The filename of the JWT secret for a given address.
@@ -97,7 +97,7 @@ impl NodeDataDir {
     }
 
     /// The location used to persist the hotswapped dev committee's starting round.
-    #[cfg(feature = "test_network")]
+    #[cfg(feature = "devnet")]
     pub fn dev_committee_state_path(&self) -> PathBuf {
         self.path.join(DEV_COMMITTEE_STATE_FILE)
     }


### PR DESCRIPTION
The PR also enables lints for all files in `./scripts` and fixes any remaining warnings with the devnet scripts. 