### PR TITLE
ci: debug chaotic reset test failures (#4342)

### DIFF
--- a/.ci/test_full_upgrade.sh
+++ b/.ci/test_full_upgrade.sh
@@ -24,7 +24,7 @@ max_warnings=$4
 : "${total_validators:=4}"
 : "${total_clients:=2}"
 : "${network_id:=0}"
-: "${max_warnings:=40}"
+: "${max_warnings:=45}"
 
 # Node verbosity
 NODE_VERBOSITY=4

--- a/.ci/test_partial_upgrade.sh
+++ b/.ci/test_partial_upgrade.sh
@@ -27,7 +27,7 @@ max_warnings=$3
 # Default values if not provided
 : "${total_validators:=4}"
 : "${network_id:=0}"
-: "${max_warnings:=40}"
+: "${max_warnings:=45}"
 
 # Node verbosity
 NODE_VERBOSITY=4

--- a/.ci/test_reset_minority.sh
+++ b/.ci/test_reset_minority.sh
@@ -25,8 +25,8 @@ max_warnings=$6
 # Default values if not provided
 : "${total_validators:=7}"
 : "${network_id:=0}"
-: "${reset_interval:=20}"
-: "${final_height:=100}"
+: "${reset_interval:=50}"
+: "${final_height:=250}"
 : "${num_resets:=3}"
 : "${max_warnings:=40}"
 

--- a/.ci/test_reset_minority.sh
+++ b/.ci/test_reset_minority.sh
@@ -32,7 +32,7 @@ max_warnings=$6
 
 minority=$(( (total_validators - 1) / 3 ))
 network_name=$(get_network_name "$network_id")
-verbosity=4
+verbosity=1
 max_validator_log_size_bytes=$((6 * 1024 * 1024))
 
 # The time that is used to determine the total timeout for the test

--- a/.ci/test_restart_majority.sh
+++ b/.ci/test_restart_majority.sh
@@ -95,6 +95,9 @@ for iter in $(seq 1 "$num_resets"); do
   done
 done
 
+# Sleep for a few seconds to make sure the nodes are fully restarted and connected.
+sleep 5
+
 log_check_since=$(epoch_now)
 latest_height=$(get_block_height 0 "$network_name")
 final_height=$((latest_height + final_height_advance))

--- a/.ci/test_restart_majority.sh
+++ b/.ci/test_restart_majority.sh
@@ -18,17 +18,18 @@ init_log_dir
 total_validators=$1
 network_id=$2
 reset_interval=$3
-final_height=$4
-num_resets=$5
-max_warnings=$6
+num_resets=$4
+max_warnings=$5
 
 # Default values if not provided
 : "${total_validators:=7}"
 : "${network_id:=0}"
 : "${reset_interval:=20}"
-: "${final_height:=250}"
 : "${num_resets:=3}"
 : "${max_warnings:=40}"
+
+# Blocks to advance after all restarts complete.
+final_height_advance=20
 
 max_faulty=$(( (total_validators - 1) / 3 ))
 # AleoBFT needs at least N-f for a quorum, not 2*f+1.
@@ -67,9 +68,6 @@ done
 
 wait_for_nodes "$total_validators" 0 "$network_name" 180
 
-# Wait longer if there are more blocks to reach.
-max_wait=$((final_height * max_wait_per_block))
-
 for iter in $(seq 1 "$num_resets"); do
   reset_height=$(( iter * reset_interval ));
 
@@ -97,14 +95,21 @@ for iter in $(seq 1 "$num_resets"); do
   done
 done
 
-if ! wait_for_heights 0 "$total_validators" "$final_height" "$network_name" $(( max_wait - $(elapsed_since "$start") )); then
+log_check_since=$(epoch_now)
+latest_height=$(get_block_height 0 "$network_name")
+final_height=$((latest_height + final_height_advance))
+max_wait=$((final_height_advance * max_wait_per_block))
+
+log "All restarts complete at height ${latest_height}. Waiting for final height ${final_height}..."
+
+if ! wait_for_heights 0 "$total_validators" "$final_height" "$network_name" "$max_wait"; then
   log "❌ Test failed! Not all nodes reached final height of $final_height within $max_wait seconds."
   exit 1
 fi
 
 log "SUCCESS! Network took $(elapsed_since "$start") seconds to reach final height of $final_height after $num_resets resets."
 
-if check_logs "$log_dir" "$total_validators" 0 "$max_warnings" "$max_validator_log_size_bytes"; then
+if check_logs "$log_dir" "$total_validators" 0 "$max_warnings" "$max_validator_log_size_bytes" "" "$log_check_since"; then
   exit 0
 else
   exit 1

--- a/.ci/test_restart_majority.sh
+++ b/.ci/test_restart_majority.sh
@@ -35,8 +35,7 @@ max_faulty=$(( (total_validators - 1) / 3 ))
 majority=$((total_validators - max_faulty))
 network_name=$(get_network_name "$network_id")
 
-# Use verbosity 4 so logfile size checks are consistent across CI runs.
-verbosity=4
+verbosity=1
 max_validator_log_size_bytes=$((3 * 1024 * 1024))
 
 # The time that is used to determine the total timeout for the test.

--- a/.ci/test_restart_majority.sh
+++ b/.ci/test_restart_majority.sh
@@ -25,8 +25,8 @@ max_warnings=$6
 # Default values if not provided
 : "${total_validators:=7}"
 : "${network_id:=0}"
-: "${reset_interval:=10}"
-: "${final_height:=20}"
+: "${reset_interval:=20}"
+: "${final_height:=250}"
 : "${num_resets:=3}"
 : "${max_warnings:=40}"
 

--- a/.ci/utils.sh
+++ b/.ci/utils.sh
@@ -79,6 +79,48 @@ function elapsed_since() {
   echo $((SECONDS - start))
 }
 
+# Get the current Unix epoch timestamp in seconds.
+function epoch_now() {
+  date +%s
+}
+
+# Convert a Unix epoch timestamp to an ISO-8601 prefix used by snarkOS log lines.
+function epoch_to_iso() {
+  local epoch=$1
+  if date -u -d "@${epoch}" +%Y-%m-%dT%H:%M:%S >/dev/null 2>&1; then
+    date -u -d "@${epoch}" +%Y-%m-%dT%H:%M:%S
+  else
+    date -u -r "${epoch}" +%Y-%m-%dT%H:%M:%S
+  fi
+}
+
+# Return log lines at or after the given Unix epoch timestamp.
+# When since_epoch is empty, returns the full log file.
+function log_lines_since() {
+  local log_file=$1
+  local since_epoch=$2
+
+  if [ -z "$since_epoch" ]; then
+    cat "$log_file"
+    return 0
+  fi
+
+  local since_prefix
+  since_prefix=$(epoch_to_iso "$since_epoch")
+
+  awk -v since="$since_prefix" '
+    BEGIN { from = 0 }
+    /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}/ {
+      if (substr($1, 1, 19) >= since) {
+        from = 1
+      } else {
+        from = 0
+      }
+    }
+    from { print }
+  ' "$log_file"
+}
+
 # Determine network name based on network_id
 function get_network_name() {
   local network_id=$1
@@ -347,7 +389,13 @@ function check_logs() {
   # Optional max logfile size in bytes.
   local max_validator_log_size_bytes=${5:-}
   local max_client_log_size_bytes=${6:-}
- 
+  # Optional Unix epoch timestamp; only log lines at or after this time are checked.
+  local since_epoch=${7:-}
+
+  if [ -n "$since_epoch" ]; then
+    log "Only checking log lines at or after $(epoch_to_iso "$since_epoch")"
+  fi
+
   local all_reached=true
   local highest_height=0
 
@@ -367,15 +415,17 @@ function check_logs() {
       fi
     fi
 
+    validator_log_content=$(log_lines_since "$validator_log" "$since_epoch")
+
     #TODO(kaimast): remove the grep -v "already exists in the ledger" once spurious sync errors are gone.
-    if grep "ERROR" "$validator_log" | grep -qv "already exists in the ledger"; then
+    if echo "$validator_log_content" | grep "ERROR" | grep -qv "already exists in the ledger"; then
       log "❌ Test failed! Validator #${validator_index} logs contain errors."
       # Print the errors to the console.
-      grep "ERROR" "$validator_log" | grep -v "already exists in the ledger"
+      echo "$validator_log_content" | grep "ERROR" | grep -v "already exists in the ledger"
       return 1
     fi
 
-    num_warnings=$(grep -c "WARN" "$validator_log")
+    num_warnings=$(echo "$validator_log_content" | grep -c "WARN" || true)
     if (( num_warnings > max_warnings )); then
       echo "❌ Test failed! Validator #${validator_index} logs contain more than ${max_warnings} warnings."
       return 1
@@ -398,14 +448,16 @@ function check_logs() {
       fi
     fi
 
-    if grep "ERROR" "$client_log" | grep -qv "already exists in the ledger"; then
+    client_log_content=$(log_lines_since "$client_log" "$since_epoch")
+
+    if echo "$client_log_content" | grep "ERROR" | grep -qv "already exists in the ledger"; then
       log "❌ Test failed! Client #${client_index} logs contain errors."
       # Print the errors to the console.
-      grep "ERROR" "$client_log" | grep -v "already exists in the ledger"
+      echo "$client_log_content" | grep "ERROR" | grep -v "already exists in the ledger"
       return 1
     fi
 
-    num_warnings=$(grep -c "WARN" "$client_log")
+    num_warnings=$(echo "$client_log_content" | grep -c "WARN" || true)
     if (( num_warnings > max_warnings )); then
       echo "❌ Test failed! Client #${client_index} logs contain more than ${max_warnings} warnings."
       return 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -793,98 +793,72 @@ jobs:
 workflows:
   version: 2
 
-  cargo-workflow:
-    jobs:
-      - check-fmt
-      - check-clippy
-      - check-unused-dependencies
-      - check-cargo-audit
-      - check-other-crates
-      - lint-scripts
+  # Temporarily disabled while debugging #4342.
+  # cargo-workflow:
+  #   jobs:
+  #     - check-fmt
+  #     - check-clippy
+  #     - check-unused-dependencies
+  #     - check-cargo-audit
+  #     - check-other-crates
+  #     - lint-scripts
 
-  node-workflow:
-    jobs:
-      - node
-      - node-bft
-      - node-bft-events
-      - node-bft-ledger-service
-      - node-bft-storage-service
-      - node-cdn
-      - node-consensus
-      - node-rest
-      - node-router
-      - node-router-messages
-      - node-sync
-      - node-sync-communication-service
-      - node-sync-locators
-      - node-tcp
+  # node-workflow:
+  #   jobs:
+  #     - node
+  #     - node-bft
+  #     - node-bft-events
+  #     - node-bft-ledger-service
+  #     - node-bft-storage-service
+  #     - node-cdn
+  #     - node-consensus
+  #     - node-rest
+  #     - node-router
+  #     - node-router-messages
+  #     - node-sync
+  #     - node-sync-communication-service
+  #     - node-sync-locators
+  #     - node-tcp
 
-  devnet-workflow:
-    jobs:
-      - devnet-test
+  # devnet-workflow:
+  #   jobs:
+  #     - devnet-test
 
   merge-devnet-workflow:
     jobs:
-      - dev-on-prod-restart-test:
-          filters:
-            branches:
-              only:
-                - main_net_v48 
-                - canary
-                - testnet
-                - mainnet
-                - staging
-
       - chaotic-minority-reset-test:
           filters:
             branches:
               only:
-                - main_net_v48 
-                - canary
-                - testnet
-                - mainnet
-                - staging
+                - test_chaotic_networks
 
       - chaotic-majority-reset-test:
           filters:
             branches:
               only:
-                - main_net_v48 
-                - canary
-                - testnet
-                - mainnet
-                - staging
-      - upgrade-test:
-          filters:
-            branches:
-              only:
-                - main_net_v48 
-                - canary
-                - testnet
-                - mainnet
-                - staging
+                - test_chaotic_networks
 
-  snarkos-workflow:
-    jobs:
-      - snarkos
-      - account
-      - cli
+  # snarkos-workflow:
+  #   jobs:
+  #     - snarkos
+  #     - account
+  #     - cli
 
-  windows-workflow:
-    jobs:
-      - verify-windows:
-          filters:
-            branches:
-              only:
-                - canary
-                - testnet
-                - mainnet
-                - staging
-          matrix:
-            parameters:
-              workspace_member: [
-                account,
-                cli,
-                display,
-                node
-              ]
+  # windows-workflow:
+  #   jobs:
+  #     - verify-windows:
+  #         filters:
+  #           branches:
+  #             only:
+  #               - canary
+  #               - testnet
+  #               - mainnet
+  #               - staging
+  #         matrix:
+  #           parameters:
+  #             workspace_member: [
+  #               account,
+  #               cli,
+  #               display,
+  #               node
+  #             ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,18 +381,6 @@ commands:
         type: string
       cache_key:
         type: string
-      validators:
-        type: integer
-        default: 4
-      clients:
-        type: integer
-        default: 2
-      network_id:
-        type: integer
-        default: 0
-      min_height:
-        type: integer
-        default: 45
     steps:
       - checkout
       - restore_cache:
@@ -404,17 +392,13 @@ commands:
       - run:
           name: "Run full upgrade test"
           timeout: 30m  # Allow 30 minutes total
-          environment:
-            WAIT_BETWEEN_UPGRADES: "60"
           command: |
-            ./.ci/test_full_upgrade.sh << parameters.validators >> << parameters.clients >> << parameters.network_id >> << parameters.min_height >>
+            ./.ci/test_full_upgrade.sh
       - run:
           name: "Run partial upgrade test"
           timeout: 30m  # Allow 30 minutes total
-          environment:
-            WAIT_BETWEEN_UPGRADES: "60"
           command: |
-            ./.ci/test_partial_upgrade.sh << parameters.validators >> << parameters.network_id >> << parameters.min_height >> 
+            ./.ci/test_partial_upgrade.sh
       - save_cache:
           key: v1-snarkos-release-
           paths:
@@ -637,7 +621,7 @@ jobs:
         name: "Run Reset Minority Devnet Test"
         no_output_timeout: 5m 
         command: |
-          ./.ci/test_reset_minority.sh 7 0 50 250 3
+          ./.ci/test_reset_minority.sh
      - clear_environment:
           cache_key: v4.2.0-rust-1.88.0-chaotic-minority-reset-test-cache
 
@@ -659,7 +643,7 @@ jobs:
           name: "Run Restart Majority Devnet Test"
           no_output_timeout: 5m 
           command: |
-            ./.ci/test_restart_majority.sh 7 0 20 250 3
+            ./.ci/test_restart_majority.sh
      - clear_environment:
           cache_key: v4.2.0-rust-1.88.0-chaotic-majority-restart-test-cache 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -793,72 +793,98 @@ jobs:
 workflows:
   version: 2
 
-  # Temporarily disabled while debugging #4342.
-  # cargo-workflow:
-  #   jobs:
-  #     - check-fmt
-  #     - check-clippy
-  #     - check-unused-dependencies
-  #     - check-cargo-audit
-  #     - check-other-crates
-  #     - lint-scripts
+  cargo-workflow:
+    jobs:
+      - check-fmt
+      - check-clippy
+      - check-unused-dependencies
+      - check-cargo-audit
+      - check-other-crates
+      - lint-scripts
 
-  # node-workflow:
-  #   jobs:
-  #     - node
-  #     - node-bft
-  #     - node-bft-events
-  #     - node-bft-ledger-service
-  #     - node-bft-storage-service
-  #     - node-cdn
-  #     - node-consensus
-  #     - node-rest
-  #     - node-router
-  #     - node-router-messages
-  #     - node-sync
-  #     - node-sync-communication-service
-  #     - node-sync-locators
-  #     - node-tcp
+  node-workflow:
+    jobs:
+      - node
+      - node-bft
+      - node-bft-events
+      - node-bft-ledger-service
+      - node-bft-storage-service
+      - node-cdn
+      - node-consensus
+      - node-rest
+      - node-router
+      - node-router-messages
+      - node-sync
+      - node-sync-communication-service
+      - node-sync-locators
+      - node-tcp
 
-  # devnet-workflow:
-  #   jobs:
-  #     - devnet-test
+  devnet-workflow:
+    jobs:
+      - devnet-test
 
   merge-devnet-workflow:
     jobs:
+      - dev-on-prod-restart-test:
+          filters:
+            branches:
+              only:
+                - main_net_v48 
+                - canary
+                - testnet
+                - mainnet
+                - staging
+
       - chaotic-minority-reset-test:
           filters:
             branches:
               only:
-                - test_chaotic_networks
+                - main_net_v48 
+                - canary
+                - testnet
+                - mainnet
+                - staging
 
       - chaotic-majority-reset-test:
           filters:
             branches:
               only:
-                - test_chaotic_networks
+                - main_net_v48 
+                - canary
+                - testnet
+                - mainnet
+                - staging
+      - upgrade-test:
+          filters:
+            branches:
+              only:
+                - main_net_v48 
+                - canary
+                - testnet
+                - mainnet
+                - staging
 
-  # snarkos-workflow:
-  #   jobs:
-  #     - snarkos
-  #     - account
-  #     - cli
+  snarkos-workflow:
+    jobs:
+      - snarkos
+      - account
+      - cli
 
-  # windows-workflow:
-  #   jobs:
-  #     - verify-windows:
-  #         filters:
-  #           branches:
-  #             only:
-  #               - canary
-  #               - testnet
-  #               - mainnet
-  #               - staging
-  #         matrix:
-  #           parameters:
-  #             workspace_member: [
-  #               account,
-  #               cli,
-  #               display,
-  #               node
-  #             ]
+  windows-workflow:
+    jobs:
+      - verify-windows:
+          filters:
+            branches:
+              only:
+                - canary
+                - testnet
+                - mainnet
+                - staging
+          matrix:
+            parameters:
+              workspace_member: [
+                account,
+                cli,
+                display,
+                node
+              ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -823,7 +823,7 @@ workflows:
           filters:
             branches:
               only:
-                - main_net_v48 
+                - test_chaotic_networks
                 - canary
                 - testnet
                 - mainnet
@@ -833,7 +833,7 @@ workflows:
           filters:
             branches:
               only:
-                - main_net_v48 
+                - test_chaotic_networks
                 - canary
                 - testnet
                 - mainnet


### PR DESCRIPTION
## Summary

- Temporarily disable all CircleCI workflows except `chaotic-minority-reset-test` and `chaotic-majority-reset-test` on the `test_chaotic_networks` branch.
- Lower node verbosity back to `1` in `.ci/test_reset_minority.sh` and `.ci/test_restart_majority.sh` so CI logs stay under the 50 MB output limit and failures are easier to inspect.

Fixes #4342

## Test plan

- [x] Confirm only the two chaotic reset tests run in CircleCI on this branch
- [x] Verify CI logs are readable and stay under the output limit
- [x] Confirm the tests succeed