### PR TITLE
[Feat] Log disconnect origin

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1379,6 +1379,8 @@ impl<N: Network> Writing for Gateway<N> {
 impl<N: Network> Disconnect for Gateway<N> {
     /// Any extra operations to be performed during a disconnect.
     async fn handle_disconnect(&self, peer_addr: SocketAddr, origin: DisconnectOrigin) {
+        debug!("Psysically disconnecting from {peer_addr}; origin: {origin:?}");
+
         if let Some(peer_ip) = self.resolve_to_listener(&peer_addr) {
             // TODO(kaimast): This can, in theory, still lead to race conditions, if we immediately reconnect to the same peer.
             // In practice, there should always be a significant delay between those two delays, so it is not an immediate issue.

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -61,6 +61,7 @@ use snarkos_node_tcp::{
     ConnectionSide,
     P2P,
     Tcp,
+    connections::DisconnectOrigin,
     protocols::{Disconnect, Handshake, OnConnect, Reading, Writing},
 };
 use snarkos_utilities::NodeDataDir;
@@ -1377,7 +1378,7 @@ impl<N: Network> Writing for Gateway<N> {
 #[async_trait]
 impl<N: Network> Disconnect for Gateway<N> {
     /// Any extra operations to be performed during a disconnect.
-    async fn handle_disconnect(&self, peer_addr: SocketAddr) {
+    async fn handle_disconnect(&self, peer_addr: SocketAddr, origin: DisconnectOrigin) {
         if let Some(peer_ip) = self.resolve_to_listener(&peer_addr) {
             // TODO(kaimast): This can, in theory, still lead to race conditions, if we immediately reconnect to the same peer.
             // In practice, there should always be a significant delay between those two delays, so it is not an immediate issue.

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1379,7 +1379,7 @@ impl<N: Network> Writing for Gateway<N> {
 impl<N: Network> Disconnect for Gateway<N> {
     /// Any extra operations to be performed during a disconnect.
     async fn handle_disconnect(&self, peer_addr: SocketAddr, origin: DisconnectOrigin) {
-        debug!("Psysically disconnecting from {peer_addr}; origin: {origin:?}");
+        debug!("Physically disconnecting from {peer_addr}; origin: {origin:?}");
 
         if let Some(peer_ip) = self.resolve_to_listener(&peer_addr) {
             // TODO(kaimast): This can, in theory, still lead to race conditions, if we immediately reconnect to the same peer.

--- a/node/router/tests/common/router.rs
+++ b/node/router/tests/common/router.rs
@@ -38,6 +38,7 @@ use snarkos_node_tcp::{
     ConnectionSide,
     P2P,
     Tcp,
+    connections::DisconnectOrigin,
     protocols::{Disconnect, Handshake, OnConnect, Reading, Writing},
 };
 use snarkvm::{
@@ -133,7 +134,7 @@ impl<N: Network> OnConnect for TestRouter<N> {
 #[async_trait]
 impl<N: Network> Disconnect for TestRouter<N> {
     /// Any extra operations to be performed during a disconnect.
-    async fn handle_disconnect(&self, peer_addr: SocketAddr) {
+    async fn handle_disconnect(&self, peer_addr: SocketAddr, _origin: DisconnectOrigin) {
         if let Some(peer_ip) = self.router().resolve_to_listener(peer_addr) {
             self.router().downgrade_peer_to_candidate(peer_ip);
         }

--- a/node/src/bootstrap_client/network.rs
+++ b/node/src/bootstrap_client/network.rs
@@ -102,7 +102,7 @@ impl<N: Network> OnConnect for BootstrapClient<N> {
 impl<N: Network> Disconnect for BootstrapClient<N> {
     /// Any extra operations to be performed during a disconnect.
     async fn handle_disconnect(&self, peer_addr: SocketAddr, origin: DisconnectOrigin) {
-        debug!("Psysically disconnecting from {peer_addr}; origin: {origin:?}");
+        debug!("Physically disconnecting from {peer_addr}; origin: {origin:?}");
 
         if let Some(listener_addr) = self.resolve_to_listener(peer_addr) {
             self.downgrade_peer_to_candidate(listener_addr);

--- a/node/src/bootstrap_client/network.rs
+++ b/node/src/bootstrap_client/network.rs
@@ -25,7 +25,7 @@ use crate::{
         MAX_PEERS_TO_SEND,
         messages::{self, Message},
     },
-    tcp::{ConnectionSide, P2P, Tcp, protocols::*},
+    tcp::{ConnectionSide, P2P, Tcp, connections::DisconnectOrigin, protocols::*},
 };
 use snarkvm::prelude::Network;
 
@@ -101,7 +101,7 @@ impl<N: Network> OnConnect for BootstrapClient<N> {
 #[async_trait]
 impl<N: Network> Disconnect for BootstrapClient<N> {
     /// Any extra operations to be performed during a disconnect.
-    async fn handle_disconnect(&self, peer_addr: SocketAddr) {
+    async fn handle_disconnect(&self, peer_addr: SocketAddr, origin: DisconnectOrigin) {
         if let Some(listener_addr) = self.resolve_to_listener(peer_addr) {
             self.downgrade_peer_to_candidate(listener_addr);
         }

--- a/node/src/bootstrap_client/network.rs
+++ b/node/src/bootstrap_client/network.rs
@@ -102,6 +102,8 @@ impl<N: Network> OnConnect for BootstrapClient<N> {
 impl<N: Network> Disconnect for BootstrapClient<N> {
     /// Any extra operations to be performed during a disconnect.
     async fn handle_disconnect(&self, peer_addr: SocketAddr, origin: DisconnectOrigin) {
+        debug!("Psysically disconnecting from {peer_addr}; origin: {origin:?}");
+
         if let Some(listener_addr) = self.resolve_to_listener(peer_addr) {
             self.downgrade_peer_to_candidate(listener_addr);
         }

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -87,7 +87,7 @@ impl<N: Network, C: ConsensusStorage<N>> OnConnect for Client<N, C> {
 impl<N: Network, C: ConsensusStorage<N>> Disconnect for Client<N, C> {
     /// Any extra operations to be performed during a disconnect.
     async fn handle_disconnect(&self, peer_addr: SocketAddr, origin: DisconnectOrigin) {
-        debug!("Psysically disconnecting from {peer_addr}; origin: {origin:?}");
+        debug!("Physically disconnecting from {peer_addr}; origin: {origin:?}");
 
         if let Some(peer_ip) = self.router.resolve_to_listener(peer_addr) {
             let was_fully_connected = self.router.downgrade_peer_to_candidate(peer_ip);

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -30,7 +30,7 @@ use snarkos_node_router::{
         UnconfirmedTransaction,
     },
 };
-use snarkos_node_tcp::{ConnectError, Connection, ConnectionSide, Tcp};
+use snarkos_node_tcp::{ConnectError, Connection, ConnectionSide, Tcp, connections::DisconnectOrigin};
 use snarkvm::{
     console::network::{ConsensusVersion, Network},
     ledger::{block::Transaction, narwhal::Data},
@@ -86,7 +86,7 @@ impl<N: Network, C: ConsensusStorage<N>> OnConnect for Client<N, C> {
 #[async_trait]
 impl<N: Network, C: ConsensusStorage<N>> Disconnect for Client<N, C> {
     /// Any extra operations to be performed during a disconnect.
-    async fn handle_disconnect(&self, peer_addr: SocketAddr) {
+    async fn handle_disconnect(&self, peer_addr: SocketAddr, origin: DisconnectOrigin) {
         if let Some(peer_ip) = self.router.resolve_to_listener(peer_addr) {
             let was_fully_connected = self.router.downgrade_peer_to_candidate(peer_ip);
 

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -87,6 +87,8 @@ impl<N: Network, C: ConsensusStorage<N>> OnConnect for Client<N, C> {
 impl<N: Network, C: ConsensusStorage<N>> Disconnect for Client<N, C> {
     /// Any extra operations to be performed during a disconnect.
     async fn handle_disconnect(&self, peer_addr: SocketAddr, origin: DisconnectOrigin) {
+        debug!("Psysically disconnecting from {peer_addr}; origin: {origin:?}");
+
         if let Some(peer_ip) = self.router.resolve_to_listener(peer_addr) {
             let was_fully_connected = self.router.downgrade_peer_to_candidate(peer_ip);
 

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -86,6 +86,8 @@ where
 impl<N: Network, C: ConsensusStorage<N>> Disconnect for Prover<N, C> {
     /// Any extra operations to be performed during a disconnect.
     async fn handle_disconnect(&self, peer_addr: SocketAddr, origin: DisconnectOrigin) {
+        debug!("Psysically disconnecting from {peer_addr}; origin: {origin:?}");
+
         if let Some(peer_ip) = self.router.resolve_to_listener(peer_addr) {
             let was_fully_connected = self.router.downgrade_peer_to_candidate(peer_ip);
             // Only remove the peer from sync if the handshake was successful.

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -26,7 +26,7 @@ use snarkos_node_router::messages::{
     PuzzleRequest,
     UnconfirmedTransaction,
 };
-use snarkos_node_tcp::{ConnectError, Connection, ConnectionSide, Tcp};
+use snarkos_node_tcp::{ConnectError, Connection, ConnectionSide, Tcp, connections::DisconnectOrigin};
 use snarkvm::{
     console::network::{ConsensusVersion, Network},
     ledger::block::Transaction,
@@ -85,7 +85,7 @@ where
 #[async_trait]
 impl<N: Network, C: ConsensusStorage<N>> Disconnect for Prover<N, C> {
     /// Any extra operations to be performed during a disconnect.
-    async fn handle_disconnect(&self, peer_addr: SocketAddr) {
+    async fn handle_disconnect(&self, peer_addr: SocketAddr, origin: DisconnectOrigin) {
         if let Some(peer_ip) = self.router.resolve_to_listener(peer_addr) {
             let was_fully_connected = self.router.downgrade_peer_to_candidate(peer_ip);
             // Only remove the peer from sync if the handshake was successful.

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -86,7 +86,7 @@ where
 impl<N: Network, C: ConsensusStorage<N>> Disconnect for Prover<N, C> {
     /// Any extra operations to be performed during a disconnect.
     async fn handle_disconnect(&self, peer_addr: SocketAddr, origin: DisconnectOrigin) {
-        debug!("Psysically disconnecting from {peer_addr}; origin: {origin:?}");
+        debug!("Physically disconnecting from {peer_addr}; origin: {origin:?}");
 
         if let Some(peer_ip) = self.router.resolve_to_listener(peer_addr) {
             let was_fully_connected = self.router.downgrade_peer_to_candidate(peer_ip);

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -82,7 +82,7 @@ where
 impl<N: Network, C: ConsensusStorage<N>> Disconnect for Validator<N, C> {
     /// Any extra operations to be performed during a disconnect.
     async fn handle_disconnect(&self, peer_addr: SocketAddr, origin: DisconnectOrigin) {
-        debug!("Psysically disconnecting from {peer_addr}; origin: {origin:?}");
+        debug!("Physically disconnecting from {peer_addr}; origin: {origin:?}");
 
         if let Some(peer_ip) = self.router.resolve_to_listener(peer_addr) {
             self.router.downgrade_peer_to_candidate(peer_ip);

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -26,7 +26,7 @@ use snarkos_node_router::messages::{
     Pong,
     UnconfirmedTransaction,
 };
-use snarkos_node_tcp::{ConnectError, Connection, ConnectionSide, Tcp};
+use snarkos_node_tcp::{ConnectError, Connection, ConnectionSide, Tcp, connections::DisconnectOrigin};
 use snarkvm::{
     console::network::{ConsensusVersion, Network},
     ledger::{block::Transaction, narwhal::Data},
@@ -81,7 +81,7 @@ where
 #[async_trait]
 impl<N: Network, C: ConsensusStorage<N>> Disconnect for Validator<N, C> {
     /// Any extra operations to be performed during a disconnect.
-    async fn handle_disconnect(&self, peer_addr: SocketAddr) {
+    async fn handle_disconnect(&self, peer_addr: SocketAddr, origin: DisconnectOrigin) {
         if let Some(peer_ip) = self.router.resolve_to_listener(peer_addr) {
             self.router.downgrade_peer_to_candidate(peer_ip);
 

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -82,6 +82,8 @@ where
 impl<N: Network, C: ConsensusStorage<N>> Disconnect for Validator<N, C> {
     /// Any extra operations to be performed during a disconnect.
     async fn handle_disconnect(&self, peer_addr: SocketAddr, origin: DisconnectOrigin) {
+        debug!("Psysically disconnecting from {peer_addr}; origin: {origin:?}");
+
         if let Some(peer_ip) = self.router.resolve_to_listener(peer_addr) {
             self.router.downgrade_peer_to_candidate(peer_ip);
 

--- a/node/tcp/src/helpers/connections.rs
+++ b/node/tcp/src/helpers/connections.rs
@@ -30,7 +30,10 @@ use tokio::{
 use tracing::*;
 
 #[cfg(doc)]
-use crate::protocols::{Handshake, Reading, Writing};
+use crate::{
+    Tcp,
+    protocols::{Disconnect, Handshake, OnConnect, Reading, Writing},
+};
 
 /// A map of all currently connected addresses to their associated connection.
 #[derive(Default)]
@@ -170,4 +173,39 @@ pub(crate) fn create_connection_span(addr: SocketAddr, parent: &Span) -> Span {
     try_span!(Level::INFO);
     try_span!(Level::WARN);
     error_span!(parent: parent, "conn", addr = %addr)
+}
+
+/// Describes what triggered a disconnect, as delivered to [`Disconnect::on_disconnect`].
+///
+/// note: Handshake failures do not appear here. A failed handshake prevents the connection
+/// from ever being registered, so there is no connection to disconnect.
+///
+/// note: When several events would race to trigger a disconnect on the same connection,
+/// only the first to claim it is delivered to [`Disconnect::on_disconnect`]; subsequent
+/// claims are silently dropped.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum DisconnectOrigin {
+    /// The [`OnConnect`] task terminated abnormally before defusing its connection cleanup.
+    /// In practice this almost always means the user's [`OnConnect::on_connect`] implementation
+    /// panicked, and the disconnect is a side effect of that panic unwinding past the cleanup
+    /// guard.
+    OnConnectAbort,
+    /// The reader task for this connection terminated. Typical causes are the peer closing
+    /// its end of the socket, a decode error from the user-supplied [`Reading::Codec`], or
+    /// no message arriving within [`Reading::IDLE_TIMEOUT_MS`]. Often (but not always)
+    /// indicates a peer-side issue.
+    Reading,
+    /// The disconnect was initiated by [`Tcp::shut_down`], which tears down every active
+    /// connection as part of stopping the node. Unlike [`DisconnectOrigin::User`], this
+    /// signals that the entire node is going away - reconnection is not meaningful.
+    Shutdown,
+    /// The disconnect was explicitly requested via [`Tcp::disconnect`]. This is the only
+    /// origin produced directly by user code; the others all reflect events the library
+    /// detected internally.
+    User,
+    /// The writer task for this connection terminated. Typical causes are a [`Writing::TIMEOUT_MS`]
+    /// timeout while flushing, an underlying socket write error, or the message channel being
+    /// closed. Often correlates with the peer disappearing, but can also reflect local-side
+    /// pipeline problems (slow consumer, broken pipe).
+    Writing,
 }

--- a/node/tcp/src/helpers/connections.rs
+++ b/node/tcp/src/helpers/connections.rs
@@ -175,13 +175,13 @@ pub(crate) fn create_connection_span(addr: SocketAddr, parent: &Span) -> Span {
     error_span!(parent: parent, "conn", addr = %addr)
 }
 
-/// Describes what triggered a disconnect, as delivered to [`Disconnect::on_disconnect`].
+/// Describes what triggered a disconnect, as delivered to [`Disconnect::handle_disconnect`].
 ///
 /// note: Handshake failures do not appear here. A failed handshake prevents the connection
 /// from ever being registered, so there is no connection to disconnect.
 ///
 /// note: When several events would race to trigger a disconnect on the same connection,
-/// only the first to claim it is delivered to [`Disconnect::on_disconnect`]; subsequent
+/// only the first to claim it is delivered to [`Disconnect::handle_disconnect`]; subsequent
 /// claims are silently dropped.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum DisconnectOrigin {

--- a/node/tcp/src/protocols/disconnect.rs
+++ b/node/tcp/src/protocols/disconnect.rs
@@ -24,7 +24,11 @@ use tracing::*;
 
 #[cfg(doc)]
 use crate::{Connection, protocols::Writing};
-use crate::{P2P, connections::create_connection_span, protocols::ProtocolHandler};
+use crate::{
+    P2P,
+    connections::{DisconnectOrigin, create_connection_span},
+    protocols::ProtocolHandler,
+};
 
 /// Can be used to automatically perform some extra actions when the node disconnects from its
 /// peer, which is especially practical if the disconnect is triggered automatically, e.g. due
@@ -44,7 +48,7 @@ where
     /// node disconnecting from a peer.
     async fn enable_disconnect(&self) {
         let (from_node_sender, mut from_node_receiver) = mpsc::channel::<(
-            SocketAddr,
+            (SocketAddr, DisconnectOrigin),
             oneshot::Sender<(JoinHandle<()>, oneshot::Receiver<()>)>,
         )>(self.tcp().config().max_connections as usize);
 
@@ -57,13 +61,13 @@ where
             trace!(parent: self_clone.tcp().span(), "spawned the Disconnect handler task");
             tx.send(()).unwrap(); // safe; the channel was just opened
 
-            while let Some((peer_addr, notifier)) = from_node_receiver.recv().await {
+            while let Some(((peer_addr, origin), notifier)) = from_node_receiver.recv().await {
                 let self_clone2 = self_clone.clone();
                 // create a channel for waiting on completion
                 let (done_tx, done_rx) = oneshot::channel();
                 let handle = tokio::spawn(async move {
                     // perform the specified extra actions
-                    if timeout(Self::TIMEOUT, self_clone2.handle_disconnect(peer_addr)).await.is_err() {
+                    if timeout(Self::TIMEOUT, self_clone2.handle_disconnect(peer_addr, origin)).await.is_err() {
                         let conn_span = create_connection_span(peer_addr, self_clone2.tcp().span());
                         warn!(parent: conn_span, "Disconnect logic timed out");
                     }
@@ -90,5 +94,5 @@ where
     /// Any extra actions to be executed during a disconnect; in order to still be able to
     /// communicate with the peer in the usual manner (i.e. via [`Writing`]), only its [`SocketAddr`]
     /// (as opposed to the related [`Connection`] object) is provided as an argument.
-    async fn handle_disconnect(&self, peer_addr: SocketAddr);
+    async fn handle_disconnect(&self, peer_addr: SocketAddr, origin: DisconnectOrigin);
 }

--- a/node/tcp/src/protocols/mod.rs
+++ b/node/tcp/src/protocols/mod.rs
@@ -17,7 +17,7 @@
 //! node's lifetime and handles a specific functionality. The communication with these tasks is done via dedicated
 //! handler objects.
 
-use std::{io, net::SocketAddr};
+use std::{io, net::SocketAddr, sync::atomic::Ordering};
 
 use once_cell::race::OnceBox;
 use tokio::{
@@ -25,7 +25,10 @@ use tokio::{
     task::JoinHandle,
 };
 
-use crate::connections::Connection;
+use crate::{
+    Tcp,
+    connections::{Connection, DisconnectOrigin},
+};
 
 mod disconnect;
 mod handshake;
@@ -49,7 +52,7 @@ pub(crate) struct Protocols {
     pub(crate) reading: OnceBox<ProtocolHandler<Connection, io::Result<Connection>>>,
     pub(crate) writing: OnceBox<writing::WritingHandler>,
     pub(crate) on_connect: OnceBox<ProtocolHandler<SocketAddr, JoinHandle<()>>>,
-    pub(crate) disconnect: OnceBox<ProtocolHandler<SocketAddr, OnDisconnectBundle>>,
+    pub(crate) disconnect: OnceBox<ProtocolHandler<(SocketAddr, DisconnectOrigin), OnDisconnectBundle>>,
 }
 
 /// An object sent to a protocol handler task; the task assumes control of a protocol-relevant item `T`,
@@ -69,5 +72,32 @@ impl<T, U> Protocol<T, U> for ProtocolHandler<T, U> {
     async fn trigger(&self, item: ReturnableItem<T, U>) {
         // ignore errors; they can only happen if a disconnect interrupts the protocol setup process
         let _ = self.0.send(item).await;
+    }
+}
+
+/// This object is used to ensure that the related peer is going to be disconnected from
+/// even if the owning task panics due to a user implementation error.
+pub(crate) struct DisconnectOnDrop {
+    pub(crate) node: Option<Tcp>,
+    pub(crate) addr: SocketAddr,
+    pub(crate) origin: DisconnectOrigin,
+}
+
+impl DisconnectOnDrop {
+    pub(crate) fn new(node: Tcp, addr: SocketAddr, origin: DisconnectOrigin) -> Self {
+        Self { node: Some(node), addr, origin }
+    }
+}
+
+impl Drop for DisconnectOnDrop {
+    fn drop(&mut self) {
+        if let Some(node) = self.node.take() {
+            let (addr, origin) = (self.addr, self.origin);
+            let needs_recovery =
+                node.connections.0.read().get(&addr).is_some_and(|c| !c.disconnecting.load(Ordering::Acquire));
+            if needs_recovery {
+                tokio::spawn(async move { node.disconnect_w_origin(addr, origin).await });
+            }
+        }
     }
 }

--- a/node/tcp/src/protocols/on_connect.rs
+++ b/node/tcp/src/protocols/on_connect.rs
@@ -23,7 +23,11 @@ use crate::{
     Connection,
     protocols::{Reading, Writing},
 };
-use crate::{P2P, protocols::ProtocolHandler};
+use crate::{
+    P2P,
+    connections::DisconnectOrigin,
+    protocols::{DisconnectOnDrop, ProtocolHandler},
+};
 
 /// Can be used to automatically perform some initial actions once the connection with a peer is
 /// fully established.
@@ -56,8 +60,13 @@ where
             while let Some((addr, notifier)) = from_node_receiver.recv().await {
                 let self_clone2 = self_clone.clone();
                 let handle = tokio::spawn(async move {
+                    // disconnect automatically if the OnConnect impl panics
+                    let mut conn_cleanup =
+                        DisconnectOnDrop::new(self_clone2.tcp().clone(), addr, DisconnectOrigin::OnConnectAbort);
                     // perform the specified initial actions
                     self_clone2.on_connect(addr).await;
+                    // if there was no panic, do not disconnect - this "defuses" the auto-cleanup
+                    conn_cleanup.node.take();
                 });
                 // notify the node that the initial actions have concluded
                 let _ = notifier.send(handle); // can't really fail

--- a/node/tcp/src/protocols/reading.rs
+++ b/node/tcp/src/protocols/reading.rs
@@ -20,7 +20,8 @@ use crate::{
     ConnectionSide,
     P2P,
     Tcp,
-    protocols::{ProtocolHandler, ReturnableConnection},
+    connections::DisconnectOrigin,
+    protocols::{DisconnectOnDrop, ProtocolHandler, ReturnableConnection},
 };
 
 use async_trait::async_trait;
@@ -154,6 +155,9 @@ impl<R: Reading> ReadingInternal for R {
             trace!(parent: &conn_span, "spawned a task for processing messages");
             tx_processing.send(()).unwrap(); // safe; the channel was just opened
 
+            // disconnect automatically regardless of how this task concludes
+            let _conn_cleanup = DisconnectOnDrop::new(node.clone(), addr, DisconnectOrigin::Reading);
+
             while let Some((msg, _guard)) = inbound_message_receiver.recv().await {
                 if let Err(e) = self_clone.process_message(addr, msg).await {
                     error!(parent: &conn_span, "can't process a message: {e}");
@@ -178,6 +182,9 @@ impl<R: Reading> ReadingInternal for R {
             // postpone reads until the connection is fully established; if the process fails,
             // this task gets aborted, so there is no need for a dedicated timeout
             let _ = rx_conn_ready.await;
+
+            // disconnect automatically regardless of how this task concludes
+            let _conn_cleanup = DisconnectOnDrop::new(node.clone(), addr, DisconnectOrigin::Reading);
 
             // dropped message log suppression helpers
             let mut dropped_count: usize = 0;
@@ -227,8 +234,6 @@ impl<R: Reading> ReadingInternal for R {
                     None => break, // end of stream
                 }
             }
-
-            let _ = node.disconnect(addr).await;
         }));
         let _ = rx_reader.await;
         conn.tasks.push(reader_task);

--- a/node/tcp/src/protocols/writing.rs
+++ b/node/tcp/src/protocols/writing.rs
@@ -35,8 +35,8 @@ use crate::{
     Connection,
     ConnectionSide,
     P2P,
-    connections::create_connection_span,
-    protocols::{Protocol, ProtocolHandler, ReturnableConnection},
+    connections::{DisconnectOrigin, create_connection_span},
+    protocols::{DisconnectOnDrop, Protocol, ProtocolHandler, ReturnableConnection},
 };
 
 type WritingSenders = Arc<RwLock<HashMap<SocketAddr, mpsc::Sender<WrappedMessage>>>>;
@@ -215,7 +215,7 @@ impl<W: Writing> WritingInternal for W {
         conn_senders.write().insert(addr, outbound_message_sender);
 
         // this will automatically drop the sender upon a disconnect
-        let auto_cleanup = SenderCleanup { addr, senders: Arc::clone(conn_senders) };
+        let sender_cleanup = SenderCleanup { addr, senders: Arc::clone(conn_senders) };
 
         // use a channel to know when the writer task is ready
         let (tx_writer, rx_writer) = oneshot::channel();
@@ -229,7 +229,10 @@ impl<W: Writing> WritingInternal for W {
             tx_writer.send(()).unwrap(); // safe; the channel was just opened
 
             // move the cleanup into the task that gets aborted on disconnect
-            let _auto_cleanup = auto_cleanup;
+            let _sender_cleanup = sender_cleanup;
+
+            // disconnect automatically regardless of how this task concludes
+            let _conn_cleanup = DisconnectOnDrop::new(node.clone(), addr, DisconnectOrigin::Writing);
 
             while let Some(wrapped_msg) = outbound_message_receiver.recv().await {
                 let msg = wrapped_msg.msg.downcast().unwrap();
@@ -252,8 +255,6 @@ impl<W: Writing> WritingInternal for W {
                     }
                 }
             }
-
-            node.disconnect(addr).await;
         }));
         let _ = rx_writer.await;
         conn.tasks.push(writer_task);

--- a/node/tcp/src/tcp.rs
+++ b/node/tcp/src/tcp.rs
@@ -46,7 +46,7 @@ use crate::{
     Config,
     KnownPeers,
     Stats,
-    connections::{Connection, ConnectionSide, Connections, create_connection_span},
+    connections::{Connection, ConnectionSide, Connections, DisconnectOrigin, create_connection_span},
     protocols::{Protocol, Protocols},
 };
 
@@ -144,7 +144,7 @@ pub struct InnerTcp {
     /// A set of connections that have not been finalized yet.
     connecting: Mutex<HashSet<SocketAddr>>,
     /// Contains objects related to the node's active connections.
-    connections: Connections,
+    pub(crate) connections: Connections,
     /// Collects statistics related to the node's peers.
     known_peers: KnownPeers,
     /// Contains the set of currently banned peers.
@@ -280,7 +280,7 @@ impl Tcp {
         for addr in self.connected_addrs() {
             let node = self.clone();
             disconnect_tasks.spawn(async move {
-                node.disconnect(addr).await;
+                node.disconnect_w_origin(addr, DisconnectOrigin::Shutdown).await;
             });
         }
         while disconnect_tasks.join_next().await.is_some() {}
@@ -363,6 +363,10 @@ impl Tcp {
     ///
     /// Returns true if the we were connected to the given address.
     pub async fn disconnect(&self, addr: SocketAddr) -> bool {
+        self.disconnect_w_origin(addr, DisconnectOrigin::User).await
+    }
+
+    pub(crate) async fn disconnect_w_origin(&self, addr: SocketAddr, origin: DisconnectOrigin) -> bool {
         // claim the disconnect to avoid duplicate executions, or return early if already claimed
         if let Some(conn) = self.connections.0.read().get(&addr) {
             if conn.disconnecting.swap(true, Relaxed) {
@@ -376,7 +380,7 @@ impl Tcp {
 
         if let Some(handler) = self.protocols.disconnect.get() {
             let (sender, receiver) = oneshot::channel();
-            handler.trigger((addr, sender)).await;
+            handler.trigger(((addr, origin), sender)).await;
             if let Ok((handle, waiter)) = receiver.await {
                 // register the associated task with the connection, in case
                 // it gets terminated before its completion


### PR DESCRIPTION
This PR will make nodes produce a single `DEBUG`-level log for each physical disconnect, and indicate where it originated from (i.e. whether it was explicit, or automatic).

As a bonus, automatic disconnect originating from `Reading` or `Writing` layers is now RAII-based, which is a cleaner approach.

Closes https://github.com/ProvableHQ/snarkOS/issues/4292.