### PR TITLE
[Fix] Abort the FD monitor task on shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,6 +366,12 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base16ct"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
@@ -828,12 +834,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1011,18 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
@@ -1160,7 +1172,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "zeroize",
 ]
 
@@ -1170,7 +1182,6 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
- "const-oid 0.10.2",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1236,6 +1247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1247,9 +1259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid 0.10.2",
  "crypto-common 0.2.2",
- "ctutils",
 ]
 
 [[package]]
@@ -1318,16 +1328,15 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.16"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91bbdd377139884fafcad8dc43a760a3e1e681aa26db910257fa6535b70e1829"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.8.0",
- "digest 0.11.3",
- "elliptic-curve",
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.8",
  "rfc6979",
- "signature 3.0.0",
- "zeroize",
+ "signature",
 ]
 
 [[package]]
@@ -1337,7 +1346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "signature 2.2.0",
+ "signature",
 ]
 
 [[package]]
@@ -1350,7 +1359,7 @@ dependencies = [
  "ed25519",
  "serde",
  "sha2 0.10.9",
- "signature 2.2.0",
+ "signature",
  "subtle",
  "zeroize",
 ]
@@ -1363,19 +1372,33 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
 version = "0.14.0-rc.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e84043d573efd4ac9d2d125817979a379204bf7e328b25a4a30487e8d100e618"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.5",
  "crypto-common 0.2.2",
- "digest 0.11.3",
  "hybrid-array",
  "rand_core 0.10.1",
- "rustcrypto-ff",
- "rustcrypto-group",
- "sec1",
  "subtle",
  "zeroize",
 ]
@@ -1509,6 +1532,16 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "fiat-crypto"
@@ -1740,6 +1773,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1835,6 +1869,17 @@ dependencies = [
  "smallvec",
  "spinning_top",
  "web-time",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1961,11 +2006,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.13.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.11.3",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2540,14 +2585,14 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-rc.8"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2c6c227649d5ec80eaae541f1736232641a0bcdb3062a52b34edb42054158"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
- "cpubits",
+ "cfg-if",
  "ecdsa",
- "elliptic-curve",
- "sha2 0.11.0",
+ "elliptic-curve 0.13.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3985,9 +4030,9 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.5.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5236ce872cac07e0fb3969b0cbf468c7d2f37d432f1b627dcb7b8d34563fb0c3"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
@@ -4066,27 +4111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustcrypto-ff"
-version = "0.14.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
-dependencies = [
- "rand_core 0.10.1",
- "subtle",
-]
-
-[[package]]
-name = "rustcrypto-group"
-version = "0.14.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "369f9b61aa45933c062c9f6b5c3c50ab710687eca83dd3802653b140b43f85ed"
-dependencies = [
- "rand_core 0.10.1",
- "rustcrypto-ff",
- "subtle",
 ]
 
 [[package]]
@@ -4278,14 +4302,13 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
-version = "0.8.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "ctutils",
- "der 0.8.0",
- "hybrid-array",
+ "base16ct 0.2.0",
+ "der 0.7.10",
+ "generic-array",
  "subtle",
  "zeroize",
 ]
@@ -4563,16 +4586,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
-dependencies = [
- "digest 0.11.3",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4664,8 +4677,8 @@ version = "4.8.0"
 dependencies = [
  "built",
  "clap",
- "crypto-bigint",
- "elliptic-curve",
+ "crypto-bigint 0.7.5",
+ "elliptic-curve 0.14.0-rc.29",
  "locktick",
  "rusty-hook",
  "snarkos-account",
@@ -5148,7 +5161,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.8.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -5173,7 +5186,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5201,7 +5214,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "blst",
  "cc",
@@ -5212,7 +5225,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5226,7 +5239,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -5236,7 +5249,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -5246,7 +5259,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -5256,7 +5269,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5276,12 +5289,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -5292,7 +5305,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5306,7 +5319,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -5321,7 +5334,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5334,7 +5347,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -5343,7 +5356,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5353,7 +5366,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5365,7 +5378,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5377,7 +5390,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5388,7 +5401,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5400,7 +5413,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -5413,7 +5426,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -5424,7 +5437,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -5440,7 +5453,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "aleo-std",
  "locktick",
@@ -5454,7 +5467,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -5474,7 +5487,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "anyhow",
  "bech32",
@@ -5492,7 +5505,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -5513,7 +5526,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -5528,7 +5541,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5539,7 +5552,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -5547,7 +5560,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5557,7 +5570,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5568,7 +5581,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5579,7 +5592,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5590,7 +5603,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5601,7 +5614,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "rand 0.10.1",
  "rustc_version",
@@ -5614,7 +5627,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5631,7 +5644,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5664,7 +5677,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "anyhow",
  "rand 0.10.1",
@@ -5676,7 +5689,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5700,7 +5713,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5719,7 +5732,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -5732,7 +5745,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5745,7 +5758,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5757,7 +5770,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5768,7 +5781,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5783,7 +5796,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5796,7 +5809,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -5805,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5826,7 +5839,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5849,7 +5862,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5866,7 +5879,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -5895,7 +5908,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5913,7 +5926,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "metrics",
 ]
@@ -5921,7 +5934,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5944,7 +5957,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-slipstream-plugin-interface"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "anyhow",
 ]
@@ -5952,7 +5965,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-slipstream-plugin-manager"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "anyhow",
  "json5",
@@ -5966,7 +5979,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6002,7 +6015,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-error"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-environment",
@@ -6014,7 +6027,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "aleo-std",
  "colored 3.1.1",
@@ -6041,7 +6054,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "enum-iterator",
  "indexmap 2.14.0",
@@ -6062,7 +6075,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "bincode",
  "serde_json",
@@ -6075,7 +6088,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6098,7 +6111,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=2021b4498#2021b4498c24fec3543bc4c06e30733b660cee48"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=de1886036c45e4d5ebc46a16c909a4d275a8dc47#de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 dependencies = [
  "proc-macro2",
  "quote 1.0.46",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "2021b4498"
+rev = "de1886036c45e4d5ebc46a16c909a4d275a8dc47"
 #version = "=4.7.3"
 
 [workspace.dependencies.anyhow]

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -341,7 +341,7 @@ impl Start {
 
             // Periodically check if the number of file descriptors isn't becoming insufficient.
             #[cfg(unix)]
-            crate::helpers::spawn_fd_monitor();
+            let fd_check_handle = crate::helpers::spawn_fd_monitor();
 
             // Clone the configurations.
             let mut self_ = self.clone();
@@ -359,6 +359,9 @@ impl Start {
                 }
                 _ => panic!("Invalid network ID specified"),
             };
+
+            #[cfg(unix)]
+            fd_check_handle.abort();
 
             Ok(String::new())
         })

--- a/cli/src/helpers/fd_check.rs
+++ b/cli/src/helpers/fd_check.rs
@@ -15,7 +15,10 @@
 
 use std::io;
 
-use tokio::time::{Duration, MissedTickBehavior, interval};
+use tokio::{
+    task,
+    time::{Duration, MissedTickBehavior, interval},
+};
 use tracing::*;
 
 /// Node-scale fd use.
@@ -129,7 +132,7 @@ pub fn system_fd_usage() -> std::io::Result<SystemFd> {
     Ok(SystemFd { allocated: read(cur_oid)?, max: read(max_oid)? })
 }
 
-pub fn spawn_fd_monitor() {
+pub fn spawn_fd_monitor() -> task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut tick = interval(Duration::from_secs(30));
         tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -193,5 +196,5 @@ pub fn spawn_fd_monitor() {
                 Err(e) => error!(error = %e, "system fd probe failed"),
             }
         }
-    });
+    })
 }

--- a/node/src/traits.rs
+++ b/node/src/traits.rs
@@ -61,10 +61,15 @@ pub trait NodeInterface<N: Network>: Routing<N> {
         // Check if there are any stragglers left.
         if let Some(handle) = &handler.handle {
             let live_tasks = handle.metrics().num_alive_tasks();
-            // The 1 "extra" task comes from the FD monitor, which is aborted once
-            // wait_for_signals concludes its work.
-            if live_tasks != 1 {
-                error!("There are still {} live tasks", live_tasks - 1);
+            let expected_leftover = if cfg!(unix) {
+                // The 1 "extra" task comes from the FD monitor, which is aborted once
+                // wait_for_signals concludes its work.
+                1
+            } else {
+                0
+            };
+            if live_tasks > expected_leftover {
+                error!("There are {} surplus live tasks", live_tasks - expected_leftover);
             }
         }
     }

--- a/node/src/traits.rs
+++ b/node/src/traits.rs
@@ -61,8 +61,10 @@ pub trait NodeInterface<N: Network>: Routing<N> {
         // Check if there are any stragglers left.
         if let Some(handle) = &handler.handle {
             let live_tasks = handle.metrics().num_alive_tasks();
-            if live_tasks != 0 {
-                error!("There are still {live_tasks} live tasks");
+            // The 1 "extra" task comes from the FD monitor, which is aborted once
+            // wait_for_signals concludes its work.
+            if live_tasks != 1 {
+                error!("There are still {} live tasks", live_tasks - 1);
             }
         }
     }


### PR DESCRIPTION
It looks like a bit of a hack (the code checks against a `1` instead of `0` now), but the FD checker is a lower-layer resource, and we wouldn't gain anything by having its handle traverse all the `Node` creation APIs - or by pulling out the current shutdown plumbing.

I checked locally that both the `ERROR` is gone, and that the FD checker task gets explicitly aborted on shutdown (which already happens implicitly).

Fixes https://github.com/ProvableHQ/snarkOS/issues/4326.