### PR TITLE
[Logs] Reduce the log level for block re-request failure

### DIFF
--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -1103,7 +1103,7 @@ impl<N: Network> BlockSync<N> {
 
                 let Some((sync_peers, min_common_ancestor)) = self.find_sync_peers_inner(start_height) else {
                     // This generally shouldn't happen, because there cannot be outstanding requests when no peers are connected.
-                    error!("Cannot re-request blocks because no or not enough peers are connected");
+                    warn!("Cannot re-request blocks because no or not enough peers are connected");
                     return result;
                 };
 


### PR DESCRIPTION
I've looked at the associated code, and it seems to me that the severity of this log is related to the expected invariants rather than any user-facing issues - we can downgrade it.

Fixes https://github.com/ProvableHQ/snarkOS/issues/4322.