### PR TITLE
feat: add a compile-time flag for credits-only history

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snarkos"
-version = "4.7.4"
+version = "4.7.5"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A decentralized operating system"
 homepage = "https://aleo.org"
@@ -48,7 +48,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "0aa6c6931"
+rev = "74ba6e2"
 #version = "=4.7.3"
 default-features = false
 


### PR DESCRIPTION
## Motivation

Port of https://github.com/ProvableHQ/snarkVM/pull/3289

This PR adds a new compile-time flag - HISTORY_CREDITS_ONLY - which, if present, causes the history feature to become restricted to credits.aleo.

## Test Plan

Manually ran a snarkOS node to test if credits.aleo history was populated
