### PR TITLE
Don't err or ip_ban when peers are ahead

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -687,7 +687,7 @@ impl<N: Network> Gateway<N> {
                             let err = err.context(format!("Peer sent an invalid block response '{peer_ip}'"));
 
                             let msg = flatten_error(&err);
-                            error!("{msg}");
+                            warn!("{msg}");
                             self.ip_ban_peer(peer_ip, Some(&msg));
                             Err(err)
                         }

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -682,12 +682,20 @@ impl<N: Network> Gateway<N> {
                             debug!("{}", flatten_error(err));
                             Ok(true)
                         }
-                        Err(err) if err.is_invalid_consensus_version() => {
+                        Err(err) if err.is_consensus_version_ahead() => {
+                            let err: anyhow::Error = err.into();
+                            let err = err.context(format!(
+                                "Peer sent a block response with a newer consensus version '{peer_ip}'"
+                            ));
+                            warn!("{}", flatten_error(&err));
+                            Ok(true)
+                        }
+                        Err(err) if err.is_consensus_version_behind() => {
                             let err: anyhow::Error = err.into();
                             let err = err.context(format!("Peer sent an invalid block response '{peer_ip}'"));
 
                             let msg = flatten_error(&err);
-                            warn!("{msg}");
+                            error!("{msg}");
                             self.ip_ban_peer(peer_ip, Some(&msg));
                             Err(err)
                         }

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -237,13 +237,19 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Client<N, C> {
                 debug!("{}", flatten_error(err.context(format!("Ignoring block response from peer '{peer_ip}'"))));
                 true
             }
-            Err(err) if err.is_invalid_consensus_version() => {
+            Err(err) if err.is_consensus_version_ahead() => {
+                let err: anyhow::Error = err.into();
+                let err = err.context(format!("Peer sent a block response with a newer consensus version '{peer_ip}'"));
+                warn!("{}", flatten_error(&err));
+                true
+            }
+            Err(err) if err.is_consensus_version_behind() => {
                 // If the error indicates the peer missed an upgrade and forked, ban it.
                 let err: anyhow::Error = err.into();
                 let err = err.context(format!("Peer sent an invalid block response '{peer_ip}'"));
 
                 let msg = flatten_error(&err);
-                warn!("{msg}");
+                error!("{msg}");
                 self.router().ip_ban_peer(peer_ip, Some(&err.to_string()));
 
                 false

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -243,7 +243,7 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Client<N, C> {
                 let err = err.context(format!("Peer sent an invalid block response '{peer_ip}'"));
 
                 let msg = flatten_error(&err);
-                error!("{msg}");
+                warn!("{msg}");
                 self.router().ip_ban_peer(peer_ip, Some(&err.to_string()));
 
                 false

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -133,9 +133,13 @@ pub enum InsertBlockResponseError<N: Network> {
     #[error("The peer did not send a consensus version")]
     NoConsensusVersion,
     #[error(
-        "The peer's consensus version for height {last_height} does not match ours: expected {expected_version}, got {peer_version}"
+        "The peer's consensus version for height {last_height} is ahead of ours: expected {expected_version}, got {peer_version}"
     )]
-    ConsensusVersionMismatch { peer_version: ConsensusVersion, expected_version: ConsensusVersion, last_height: u32 },
+    ConsensusVersionAhead { peer_version: ConsensusVersion, expected_version: ConsensusVersion, last_height: u32 },
+    #[error(
+        "The peer's consensus version for height {last_height} is behind ours: expected {expected_version}, got {peer_version}"
+    )]
+    ConsensusVersionBehind { peer_version: ConsensusVersion, expected_version: ConsensusVersion, last_height: u32 },
     #[error("Block Sync already advanced to block {height}")]
     BlockSyncAlreadyAdvanced { height: u32 },
     #[error("No such request for height {height}")]
@@ -160,9 +164,14 @@ impl<N: Network> InsertBlockResponseError<N> {
         matches!(self, Self::NoSuchRequest { .. } | Self::BlockSyncAlreadyAdvanced { .. })
     }
 
-    // Returns true if the error is about an invalid consensus version.
-    pub fn is_invalid_consensus_version(&self) -> bool {
-        matches!(self, Self::ConsensusVersionMismatch { .. } | Self::NoConsensusVersion)
+    // Returns true if the peer's consensus version is ahead of ours.
+    pub fn is_consensus_version_ahead(&self) -> bool {
+        matches!(self, Self::ConsensusVersionAhead { .. })
+    }
+
+    // Returns true if the peer's consensus version is behind ours or missing.
+    pub fn is_consensus_version_behind(&self) -> bool {
+        matches!(self, Self::ConsensusVersionBehind { .. } | Self::NoConsensusVersion)
     }
 }
 
@@ -662,10 +671,18 @@ impl<N: Network> BlockSync<N> {
             if expected_consensus_version >= ConsensusVersion::V12 {
                 if let Some(peer_version) = latest_consensus_version {
                     if peer_version != expected_consensus_version {
-                        break 'outer Err(InsertBlockResponseError::ConsensusVersionMismatch {
-                            peer_version,
-                            expected_version: expected_consensus_version,
-                            last_height,
+                        break 'outer Err(if peer_version > expected_consensus_version {
+                            InsertBlockResponseError::ConsensusVersionAhead {
+                                peer_version,
+                                expected_version: expected_consensus_version,
+                                last_height,
+                            }
+                        } else {
+                            InsertBlockResponseError::ConsensusVersionBehind {
+                                peer_version,
+                                expected_version: expected_consensus_version,
+                                last_height,
+                            }
                         });
                     }
                 } else {


### PR DESCRIPTION
## Motivation

Partially addresses https://github.com/ProvableHQ/snarkOS/issues/4326

Upgrades are valid behaviour.

Syncing nodes which didn't upgrade yet IP ban peers which did upgrade. That seems unfortunate because nodes often optimistically sync, so if 50% of the network didn't upgrade yet they may ban the other 50% and the chain will halt for `IP_BAN_TIME_IN_SECS = 300` seconds.