### PR TITLE
[Tests] Relax the cert count check under test_network

### DIFF
--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -505,7 +505,12 @@ impl<N: Network> Storage<N> {
                 bail!("Missing certificates for the previous round {previous_round} in storage {gc_log}")
             }
             // Ensure the number of previous certificate IDs is at or below the number of committee members.
-            if batch_header.previous_certificate_ids().len() > previous_committee_lookback.num_members() {
+            // As for the `test_network` clause, a more robust approach would be to set the
+            // previous_committee_lookback appropriately when dev-on-prod is activated, or to only skip this
+            // check right at the hotswap height.
+            if !cfg!(feature = "test_network")
+                && batch_header.previous_certificate_ids().len() > previous_committee_lookback.num_members()
+            {
                 bail!("Too many previous certificates for round {round} {gc_log}")
             }
             // Initialize a set of the previous authors.


### PR DESCRIPTION
The check for the number of certificates vs. the number of committee members is too strict for `dev_on_prod`-style tests, as the `test_network` feature makes `get_committee_lookback_for_round` always return the dev committee, which is typically smaller than the prod one, easily failing the aforementioned check.

The fix is trivial: add an extra compile-time condition to the existing check. It skips the check for `test_network`, while being completely ignored in other builds.

Fixes https://github.com/ProvableHQ/snarkOS/issues/4274.

note: I haven't been able to reliably trigger the issue in local tests, but I've been unable to to so with this change in place.