### PR TITLE
[Fix] Record confirmed transmission latency regardless of age

### DIFF
--- a/node/metrics/src/lib.rs
+++ b/node/metrics/src/lib.rs
@@ -124,9 +124,26 @@ pub fn add_transmission_latency_metric<N: Network>(
     let keys_to_remove = cfg_iter!(&*transmissions_tracker)
         .flat_map(|(transmission_id, timestamp)| {
             let elapsed_time = std::time::Duration::from_secs((ts_now - *timestamp) as u64);
+            let transmission_type = match transmission_id {
+                TransmissionID::Solution(solution_id, _) if solution_ids.contains(solution_id) => Some("solution"),
+                TransmissionID::Transaction(transaction_id, _) if transaction_ids.contains(transaction_id) => {
+                    Some("transaction")
+                }
+                // Either a ratification, or the transmission was not included in the block
+                _ => None,
+            };
 
-            if elapsed_time.as_secs() > AGE_THRESHOLD_SECONDS as u64 {
-                // This entry is stale-- remove it from transmission queue and record it as a stale transmission.
+            if let Some(transmission_type_string) = transmission_type {
+                histogram_label(
+                    consensus::TRANSMISSION_LATENCY,
+                    "transmission_type",
+                    transmission_type_string.to_owned(),
+                    elapsed_time.as_secs_f64(),
+                );
+                Some(*transmission_id)
+            } else if elapsed_time.as_secs() > AGE_THRESHOLD_SECONDS as u64 {
+                // A transmission included in this block is confirmed, so record its latency even if it
+                // predates the staleness threshold — confirmation takes precedence over staleness.
                 match transmission_id {
                     TransmissionID::Solution(..) => increment_counter(consensus::STALE_UNCONFIRMED_SOLUTIONS),
                     TransmissionID::Transaction(..) => increment_counter(consensus::STALE_UNCONFIRMED_TRANSACTIONS),
@@ -134,26 +151,7 @@ pub fn add_transmission_latency_metric<N: Network>(
                 }
                 Some(*transmission_id)
             } else {
-                let transmission_type = match transmission_id {
-                    TransmissionID::Solution(solution_id, _) if solution_ids.contains(solution_id) => Some("solution"),
-                    TransmissionID::Transaction(transaction_id, _) if transaction_ids.contains(transaction_id) => {
-                        Some("transaction")
-                    }
-                    // Either a ratification, or the transmission was not included in the block
-                    _ => None,
-                };
-
-                if let Some(transmission_type_string) = transmission_type {
-                    histogram_label(
-                        consensus::TRANSMISSION_LATENCY,
-                        "transmission_type",
-                        transmission_type_string.to_owned(),
-                        elapsed_time.as_secs_f64(),
-                    );
-                    Some(*transmission_id)
-                } else {
-                    None
-                }
+                None
             }
         })
         .collect::<Vec<_>>();


### PR DESCRIPTION
 ## Motivation                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            

`add_transmission_latency_metric` checks staleness before checking whether a transmission was included in the block. Because a tracker entry lingers from first-seen until it's either confirmed or ages out, any transmission that confirms after the 30-minute threshold takes the stale branch:

```
if elapsed > 30min  → count STALE_UNCONFIRMED, drop     ← runs first                                                                                                                                                                                                                                                                                      
else if in block    → record TRANSMISSION_LATENCY, drop ← never reached when old 
```                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
Two consequences, both wrong:                                                                                                                                                                                                                                                                                                                             
  - `TRANSMISSION_LATENCY` is silently truncated at 30 min — the slowest confirmations, exactly the tail you watch, never reach the histogram, biasing p99/max low.                                                                                                                                                                                           
  - `STALE_UNCONFIRMED_{SOLUTIONS,TRANSACTIONS}` is polluted with transmissions that did land in the block.  
  
It only surfaces under congestion / post-stall recovery (healthy-network confirmations are seconds), but those are precisely the moments the metric is supposed to be trustworthy.

## Test Plan

No unit test: the function is pure side-effects on the global metrics recorder (untestable without a recorder harness), and the post-fix precedence is self-evident — adding an abstraction solely to make it testable would bury a one-branch semantic fix. 

## Documentation

Observability-only — no consensus, liveness, or funds impact.

## Backwards compatibility

None affected — metric semantics only; no wire, storage, or protocol changes.
