### PR TITLE
[Logs] Enhance low-level connection spans

### DIFF
--- a/node/tcp/src/helpers/connections.rs
+++ b/node/tcp/src/helpers/connections.rs
@@ -27,6 +27,7 @@ use tokio::{
     sync::oneshot,
     task::JoinHandle,
 };
+use tracing::*;
 
 #[cfg(doc)]
 use crate::protocols::{Handshake, Reading, Writing};
@@ -89,11 +90,13 @@ pub struct Connection {
     pub(crate) disconnecting: AtomicBool,
     /// Handles to tasks spawned for the connection.
     pub(crate) tasks: Vec<JoinHandle<()>>,
+    /// The tracing span.
+    pub(crate) span: Span,
 }
 
 impl Connection {
     /// Creates a [`Connection`] with placeholders for protocol-related objects.
-    pub(crate) fn new(addr: SocketAddr, stream: TcpStream, side: ConnectionSide) -> Self {
+    pub(crate) fn new(addr: SocketAddr, stream: TcpStream, side: ConnectionSide, span: Span) -> Self {
         Self {
             addr,
             stream: Some(stream),
@@ -103,6 +106,7 @@ impl Connection {
             disconnecting: Default::default(),
             side,
             tasks: Default::default(),
+            span,
         }
     }
 
@@ -115,6 +119,12 @@ impl Connection {
     /// and `ConnectionSide::Responder` if the connection request was initiated by Tcp.
     pub fn side(&self) -> ConnectionSide {
         self.side
+    }
+
+    /// Returns the tracing [`Span`] associated with the connection.
+    #[inline]
+    pub const fn span(&self) -> &Span {
+        &self.span
     }
 }
 
@@ -144,4 +154,20 @@ impl Drop for Connection {
             task.abort();
         }
     }
+}
+
+pub(crate) fn create_connection_span(addr: SocketAddr, parent: &Span) -> Span {
+    macro_rules! try_span {
+        ($lvl:expr) => {
+            let s = span!(parent: parent, $lvl, "conn", addr = %addr);
+            if !s.is_disabled() {
+                return s;
+            }
+        };
+    }
+    try_span!(Level::TRACE);
+    try_span!(Level::DEBUG);
+    try_span!(Level::INFO);
+    try_span!(Level::WARN);
+    error_span!(parent: parent, "conn", addr = %addr)
 }

--- a/node/tcp/src/protocols/disconnect.rs
+++ b/node/tcp/src/protocols/disconnect.rs
@@ -24,7 +24,7 @@ use tracing::*;
 
 #[cfg(doc)]
 use crate::{Connection, protocols::Writing};
-use crate::{P2P, protocols::ProtocolHandler};
+use crate::{P2P, connections::create_connection_span, protocols::ProtocolHandler};
 
 /// Can be used to automatically perform some extra actions when the node disconnects from its
 /// peer, which is especially practical if the disconnect is triggered automatically, e.g. due
@@ -64,7 +64,8 @@ where
                 let handle = tokio::spawn(async move {
                     // perform the specified extra actions
                     if timeout(Self::TIMEOUT, self_clone2.handle_disconnect(peer_addr)).await.is_err() {
-                        warn!(parent: self_clone2.tcp().span(), "Disconnect logic timed out for {peer_addr}");
+                        let conn_span = create_connection_span(peer_addr, self_clone2.tcp().span());
+                        warn!(parent: conn_span, "Disconnect logic timed out");
                     }
                     // notify the node that the extra actions have concluded
                     // and that the related connection can be dropped

--- a/node/tcp/src/protocols/handshake.rs
+++ b/node/tcp/src/protocols/handshake.rs
@@ -58,24 +58,24 @@ where
             tx.send(()).unwrap(); // safe; the channel was just opened
 
             while let Some((conn, result_sender)) = from_node_receiver.recv().await {
-                let addr = conn.addr();
+                let conn_span = conn.span().clone();
 
                 let node = self_clone.clone();
                 tokio::spawn(async move {
-                    debug!(parent: node.tcp().span(), "shaking hands with {} as the {:?}", addr, !conn.side());
+                    debug!(parent: &conn_span, "shaking hands as the {:?}", !conn.side());
                     let result = timeout(Duration::from_millis(Self::TIMEOUT_MS), node.perform_handshake(conn)).await;
 
                     let ret: io::Result<_> = match result {
                         Ok(Ok(conn)) => {
-                            debug!(parent: node.tcp().span(), "successfully handshaken with {addr}");
+                            debug!(parent: &conn_span, "successfully handshaken");
                             Ok(conn)
                         }
                         Ok(Err(err)) => {
-                            debug!(parent: node.tcp().span(), "handshake with {addr} failed: {err}");
+                            debug!(parent: &conn_span, "handshake failed: {err}");
                             Err(err.into())
                         }
                         Err(_) => {
-                            debug!(parent: node.tcp().span(), "handshake with {addr} timed out");
+                            debug!(parent: &conn_span, "handshake timed out");
                             Err(io::ErrorKind::TimedOut.into())
                         }
                     };

--- a/node/tcp/src/protocols/reading.rs
+++ b/node/tcp/src/protocols/reading.rs
@@ -16,6 +16,7 @@
 #[cfg(doc)]
 use crate::{Config, protocols::Handshake};
 use crate::{
+    Connection,
     ConnectionSide,
     P2P,
     Tcp,
@@ -118,7 +119,7 @@ trait ReadingInternal: Reading {
     fn map_codec<T: AsyncRead>(
         &self,
         framed: FramedRead<T, Self::Codec>,
-        addr: SocketAddr,
+        conn: &Connection,
     ) -> FramedRead<T, CountingCodec<Self::Codec>>;
 }
 
@@ -129,7 +130,7 @@ impl<R: Reading> ReadingInternal for R {
         let codec = self.codec(addr, !conn.side());
         let reader = conn.reader.take().expect("missing connection reader!");
         let framed = FramedRead::new(reader, codec);
-        let mut framed = self.map_codec(framed, addr);
+        let mut framed = self.map_codec(framed, &conn);
 
         // the connection will notify the reading task once it's fully ready
         let (tx_conn_ready, rx_conn_ready) = oneshot::channel();
@@ -147,14 +148,15 @@ impl<R: Reading> ReadingInternal for R {
 
         // the task for processing parsed messages
         let self_clone = self.clone();
+        let conn_span = conn.span().clone();
         let inbound_processing_task = tokio::spawn(Box::pin(async move {
             let node = self_clone.tcp();
-            trace!(parent: node.span(), "spawned a task for processing messages from {addr}");
+            trace!(parent: &conn_span, "spawned a task for processing messages");
             tx_processing.send(()).unwrap(); // safe; the channel was just opened
 
             while let Some((msg, _guard)) = inbound_message_receiver.recv().await {
                 if let Err(e) = self_clone.process_message(addr, msg).await {
-                    error!(parent: node.span(), "can't process a message from {addr}: {e}");
+                    error!(parent: &conn_span, "can't process a message: {e}");
                     node.known_peers().register_failure(addr.ip());
                 }
                 // _guard drops here, after process_message completes
@@ -168,8 +170,9 @@ impl<R: Reading> ReadingInternal for R {
 
         // the task for reading messages from a stream
         let node = self.tcp().clone();
+        let conn_span = conn.span().clone();
         let reader_task = tokio::spawn(Box::pin(async move {
-            trace!(parent: node.span(), "spawned a task for reading messages from {addr}");
+            trace!(parent: &conn_span, "spawned a task for reading messages");
             tx_reader.send(()).unwrap(); // safe; the channel was just opened
 
             // postpone reads until the connection is fully established; if the process fails,
@@ -185,7 +188,7 @@ impl<R: Reading> ReadingInternal for R {
                 let read_result = match timeout(Self::IDLE_TIMEOUT, next_frame_future).await {
                     Ok(res) => res, // IO completed (success or error)
                     Err(_) => {
-                        debug!(parent: node.span(), "connection with {addr} timed out due to inactivity");
+                        debug!(parent: &conn_span, "connection timed out due to inactivity");
                         break;
                     }
                 };
@@ -199,26 +202,21 @@ impl<R: Reading> ReadingInternal for R {
                                     // avoid log flooding
                                     dropped_count += 1;
                                     if last_drop_log.elapsed() >= Duration::from_secs(1) {
-                                        warn_about_dropped_messages(
-                                            &node,
-                                            addr,
-                                            &mut dropped_count,
-                                            &mut last_drop_log,
-                                        );
+                                        warn_about_dropped_messages(&conn_span, &mut dropped_count, &mut last_drop_log);
                                     }
                                 }
                                 mpsc::error::TrySendError::Closed(_) => {
-                                    error!(parent: node.span(), "inbound channel closed for {addr}");
+                                    error!(parent: &conn_span, "inbound channel closed");
                                     break;
                                 }
                             }
                         } else if dropped_count != 0 {
-                            warn_about_dropped_messages(&node, addr, &mut dropped_count, &mut last_drop_log);
-                            debug!(parent: node.span(), "the inbound queue for {addr} is no longer saturated");
+                            warn_about_dropped_messages(&conn_span, &mut dropped_count, &mut last_drop_log);
+                            debug!(parent: &conn_span, "the inbound queue is no longer saturated");
                         }
                     }
                     Some(Err(e)) => {
-                        error!(parent: node.span(), "can't read from {addr}: {e}");
+                        error!(parent: &conn_span, "can't read: {e}");
                         node.known_peers().register_failure(addr.ip());
                         if node.config().fatal_io_errors.contains(&e.kind()) {
                             break;
@@ -242,9 +240,9 @@ impl<R: Reading> ReadingInternal for R {
     fn map_codec<T: AsyncRead>(
         &self,
         framed: FramedRead<T, Self::Codec>,
-        addr: SocketAddr,
+        conn: &Connection,
     ) -> FramedRead<T, CountingCodec<Self::Codec>> {
-        framed.map_decoder(|codec| CountingCodec { codec, node: self.tcp().clone(), addr, acc: 0 })
+        framed.map_decoder(|codec| CountingCodec { codec, node: self.tcp().clone(), acc: 0, span: conn.span().clone() })
     }
 }
 
@@ -252,8 +250,8 @@ impl<R: Reading> ReadingInternal for R {
 struct CountingCodec<D: Decoder> {
     codec: D,
     node: Tcp,
-    addr: SocketAddr,
     acc: usize,
+    span: Span,
 }
 
 impl<D: Decoder> Decoder for CountingCodec<D> {
@@ -267,11 +265,11 @@ impl<D: Decoder> Decoder for CountingCodec<D> {
         let read_len = initial_buf_len - final_buf_len + self.acc;
 
         if read_len != 0 {
-            trace!(parent: self.node.span(), "read {}B from {}", read_len, self.addr);
+            trace!(parent: &self.span, "read {read_len}B");
 
             if ret.is_some() {
                 self.acc = 0;
-                self.node.known_peers().register_received_message(self.addr.ip(), read_len);
+                // self.node.known_peers().register_received_message(self.addr.ip(), read_len);
                 self.node.stats().register_received_message(read_len);
             } else {
                 self.acc = read_len;
@@ -304,10 +302,10 @@ impl Drop for QueuedMessageGuard {
 }
 
 /// Warns that some messages were dropped and resets the related counters.
-fn warn_about_dropped_messages(node: &Tcp, addr: SocketAddr, dropped_count: &mut usize, last_drop_log: &mut Instant) {
+fn warn_about_dropped_messages(span: &Span, dropped_count: &mut usize, last_drop_log: &mut Instant) {
     warn!(
-        parent: node.span(),
-        "dropped {dropped_count} messages from {addr} due\
+        parent: span,
+        "dropped {dropped_count} messages due\
         to inbound queue saturation",
     );
     // reset counters

--- a/node/tcp/src/protocols/writing.rs
+++ b/node/tcp/src/protocols/writing.rs
@@ -35,6 +35,7 @@ use crate::{
     Connection,
     ConnectionSide,
     P2P,
+    connections::create_connection_span,
     protocols::{Protocol, ProtocolHandler, ReturnableConnection},
 };
 
@@ -122,7 +123,8 @@ where
                 sender
                     .try_send(msg)
                     .map_err(|e| {
-                        error!(parent: self.tcp().span(), "can't send a message to {}: {}", addr, e);
+                        let conn_span = create_connection_span(addr, self.tcp().span());
+                        error!(parent: conn_span, "can't send a message: {e}");
                         self.tcp().stats().register_failure();
                         io::ErrorKind::Other.into()
                     })
@@ -153,7 +155,8 @@ where
             for (addr, message_sender) in senders {
                 let (msg, _delivery) = WrappedMessage::new(Box::new(message.clone()));
                 let _ = message_sender.try_send(msg).map_err(|e| {
-                    error!(parent: self.tcp().span(), "can't send a message to {}: {}", addr, e);
+                    let conn_span = create_connection_span(addr, self.tcp().span());
+                    error!(parent: conn_span, "can't send a message: {e}");
                     self.tcp().stats().register_failure();
                 });
             }
@@ -219,9 +222,10 @@ impl<W: Writing> WritingInternal for W {
 
         // the task for writing outbound messages
         let self_clone = self.clone();
+        let conn_span = conn.span().clone();
         let writer_task = tokio::spawn(Box::pin(async move {
             let node = self_clone.tcp();
-            trace!(parent: node.span(), "spawned a task for writing messages to {}", addr);
+            trace!(parent: &conn_span, "spawned a task for writing messages");
             tx_writer.send(()).unwrap(); // safe; the channel was just opened
 
             // move the cleanup into the task that gets aborted on disconnect
@@ -233,13 +237,13 @@ impl<W: Writing> WritingInternal for W {
                 match self_clone.write_to_stream(*msg, &mut framed).await {
                     Ok(len) => {
                         let _ = wrapped_msg.delivery_notification.send(Ok(()));
-                        node.known_peers().register_sent_message(addr.ip(), len);
+                        // node.known_peers().register_sent_message(addr.ip(), len);
                         node.stats().register_sent_message(len);
-                        trace!(parent: node.span(), "sent {}B to {}", len, addr);
+                        trace!(parent: &conn_span, "sent {len}B");
                     }
                     Err(e) => {
                         node.known_peers().register_failure(addr.ip());
-                        error!(parent: node.span(), "couldn't send a message to {}: {}", addr, e);
+                        error!(parent: &conn_span, "couldn't send a message: {e}");
                         let is_fatal = node.config().fatal_io_errors.contains(&e.kind());
                         let _ = wrapped_msg.delivery_notification.send(Err(e));
                         if is_fatal {

--- a/node/tcp/src/tcp.rs
+++ b/node/tcp/src/tcp.rs
@@ -46,7 +46,7 @@ use crate::{
     Config,
     KnownPeers,
     Stats,
-    connections::{Connection, ConnectionSide, Connections},
+    connections::{Connection, ConnectionSide, Connections, create_connection_span},
     protocols::{Protocol, Protocols},
 };
 
@@ -553,7 +553,8 @@ impl Tcp {
             }
         }
 
-        let connection = Connection::new(peer_addr, stream, !own_side);
+        let conn_span = create_connection_span(peer_addr, self.span());
+        let connection = Connection::new(peer_addr, stream, !own_side, conn_span);
 
         // Enact the enabled protocols.
         let mut connection = self.enable_protocols(connection).await?;
@@ -742,7 +743,7 @@ mod tests {
 
         // Simulate an active connection.
         let stream = TcpStream::connect(peer_ip).await.unwrap();
-        tcp.connections.add(Connection::new(peer_ip, stream, ConnectionSide::Initiator));
+        tcp.connections.add(Connection::new(peer_ip, stream, ConnectionSide::Initiator, Span::none()));
         assert!(!tcp.can_add_connection());
 
         // Ensure that we cannot invoke connect() successfully in this case.
@@ -770,7 +771,7 @@ mod tests {
 
         // Simulate an active and a pending connection (this case should never occur).
         let stream = TcpStream::connect(peer_ip).await.unwrap();
-        tcp.connections.add(Connection::new(peer_ip, stream, ConnectionSide::Responder));
+        tcp.connections.add(Connection::new(peer_ip, stream, ConnectionSide::Responder, Span::none()));
         tcp.connecting.lock().insert(peer_ip);
         assert!(!tcp.can_add_connection());
 
@@ -799,7 +800,7 @@ mod tests {
 
         // Simulate an active connection.
         let stream = TcpStream::connect(peer1_ip).await.unwrap();
-        tcp.connections.add(Connection::new(peer1_ip, stream, ConnectionSide::Responder));
+        tcp.connections.add(Connection::new(peer1_ip, stream, ConnectionSide::Responder, Span::none()));
         assert!(!tcp.can_add_connection());
         assert_eq!(tcp.num_connected(), 1);
         assert_eq!(tcp.num_connecting(), 0);


### PR DESCRIPTION
This PR enhances the low-level network logs with structured spans in order to simplify structure, reading, filtering, etc.

These logs require a high degree of verbosity, so these changes are mostly aimed at developers and their debugging experience.

before:
```
TRACE tcp{name="0"}: snarkos_node_tcp::protocols::writing: sent 55B to 127.0.0.1:5000
```

after:
```
TRACE tcp{name="0"}:conn{addr=127.0.0.1:5000}: snarkos_node_tcp::protocols::writing: sent 55B
```