### PR TITLE
[Feat] Increase REST body limit

### DIFF
--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -318,8 +318,8 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         routes
             // Pass in `Rest` to make things convenient.
             .with_state(self.clone())
-            // Cap the request body size at 512KiB.
-            .layer(DefaultBodyLimit::max(512 * 1024))
+            // Cap the request body size at 1.5MiB.
+            .layer(DefaultBodyLimit::max(2 * 768 * 1024))
             .layer(GovernorLayer {
                 config: governor_config.into(),
             })


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This PR increases the Request body size from 512kb to 1.5mb. In testing, deployment transactions have exceeded the current bounds.

This also matches the limit upgrade set in - https://github.com/ProvableHQ/aleo-devnode/pull/11 and https://github.com/ProvableHQ/leo/pull/29438.