### PR TITLE
[Logs] Be more explicit about unexpected peer status during promotion

### DIFF
--- a/node/network/src/peer.rs
+++ b/node/network/src/peer.rs
@@ -133,7 +133,11 @@ impl<N: Network> Peer<N> {
         // Logic check: this can only happen during the handshake. This isn't a fatal
         // error, but should not be triggered.
         if !matches!(self, Self::Connecting(_)) {
-            warn!("Peer '{listener_addr}' is being upgraded to Connected, but isn't Connecting");
+            warn!(
+                "Peer '{listener_addr}' is being upgraded to Connected, but isn't Connecting \
+                - it is {}",
+                if self.is_connected() { "already Connected" } else { "only a Candidate" }
+            );
         }
 
         *self = Self::Connected(ConnectedPeer {


### PR DESCRIPTION
The peer may be a `Candidate`, `Connecting`, or `Connected`. If a promotion to `Connected` happens from anything other than `Connecting`, it is unexpected. This log extension will tell us whether the promotion may happen from:
- `Connected` - indicating that we may need to be stricter about our tie-break in case of two-sided connections
- `Candidate` - indicating that it is possible for us to immediately reconnect to a peer that we've just disconnected from

Both options should effectively be harmless:
- a two-sided low-level connection would effectively be superseded in the high-level layer by the latter one, with the initial one shortly timing out via protocol logic
- a promotion from `Candidate` to `Connected` implies we were disconnected from a fully connected peer *during* a later handshake with them (downgrading them in the higher layer from `Connecting` to `Candidate`), and basically resuming a preexisting connection

Still, this is avoidable, and would simplify debugging.

CC https://github.com/ProvableHQ/snarkOS/issues/4291