### PR TITLE
[Feat] Stricter fd limit checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4658,7 +4658,6 @@ dependencies = [
  "crossterm",
  "indexmap 2.14.0",
  "locktick",
- "nix 0.29.0",
  "nix 0.30.1",
  "num_cpus",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3959,6 +3959,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlimit"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f35ee2729c56bb610f6dba436bf78135f728b7373bdffae2ec815b2d3eb98cc3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4649,12 +4658,14 @@ dependencies = [
  "crossterm",
  "indexmap 2.14.0",
  "locktick",
+ "nix 0.29.0",
  "nix 0.30.1",
  "num_cpus",
  "parking_lot",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rayon",
+ "rlimit",
  "rpassword",
  "self_update",
  "serde",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -87,6 +87,9 @@ workspace = true
 features = [ "parking_lot" ]
 optional = true
 
+[target.'cfg(all(unix, not(target_os = "linux")))'.dependencies]
+nix = { version = "0.29", features = ["fs"] }
+
 [dependencies.num_cpus]
 workspace = true
 
@@ -101,6 +104,9 @@ workspace = true
 
 [dependencies.rayon]
 workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+rlimit = "0.11"
 
 [dependencies.rpassword]
 version = "7.4.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -181,7 +181,7 @@ features = [ "test-helpers" ]
 [target."cfg(target_family = \"unix\")".dependencies.nix]
 version = "0.30"
 default-features = false
-features = [ "fs", "resource" ]
+features = [ "resource" ]
 
 [target.'cfg(unix)'.dependencies]
 rlimit = "0.11"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -87,9 +87,6 @@ workspace = true
 features = [ "parking_lot" ]
 optional = true
 
-[target.'cfg(all(unix, not(target_os = "linux")))'.dependencies]
-nix = { version = "0.29", features = ["fs"] }
-
 [dependencies.num_cpus]
 workspace = true
 
@@ -104,9 +101,6 @@ workspace = true
 
 [dependencies.rayon]
 workspace = true
-
-[target.'cfg(target_os = "linux")'.dependencies]
-rlimit = "0.11"
 
 [dependencies.rpassword]
 version = "7.4.0"
@@ -187,4 +181,7 @@ features = [ "test-helpers" ]
 [target."cfg(target_family = \"unix\")".dependencies.nix]
 version = "0.30"
 default-features = false
-features = [ "resource" ]
+features = [ "fs", "resource" ]
+
+[target.'cfg(unix)'.dependencies]
+rlimit = "0.11"

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -339,6 +339,10 @@ impl Start {
             // Error messages.
             let node_parse_error = || "Failed to start node";
 
+            // Periodically check if the number of file descriptors isn't becoming insufficient.
+            #[cfg(unix)]
+            crate::helpers::spawn_fd_monitor();
+
             // Clone the configurations.
             let mut self_ = self.clone();
 

--- a/cli/src/helpers/fd_check.rs
+++ b/cli/src/helpers/fd_check.rs
@@ -110,6 +110,8 @@ pub fn system_fd_usage() -> std::io::Result<SystemFd> {
     let (cur_oid, max_oid) = ("kern.num_files", "kern.maxfiles");
     #[cfg(any(target_os = "openbsd", target_os = "netbsd"))]
     let (cur_oid, max_oid) = ("kern.nfiles", "kern.maxfiles");
+    #[cfg(not(any(target_os = "freebsd", target_os = "macos", target_os = "openbsd", target_os = "netbsd")))]
+    return Err(std::io::Error::new(std::io::ErrorKind::Unsupported, "system fd probe unsupported on this OS"));
 
     fn read(oid: &str) -> std::io::Result<u64> {
         let out = std::process::Command::new("sysctl").arg("-n").arg(oid).output()?;

--- a/cli/src/helpers/fd_check.rs
+++ b/cli/src/helpers/fd_check.rs
@@ -166,7 +166,7 @@ pub fn spawn_fd_monitor() {
                 Err(e) => error!(error = %e, "process fd probe failed"),
             }
 
-            // (2) whole-machine fds
+            // (2) whole-machine fds are allowed 5 percentage points more leeway.
             match system_fd_usage() {
                 Ok(s) => {
                     let (pct, left) = (s.ratio() * 100.0, s.max.saturating_sub(s.allocated));

--- a/cli/src/helpers/fd_check.rs
+++ b/cli/src/helpers/fd_check.rs
@@ -1,0 +1,193 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io;
+
+use tokio::time::{Duration, MissedTickBehavior, interval};
+use tracing::*;
+
+/// Node-scale fd use.
+#[derive(Debug, Clone, Copy)]
+pub struct FdUsage {
+    /// File descriptors currently open.
+    pub open: u64,
+    /// Current soft limit (RLIMIT_NOFILE). `None` == unlimited.
+    pub soft_limit: Option<u64>,
+}
+
+impl FdUsage {
+    /// Fraction of the soft limit in use (0.0..=1.0). 0.0 when unlimited.
+    pub fn ratio(&self) -> f64 {
+        match self.soft_limit {
+            Some(limit) if limit > 0 => self.open as f64 / limit as f64,
+            _ => 0.0,
+        }
+    }
+
+    /// True once usage reaches `threshold` of the soft limit (e.g. 0.8 == 80%).
+    pub fn approaching_limit(&self, threshold: f64) -> bool {
+        self.soft_limit.is_some() && self.ratio() >= threshold
+    }
+}
+
+/// Probe the live system: current soft limit + count of open descriptors.
+pub fn fd_usage() -> io::Result<FdUsage> {
+    let soft_limit = soft_nofile_limit()?;
+    let open = count_open_fds(soft_limit)?;
+    Ok(FdUsage { open, soft_limit })
+}
+
+fn soft_nofile_limit() -> io::Result<Option<u64>> {
+    let (soft, _hard) = rlimit::Resource::NOFILE.get()?;
+    Ok(if soft == rlimit::INFINITY { None } else { Some(soft) })
+}
+
+#[cfg(target_os = "linux")]
+fn count_open_fds(_limit: Option<u64>) -> io::Result<u64> {
+    // Each open descriptor is an entry in /proc/self/fd. The directory
+    // handle itself holds one fd while we iterate, so subtract it back out.
+    let mut n: u64 = 0;
+    for entry in std::fs::read_dir("/proc/self/fd")? {
+        entry?;
+        n += 1;
+    }
+    Ok(n.saturating_sub(1))
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn count_open_fds(limit: Option<u64>) -> io::Result<u64> {
+    // Portable fallback (macOS, *BSD, ...): probe each slot with
+    // fcntl(F_GETFD). O(limit) syscalls, no /proc dependency.
+    use nix::fcntl::{FcntlArg, fcntl};
+    let max = limit.unwrap_or(65_536).min(i32::MAX as u64) as i32;
+    let n = (0..max).filter(|&fd| fcntl(fd, FcntlArg::F_GETFD).is_ok()).count();
+    Ok(n as u64)
+}
+
+/// System-wide (whole machine) fd use.
+#[derive(Debug, Clone, Copy)]
+pub struct SystemFd {
+    pub allocated: u64,
+    pub max: u64,
+}
+
+impl SystemFd {
+    pub fn ratio(&self) -> f64 {
+        if self.max > 0 { self.allocated as f64 / self.max as f64 } else { 0.0 }
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn system_fd_usage() -> std::io::Result<SystemFd> {
+    // /proc/sys/fs/file-nr => "<allocated>\t<free, always 0>\t<max>"
+    let s = std::fs::read_to_string("/proc/sys/fs/file-nr")?;
+    let mut f = s.split_whitespace();
+    let bad = || std::io::Error::new(std::io::ErrorKind::InvalidData, "unexpected file-nr format");
+    let allocated = f.next().and_then(|v| v.parse().ok()).ok_or_else(bad)?;
+    let _free = f.next(); // always 0 on modern kernels
+    let max = f.next().and_then(|v| v.parse().ok()).ok_or_else(bad)?;
+    Ok(SystemFd { allocated, max })
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+pub fn system_fd_usage() -> std::io::Result<SystemFd> {
+    // OID names differ by flavor; values are plain integers.
+    #[cfg(target_os = "freebsd")]
+    let (cur_oid, max_oid) = ("kern.openfiles", "kern.maxfiles");
+    #[cfg(target_os = "macos")]
+    let (cur_oid, max_oid) = ("kern.num_files", "kern.maxfiles");
+    #[cfg(any(target_os = "openbsd", target_os = "netbsd"))]
+    let (cur_oid, max_oid) = ("kern.nfiles", "kern.maxfiles");
+
+    fn read(oid: &str) -> std::io::Result<u64> {
+        let out = std::process::Command::new("sysctl").arg("-n").arg(oid).output()?;
+        if !out.status.success() {
+            return Err(std::io::Error::new(std::io::ErrorKind::NotFound, format!("sysctl {oid} unavailable")));
+        }
+        String::from_utf8_lossy(&out.stdout)
+            .trim()
+            .parse()
+            .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidData, format!("bad value for {oid}")))
+    }
+
+    Ok(SystemFd { allocated: read(cur_oid)?, max: read(max_oid)? })
+}
+
+pub fn spawn_fd_monitor() {
+    tokio::spawn(async move {
+        let mut tick = interval(Duration::from_secs(30));
+        tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        loop {
+            tick.tick().await;
+
+            // (1) the node's own fds
+            match fd_usage() {
+                Ok(u) => {
+                    if let Some(limit) = u.soft_limit {
+                        let (pct, left) = (u.ratio() * 100.0, limit.saturating_sub(u.open));
+                        if u.ratio() >= 0.95 {
+                            error!(
+                                scope = "process",
+                                open = u.open,
+                                limit,
+                                left,
+                                pct = format!("{pct:.1}%"),
+                                "node fd usage critical"
+                            );
+                        } else if u.ratio() >= 0.80 {
+                            warn!(
+                                scope = "process",
+                                open = u.open,
+                                limit,
+                                left,
+                                pct = format!("{pct:.1}%"),
+                                "node fd usage elevated"
+                            );
+                        }
+                    }
+                }
+                Err(e) => error!(error = %e, "process fd probe failed"),
+            }
+
+            // (2) whole-machine fds
+            match system_fd_usage() {
+                Ok(s) => {
+                    let (pct, left) = (s.ratio() * 100.0, s.max.saturating_sub(s.allocated));
+                    if s.ratio() >= 0.90 {
+                        error!(
+                            scope = "system",
+                            allocated = s.allocated,
+                            max = s.max,
+                            left,
+                            pct = format!("{pct:.1}%"),
+                            "system-wide fd usage critical"
+                        );
+                    } else if s.ratio() >= 0.75 {
+                        warn!(
+                            scope = "system",
+                            allocated = s.allocated,
+                            max = s.max,
+                            left,
+                            pct = format!("{pct:.1}%"),
+                            "system-wide fd usage elevated"
+                        );
+                    }
+                }
+                Err(e) => error!(error = %e, "system fd probe failed"),
+            }
+        }
+    });
+}

--- a/cli/src/helpers/fd_check.rs
+++ b/cli/src/helpers/fd_check.rs
@@ -67,13 +67,15 @@ fn count_open_fds(_limit: Option<u64>) -> io::Result<u64> {
 }
 
 #[cfg(all(unix, not(target_os = "linux")))]
-fn count_open_fds(limit: Option<u64>) -> io::Result<u64> {
-    // Portable fallback (macOS, *BSD, ...): probe each slot with
-    // fcntl(F_GETFD). O(limit) syscalls, no /proc dependency.
-    use nix::fcntl::{FcntlArg, fcntl};
-    let max = limit.unwrap_or(65_536).min(i32::MAX as u64) as i32;
-    let n = (0..max).filter(|&fd| fcntl(fd, FcntlArg::F_GETFD).is_ok()).count();
-    Ok(n as u64)
+fn count_open_fds(_limit: Option<u64>) -> io::Result<u64> {
+    // macOS and most BSDs expose open fds via /dev/fd (same idea as Linux's /proc/self/fd).
+    // The directory handle itself holds one fd while we iterate, so subtract it back out.
+    let mut n: u64 = 0;
+    for entry in std::fs::read_dir("/dev/fd")? {
+        entry?;
+        n += 1;
+    }
+    Ok(n.saturating_sub(1))
 }
 
 /// System-wide (whole machine) fd use.

--- a/cli/src/helpers/mod.rs
+++ b/cli/src/helpers/mod.rs
@@ -22,6 +22,9 @@ use log_writer::*;
 mod dynamic_format;
 use dynamic_format::*;
 
+mod fd_check;
+pub use fd_check::*;
+
 pub(crate) mod args;
 
 pub mod logger;

--- a/cli/src/helpers/mod.rs
+++ b/cli/src/helpers/mod.rs
@@ -47,16 +47,11 @@ pub fn check_open_files_limit(minimum: u64) {
         Ok((soft_limit, _)) => {
             // Check if requirements are met.
             if soft_limit < minimum {
-                // Warn about too low limit.
-                let warning = [
-                    format!("⚠️  The open files limit ({soft_limit}) for this process is lower than recommended."),
-                    format!("  • To ensure correct behavior of the node, please raise it to at least {minimum}."),
-                    "  • See the `ulimit` command and `/etc/security/limits.conf` for more details.".to_owned(),
-                ]
-                .join("\n")
-                .yellow()
-                .bold();
-                eprintln!("{warning}\n");
+                panic!(
+                    "The open files limit ({soft_limit}) for this process is too low.\n\
+                    Please raise it to at least {minimum}\n\
+                    See the `ulimit` command and `/etc/security/limits.conf` for more details.",
+                );
             }
         }
         Err(err) => {

--- a/cli/src/helpers/mod.rs
+++ b/cli/src/helpers/mod.rs
@@ -22,7 +22,9 @@ use log_writer::*;
 mod dynamic_format;
 use dynamic_format::*;
 
+#[cfg(target_family = "unix")]
 mod fd_check;
+#[cfg(target_family = "unix")]
 pub use fd_check::*;
 
 pub(crate) mod args;
@@ -51,8 +53,8 @@ pub fn check_open_files_limit(minimum: u64) {
             // Check if requirements are met.
             if soft_limit < minimum {
                 panic!(
-                    "The open files limit ({soft_limit}) for this process is too low.\n\
-                    Please raise it to at least {minimum}\n\
+                    "The open files limit ({soft_limit}) for this process is too low. \
+                    Please raise it to at least {minimum} \
                     See the `ulimit` command and `/etc/security/limits.conf` for more details.",
                 );
             }


### PR DESCRIPTION
Startup enforcement is trivial, just a switch from an existing log to a panic.

As for the fs check, this PR proposes a more advanced solution than the one outlined in the issue, because attempting to open a file:
- would only flip at 100% capacity (no room for recovery)
- consumes an fd to run the check, potentially being the one that breaks the node
- is racy: the probe might succeed, while a microsecond later, the node might fail

I tested it briefly locally, checking both the per-process (by adding connections) and per-system (by starting external sockets) value.

The `nix` dependency (needed for non-Linux UNIXes) already exists in our tree; `rlimit` is new, but it's small, and we're already using its only dependency (`libc`). Using `libc` directly would break the `deny(unsafe)` rule.

Closes https://github.com/ProvableHQ/snarkOS/issues/4306.