### PR TITLE
Use transaction compute spend helper

### DIFF
--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -43,10 +43,7 @@ use snarkvm::{
         bail,
         cfg_into_iter,
         consensus_config_value_by_version,
-        deploy_compute_cost_in_microcredits,
-        deployment_cost,
-        execute_compute_cost_in_microcredits,
-        execution_cost,
+        transaction_compute_spend_in_microcredits,
     },
 };
 
@@ -543,32 +540,15 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
         let transaction_spend_limit =
             consensus_config_value_by_version!(N, TRANSACTION_SPEND_LIMIT, consensus_version).unwrap();
         let id = transaction.id();
-        match transaction {
-            Transaction::Deploy(_, _, _, deployment, _) => {
-                let (_, cost_details) = deployment_cost(self.ledger.vm().process(), deployment, consensus_version)?;
-                let compute_spend = deploy_compute_cost_in_microcredits(cost_details, consensus_version);
-                ensure!(
-                    compute_spend <= transaction_spend_limit,
-                    "Transaction '{id}' exceeds the transaction spend limit with compute_spend: '{compute_spend}'"
-                );
-                Ok(compute_spend)
-            }
-            Transaction::Execute(_, _, execution, _) => {
-                let (_, cost_details) = execution_cost(self.ledger.vm().process(), execution, consensus_version)?;
-                let compute_spend = execute_compute_cost_in_microcredits(cost_details, consensus_version);
-                if consensus_version >= ConsensusVersion::V11 {
-                    // From V11, add this check for consistency with our deployment checks.
-                    ensure!(
-                        compute_spend <= transaction_spend_limit,
-                        "Transaction '{id}' exceeds the transaction spend limit with compute_spend: '{compute_spend}'"
-                    );
-                }
-                Ok(compute_spend)
-            }
-            Transaction::Fee(..) => {
-                bail!("Fee transactions are internal to the VM, transaction {id} is invalid.")
-            }
-        }
+
+        let compute_spend =
+            transaction_compute_spend_in_microcredits(self.ledger.vm().process(), transaction, consensus_version)?;
+        ensure!(
+            compute_spend <= transaction_spend_limit,
+            "Transaction '{id}' exceeds the transaction spend limit with compute_spend: '{compute_spend}'"
+        );
+
+        Ok(compute_spend)
     }
 
     fn is_stopped(&self) -> bool {


### PR DESCRIPTION
## Motivation

DRYing things up, see #4253 

## Test Plan

Relying on existing tests.

## Documentation

N/A

## Backwards compatibility

Logic should be identical so no backwards compatibility issues expected.