### PR TITLE
Remove thread pool starvation

### DIFF
--- a/node/bft/src/helpers/telemetry.rs
+++ b/node/bft/src/helpers/telemetry.rs
@@ -18,7 +18,7 @@ use snarkvm::{
         committee::Committee,
         narwhal::{BatchCertificate, BatchHeader, Subdag},
     },
-    prelude::{Address, Field, Network, cfg_chunks, cfg_iter},
+    prelude::{Address, Field, Network, cfg_iter},
 };
 
 use indexmap::{IndexMap, IndexSet};
@@ -46,7 +46,39 @@ use std::{collections::BTreeMap, sync::Arc};
 ///     Combined Score: The weighted score using the certificate and signature scores
 type ParticipationScores = (f64, f64, f64);
 
+/// The metadata of a certificate that the telemetry tracker keeps track of.
+///
+/// This is derived before acquiring any of the tracker's locks, so that the (relatively expensive)
+/// recovery of the signer addresses can be done in parallel without holding a lock.
+struct CertificateMetadata<N: Network> {
+    /// The round of the certificate.
+    round: u64,
+    /// The ID of the certificate.
+    id: Field<N>,
+    /// The author of the certificate.
+    author: Address<N>,
+    /// The author of the certificate, followed by the address of each of its signers.
+    signers: Vec<Address<N>>,
+}
+
+impl<N: Network> CertificateMetadata<N> {
+    fn new(certificate: &BatchCertificate<N>) -> Self {
+        let author = certificate.author();
+        let signers = [author]
+            .into_iter()
+            .chain(certificate.signatures().map(|signature| signature.to_address()))
+            .collect::<Vec<_>>();
+
+        Self { round: certificate.round(), id: certificate.id(), author, signers }
+    }
+}
+
 /// Tracker for the participation metrics of validators.
+///
+/// Note: none of the locks below may be acquired inside a parallel iterator, and none of them may
+/// be held while running one. The rayon thread pool has a fixed number of workers, so a parallel
+/// iterator that blocks on one of these locks can occupy every worker, which in turn prevents the
+/// lock holder's own parallel iterator from ever being scheduled.
 #[derive(Clone, Debug)]
 pub struct Telemetry<N: Network> {
     /// The certificates seen for each round
@@ -110,13 +142,14 @@ impl<N: Network> Telemetry<N> {
         let next_gc_round = subdag.anchor_round().saturating_sub(BatchHeader::<N>::MAX_GC_ROUNDS as u64);
         self.garbage_collect_certificates(next_gc_round);
 
-        // Insert the subdag certificates.
-        cfg_iter!(subdag).for_each(|(_round, certificates)| {
-            cfg_iter!(certificates).for_each(|certificate| {
-                // TODO (raychu86): Can be greatly optimized by doing a one-shot update instead of individual certificates.
-                self.insert_certificate(certificate);
-            })
-        });
+        // Derive the metadata of each certificate in parallel, before acquiring any lock.
+        // Recovering the address of a signer is expensive, so this is the bulk of the work here.
+        let certificates: Vec<_> = subdag.values().flatten().collect();
+        let metadata: Vec<_> =
+            cfg_iter!(certificates).map(|certificate| CertificateMetadata::new(certificate)).collect();
+
+        // Insert the subdag certificates in a single pass.
+        self.insert_certificate_metadata(&metadata);
 
         // Calculate the participation scores.
         self.update_participation_scores();
@@ -124,42 +157,35 @@ impl<N: Network> Telemetry<N> {
 
     /// Insert a certificate to the telemetry tracker.
     pub fn insert_certificate(&self, certificate: &BatchCertificate<N>) {
-        // Acquire the lock for `tracked_certificates`.
+        self.insert_certificate_metadata(&[CertificateMetadata::new(certificate)]);
+    }
+
+    /// Insert the metadata of the given certificates to the telemetry tracker.
+    fn insert_certificate_metadata(&self, metadata: &[CertificateMetadata<N>]) {
+        // Acquire the locks, in the same order as in `garbage_collect_certificates`.
         let mut tracked_certificates = self.tracked_certificates.write();
-
-        // Retrieve the certificate round, author, and ID.
-        let certificate_round = certificate.round();
-        let certificate_author = certificate.author();
-        let certificate_id = certificate.id();
-
-        // If the certificate already exists in the tracker, then return early.
-        if tracked_certificates.get(&certificate_round).is_some_and(|certs| certs.contains(&certificate_id)) {
-            return;
-        }
-
-        // Insert the certificate ID.
-        tracked_certificates.entry(certificate_round).or_default().insert(certificate_id);
-
-        // Acquire the lock for `validator_signatures`
         let mut validator_signatures = self.validator_signatures.write();
-
-        // Insert the certificate author and signers.
-        for address in
-            [certificate_author].into_iter().chain(certificate.signatures().map(|signature| signature.to_address()))
-        {
-            validator_signatures
-                .entry(address)
-                .or_default()
-                .entry(certificate_round)
-                .and_modify(|count| *count += 1)
-                .or_insert(1);
-        }
-
-        // Acquire the lock for `validator_certificates`.
         let mut validator_certificates = self.validator_certificates.write();
 
-        // Insert the certificate
-        validator_certificates.entry(certificate_author).or_default().insert(certificate_round);
+        for metadata in metadata {
+            // If the certificate already exists in the tracker, then skip it.
+            if !tracked_certificates.entry(metadata.round).or_default().insert(metadata.id) {
+                continue;
+            }
+
+            // Insert the certificate author and signers.
+            for address in &metadata.signers {
+                validator_signatures
+                    .entry(*address)
+                    .or_default()
+                    .entry(metadata.round)
+                    .and_modify(|count| *count += 1)
+                    .or_insert(1);
+            }
+
+            // Insert the certificate
+            validator_certificates.entry(metadata.author).or_default().insert(metadata.round);
+        }
     }
 
     /// Calculate and update the participation scores for each validator.
@@ -175,6 +201,7 @@ impl<N: Network> Telemetry<N> {
         }
 
         // Fetch the certificates and signatures.
+        // Note: the work below is intentionally serial, as it is done while holding these locks.
         let tracked_certificates = self.tracked_certificates.read();
         let validator_signatures = self.validator_signatures.read();
         let validator_certificates = self.validator_certificates.read();
@@ -183,7 +210,8 @@ impl<N: Network> Telemetry<N> {
         let total_certificates = validator_certificates.values().map(|rounds| rounds.len()).sum::<usize>();
 
         // Calculate the signature participation scores for each validator.
-        let signature_participation_scores: IndexMap<_, _> = cfg_iter!(&*validator_signatures)
+        let signature_participation_scores: IndexMap<_, _> = validator_signatures
+            .iter()
             .map(|(address, signatures)| {
                 let total_signatures = signatures.values().sum::<u32>() as f64;
                 let score = total_signatures / total_certificates as f64 * 100.0;
@@ -194,10 +222,12 @@ impl<N: Network> Telemetry<N> {
         // Calculate the certificate participation scores for each validator.
         // This score is based on how many certificates the validator has included in every two rounds.
         let tracked_rounds: Vec<_> = tracked_certificates.keys().skip_while(|r| *r % 2 == 0).copied().collect();
-        let certificate_participation_scores: IndexMap<_, _> = cfg_iter!(&*validator_certificates)
+        let certificate_participation_scores: IndexMap<_, _> = validator_certificates
+            .iter()
             .map(|(address, certificate_rounds)| {
                 // Count the number of round pairs that are included in the certificate rounds.
-                let num_included_round_pairs = cfg_chunks!(&tracked_rounds, 2)
+                let num_included_round_pairs = tracked_rounds
+                    .chunks(2)
                     .filter(|chunk| chunk.iter().any(|r| certificate_rounds.contains(r)))
                     .count();
                 // Calculate the number of round pairs.
@@ -218,6 +248,9 @@ impl<N: Network> Telemetry<N> {
             let combined_score = weighted_score(certificate_score, signature_score);
             new_participation_scores.insert(address, (certificate_score, signature_score, combined_score));
         }
+
+        // Release the locks before updating the participation scores.
+        drop((tracked_certificates, validator_signatures, validator_certificates));
 
         // Update the participation scores.
         *self.participation_scores.write() = new_participation_scores;
@@ -287,6 +320,32 @@ mod tests {
             telemetry.insert_certificate(certificate);
         }
         assert_eq!(telemetry.tracked_certificates.read().get(&current_round).unwrap().len(), certificates.len());
+    }
+
+    #[test]
+    fn test_insert_duplicate_certificate() {
+        let rng = &mut TestRng::default();
+
+        // Initialize the telemetry tracker.
+        let telemetry = Telemetry::<CurrentNetwork>::new();
+
+        // Set the current round.
+        let current_round = 2;
+
+        // Sample a certificate.
+        let certificate = sample_batch_certificate_for_round(current_round, rng);
+
+        // Insert the certificate, and snapshot the tracked signatures.
+        telemetry.insert_certificate(&certificate);
+        let validator_signatures = telemetry.validator_signatures.read().clone();
+
+        // Insert the same certificate again.
+        telemetry.insert_certificate(&certificate);
+
+        // Ensure the certificate and its signatures were only counted once.
+        assert_eq!(telemetry.tracked_certificates.read().get(&current_round).unwrap().len(), 1);
+        assert_eq!(*telemetry.validator_signatures.read(), validator_signatures);
+        assert_eq!(telemetry.validator_certificates.read().get(&certificate.author()).unwrap().len(), 1);
     }
 
     #[test]

--- a/node/metrics/src/lib.rs
+++ b/node/metrics/src/lib.rs
@@ -121,7 +121,11 @@ pub fn add_transmission_latency_metric<N: Network>(
     let ts_now = OffsetDateTime::now_utc().unix_timestamp();
 
     // Determine which keys to remove.
-    let keys_to_remove = cfg_iter!(&*transmissions_tracker)
+    // Note: this is intentionally serial, as it is done while holding the lock above. A parallel
+    // iterator that blocks on a lock can occupy every worker of the rayon thread pool, which in
+    // turn prevents the lock holder's own parallel iterator from ever being scheduled.
+    let keys_to_remove = transmissions_tracker
+        .iter()
         .flat_map(|(transmission_id, timestamp)| {
             let elapsed_time = std::time::Duration::from_secs((ts_now - *timestamp) as u64);
 


### PR DESCRIPTION
## Motivation

A validator halted and/or stopped reporting metrics, printing this on repeat:
```
│2026-07-29T11:29:26.232703Z  INFO [locktick] checking for active lock guards                                                                           │
│2026-07-29T11:29:26.233098Z  INFO [locktick] /home/ubuntu/snarkOS/node/bft/src/bft.rs@602:53 (Lock): 39; 1 active; 18 waiting; avg d: 368.549535ms; avg│
│2026-07-29T11:29:26.233110Z  INFO [locktick] /home/ubuntu/snarkOS/node/bft/src/helpers/telemetry.rs@128:40 (Write): 5034; 0 active; 32 waiting; avg d: │
│2026-07-29T11:29:26.233113Z  INFO [locktick] /home/ubuntu/snarkOS/node/bft/src/helpers/telemetry.rs@178:36 (Read): 98; 1 active; 0 waiting; avg d: 1.54│
│2026-07-29T11:29:26.233116Z  INFO [locktick] /home/ubuntu/snarkOS/node/bft/src/helpers/telemetry.rs@179:36 (Read): 98; 1 active; 0 waiting; avg d: 1.48│
│2026-07-29T11:29:26.233118Z  INFO [locktick] /home/ubuntu/snarkOS/node/bft/src/helpers/telemetry.rs@180:38 (Read): 98; 1 active; 0 waiting; avg d: 1.41│
│2026-07-29T11:29:26.233122Z  INFO [locktick] /home/ubuntu/snarkOS/node/bft/src/primary.rs@475:69 (Write): 23; 1 active; 0 waiting; avg d: 114.098573ms;│
│2026-07-29T11:29:26.233126Z  INFO [locktick] /home/ubuntu/snarkOS/node/bft/src/sync/mod.rs@538:47 (Lock): 1; 1 active; 0 waiting; avg d: 0ns; avg w: 15│
│2026-07-29T11:29:26.233137Z  INFO [locktick] /home/ubuntu/snarkOS/node/bft/src/sync/mod.rs@375:34 (Lock): 2; 1 active; 0 waiting; avg d: 9.626086953s; │
│2026-07-29T11:29:26.233154Z DEBUG [locktick] finished the check in 430.4µs                                                                             │
```

Opus 5 believes:

The deadlock wasn't a lock-ordering cycle between two locks — it was the rayon thread pool starving itself through the telemetry locks.

## The cycle
Telemetry::update_participation_scores took read guards on all three trackers and then ran rayon parallel iterators while holding them:
```
let tracked_certificates = self.tracked_certificates.read();   // line 178
let validator_signatures = self.validator_signatures.read();   // line 179
let validator_certificates = self.validator_certificates.read(); // line 180
```
...
let signature_participation_scores: IndexMap<_, _> = cfg_iter!(&*validator_signatures)   // line 186
Meanwhile Telemetry::insert_subdag did the opposite: it fanned certificates out over rayon and acquired a write guard on the same lock inside each closure (insert_certificate, line 128). cfg_iter! expands to par_iter(), so both of these run on the single global pool, which is built with a fixed num_cpus workers in cli/src/commands/start.rs:

```
start.rs
Lines 993-997
rayon::ThreadPoolBuilder::new()
    .stack_size(8 * 1024 * 1024)
    .num_threads(num_rayon_cores_global)
    .build_global()
    .unwrap();
```

So: thread A is inside update_participation_scores, holding the three read guards, blocked waiting for its par_iter jobs to be picked up. Every worker in the pool is blocked in tracked_certificates.write() on behalf of a different, concurrent insert_subdag. Those writes can't be granted until A drops its read guards, and A can't proceed until a worker becomes free. Nothing breaks the tie, forever.

Your log says exactly this. All three read sites report 1 active simultaneously, so one thread is sitting past line 180 with all three guards. Line 128 reports 32 waiting, which is the whole pool parked on that one write lock — a worker count, not a coincidence.

The two concurrent insert_subdag calls come from the only two callers, and both appear wedged in the log: the BFT commit path at node/bft/src/bft.rs:804 (which is why bft.rs@602, the commit_lock, shows 1 active; 18 waiting) and the bootup/post-sync path at node/bft/src/sync/mod.rs:449 (which is why sync/mod.rs@375, the pending_blocks mutex, shows avg d: 9.6s, and why response_lock at sync/mod.rs@538 is still held). Everything else in that log, including propose_batch's latest_proposal_timestamp write at primary.rs@475, is downstream fallout rather than a cause.

## Why it surfaced now rather than always
It needs two insert_subdag calls overlapping, which happens when the sync path is replaying blocks at the same time as the BFT is committing. Note that telemetry is on by default for the node binary (root Cargo.toml:272), so this is live in production builds, not just a feature-gated experiment.

