### PR TITLE
[Chore] Move the Message version compat check to compilation

### DIFF
--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -67,6 +67,7 @@ use snarkvm::prelude::{
     Address,
     ConsensusVersion,
     FromBytes,
+    MainnetV0,
     Network,
     Signature,
     ToBytes,
@@ -76,6 +77,19 @@ use snarkvm::prelude::{
 };
 
 use std::{borrow::Cow, io, net::SocketAddr};
+
+// A compile-time compatibility check for the Message.
+const _: () = {
+    let msg_versions = Message::<MainnetV0>::VERSIONS;
+    let net_versions = MainnetV0::_CONSENSUS_VERSION_HEIGHTS;
+
+    let message_version = msg_versions[msg_versions.len() - 1].0;
+    let expected_version = net_versions[net_versions.len() - 1].0;
+
+    if message_version as u16 != expected_version as u16 {
+        panic!("Message <> ConsensusVersion mismatch!");
+    }
+};
 
 pub trait MessageTrait: ToBytes + FromBytes {
     /// Returns the message name.
@@ -318,20 +332,5 @@ mod tests {
         consensus_constants_increasing_heights::<MainnetV0>();
         consensus_constants_increasing_heights::<TestnetV0>();
         consensus_constants_increasing_heights::<CanaryV0>();
-    }
-
-    #[test]
-    fn test_latest_consensus_version() {
-        let message_consensus_version = Message::<MainnetV0>::VERSIONS.last().unwrap().0;
-        let expected_consensus_version = MainnetV0::CONSENSUS_VERSION_HEIGHTS().last().unwrap().0;
-        assert_eq!(message_consensus_version, expected_consensus_version);
-
-        let message_consensus_version = Message::<TestnetV0>::VERSIONS.last().unwrap().0;
-        let expected_consensus_version = TestnetV0::CONSENSUS_VERSION_HEIGHTS().last().unwrap().0;
-        assert_eq!(message_consensus_version, expected_consensus_version);
-
-        let message_consensus_version = Message::<CanaryV0>::VERSIONS.last().unwrap().0;
-        let expected_consensus_version = CanaryV0::CONSENSUS_VERSION_HEIGHTS().last().unwrap().0;
-        assert_eq!(message_consensus_version, expected_consensus_version);
     }
 }


### PR DESCRIPTION
I've considered alternative approaches, but this one is the safest and introduces the least changes; it takes advantage of an anonymous constant trick that allows us to move the existing test check to the compilation phase. I only introduced it for `MainnetV0`, as the same check applies to other networks, since our implementation of `Message::VERSIONS` is the same for all of them.

I tested this locally - it panics if snarkVM bumps the list of consensus versions without `Message::VERSIONS` accounting for it.

Fixes https://github.com/ProvableHQ/snarkOS/issues/4319.