### PR TITLE
[WIP] Gracefully handle nodes that now prune historical blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5179,8 +5179,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea37705e6ba5f11a8da0f61393ba14aa320fcaf9fb410dff835c396ba20283a"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -5205,8 +5204,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c2d54fee12c2bb1c58ef9a46be861f4b0b07285046b67918ce8ca61757d9a70"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5234,8 +5232,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e5bbfecfeae202f2be87042979cd898fda3fd31af6fa4a544987a029764373"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "blst",
  "cc",
@@ -5246,8 +5243,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e67a5337192cb95713736c724e4209c82b73c8ca2208033b80efc9d9e0d1dfe"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5261,8 +5257,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f096425d431e6f3b6bd190756016464cee1627435d043ee1edcd2fd368a96e5d"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -5272,8 +5267,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3620f97ce1946468e0771bf6f5c2cd4cad53835e65a6369556813e364e61f26e"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -5283,8 +5277,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb124eb7120d08fdf493248a1b0a992549b6c3c0d6a5952f7ccd4cfb39f9e88"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -5294,8 +5287,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eedb2cc4f93b8ecda8c1f05a4faaac10e55127f0fc09d7749dfc610d4bcbaa0f"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5315,14 +5307,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2351fbdbb775fc850617ab0043b1b0033a47a6151b5bf516cc49c3c883b08a3"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "292c9506df0d1ec32dd4ef58d52e56716b6ccd3ca4ce4769852afeeb47856b5e"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -5333,8 +5323,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df200abab8279b37fc386fb419e0bcdb83efa8ba291e8d62a893427d7f23d4b1"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5348,8 +5337,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f0060b2c07f80a26b0f9547ef040f47b1c37c6aa5adb1983a19c144e091518"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -5364,8 +5352,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f104b0d3c7637f37d8abeb743c8ba31a518127ce0117b190879e0fac48c933d0"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5378,8 +5365,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad042be95bb0b5c9545ac3a12f9f3fde852f1167481d47d1c13a3aae3cdcdb9"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -5388,8 +5374,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65d5d37de0ae246a7f734c1d897c4b8eb9f5df7a1fdddf420ac65d3b64a4bcf5"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5399,8 +5384,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dcf26d059063dc16a37f3a923583c66899ec13d52a0e86c8fa141d78e776e02"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5412,8 +5396,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d83fd4b20ee4f964bb1c40459d67e0741872f56197898b45df8e86e639926c"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5425,8 +5408,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8b1a4e94e49487f02d8b308e03d6c56f50dbb5a1441ad3a74f04f6ba745b4b"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5437,8 +5419,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "665506fbf883d0aa0b152b06b324a609841742064a88dc9a355753ed90da57d8"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5450,8 +5431,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b611f443daa6140f2c5bbdf5d184567f2b88cf73be5d7160500c3a5d56ca209f"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -5464,8 +5444,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9adbf603ba5930c02d18bdd748c14418c2bbaf4bf6041f786571d510eac5db21"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -5476,8 +5455,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb693083ea8c9d1ed2a71880730b7251410aa45003602c16f89fbcda8b9ba860"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -5494,8 +5472,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad460b844a736bae3f4fadb393313d2c2c7cdbdce3d228d8c339cec387251011"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "aleo-std",
  "locktick",
@@ -5509,8 +5486,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97bc1b423cf6304ab4f35a71b995be7bf9c5429bed1f92578a212c933b161f84"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -5530,8 +5506,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "272b60c9c736f7cc4aec0ad66ff960ddaa575657e4c5fcc6a69207ba60fb19cc"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -5549,8 +5524,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26501fe0d11bb0601267efb42ca51c495ad86793878a1747cf16ed097b0f1342"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -5571,8 +5545,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da6c236d32f2f37b430d4d6ef134ff9395cb35f16c8af6bd4e0fb388ae1195f7"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -5587,8 +5560,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ee19a161735abffdea99051ed7200c0fae13201ab57dc2f375a9403bd1bb11"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5599,8 +5571,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649f21d68e74d94c28936fd01b53e2acd7d26c31d01a894497bbf6f41b05c4bd"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -5608,8 +5579,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a004d12492258c3e6e9847d8b6b2462c3c03721c5f643c338a93f08f97ef3ad"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5619,8 +5589,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977fcf939d3d2f1398d041ede04dd1ed4eed82febc6ea91e41e0ef26d1a11b01"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5631,8 +5600,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ceaca4e72d54890d115a05d3798c5d3d8e785aedf471cb5d47aa80ac3a7169b"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5643,8 +5611,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50234ae5b7cbeb042d5c768d821c555b649df36f3c0bbf5d2d053639a67274b0"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5655,8 +5622,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b42f0e1b1730ab805ba02c4a2f30a31bdd62600301d23913399675aa896346"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5667,8 +5633,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7e845865d40b36069fa76ef88a9e78f7f9c33f64c4e19f7cfd601922fab702"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "rand 0.10.2",
  "rustc_version",
@@ -5681,8 +5646,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4121086d60733b44bba6a7cb56c8b740d38257326bc86bc74ec96b92b6952c47"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5699,8 +5663,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8509cbe5ca45ce545db05a3fb706422770c01515f2f92065faaf7b10a30a52"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5733,8 +5696,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e32462f86a9cb94444976c434c527ed5b10759d434e03f1196c3b02a2823b53"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "anyhow",
  "rand 0.10.2",
@@ -5746,8 +5708,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a29e2ba2899708c5ed75c38fa240b90ef1c93b09666d294f7d70d7f0fd6c7d"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5771,8 +5732,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6eb6a7fde1b507454297556a66db81423201d351e1806c13408ee94cde0889"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5791,8 +5751,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5c565c1efc362a10db86b29a3c1337ecb66a028b3e1d6b8ff2318640e4233b"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -5805,8 +5764,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2239748ed6c1259ccc2ee221a2efc0c7567f9c4e7cacf5d3580a6423bbe5438"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5819,8 +5777,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685d70bba106e3dc276e7a056542b5f0682ba192bba9afde47c2c0cd55655fc7"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5832,8 +5789,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d8111c3baf730cb815b594fccefab73d52a7621e99a65c6298f98e9248db7a4"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5844,8 +5800,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4e3831d8473ea7f5239f69a417c6bfc7d7a7531c544957b1ea94d9a7c75cc7"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -5860,8 +5815,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c2f87d46761bf5408f08f81c9a55adc09f84b58121344d892363efd3f246c9"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5874,8 +5828,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c7159701d1dc29c891bcfff338471fb1c331923a85338650c499a42dff52dd"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -5884,8 +5837,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "270240b6d6f04754b6d5fd22db59448b14a80fff11d92ffb897edaa169f58f08"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5906,8 +5858,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3192db98219ba7abc3a11542c882a481efc3061973c38983aa67416e5d011a0"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5930,8 +5881,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61045a320a7fb64e43ecf3aa588277f0d7a9e5803c55d5e1b4d9bb6dea953fb2"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5948,8 +5898,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8dd8b8f01f14ef8683ec7ac8eaa23a18d78f7f7f93bc697c82df1eecdbc6a4b"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -5978,8 +5927,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5013b0531bdf09281334d9ba4d02e738809054b1fa98add30973ba70d4799634"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5997,8 +5945,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b344c526b425d969737e5ddc13e505e447333834c76730d9ab9b9e8978e15c2"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "metrics",
 ]
@@ -6006,8 +5953,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3199f958582fccc99b949b8f8ba9c5da993f54d5281a62620fca7c25686e1465"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6030,8 +5976,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-slipstream-plugin-interface"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1e149ae777ba08668697a8d2b6958e1357a3d06a0dad71c8df825a85db0fa7"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "anyhow",
 ]
@@ -6039,8 +5984,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-slipstream-plugin-manager"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59035a93576fc397540196e2e0ead9343e7d45125a01a2c930dc72e7fd0ecc63"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "anyhow",
  "json5",
@@ -6054,8 +5998,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7224e637c7c9816bee7d3b2b844b558810fc716267d06fec1c08b9fda2696750"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6091,8 +6034,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-error"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "846083cbef396e56e9df9fdfe6cb5382c1cc2404cc83b498a1cf2d7c2fd2e860"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-environment",
@@ -6104,8 +6046,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55f65479f0c1ab873f6e941b08cc027a0f92b40c6815cb116c793d7910bd7b1"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "aleo-std",
  "colored 3.1.1",
@@ -6132,8 +6073,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d568a98d96a400b4da9057a53c3f6f557c16d4533181a72e0e1d0e1e29e76c11"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "enum-iterator",
  "indexmap 2.14.0",
@@ -6154,8 +6094,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a0ab870d9ced282db29593e69021ccd4f11edc67580e35530daac2ac054444"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "bincode",
  "serde_json",
@@ -6168,8 +6107,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01620a5549a87084e24478a253d98965277f4d963e14b462ad7eb57f698b6081"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6192,8 +6130,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e90f015f504dc18b7faecc6e2056b90178af6511d4b15e412e76826635eedb"
+source = "git+https://github.com/eranrund/snarkVM.git?rev=a814b5cf2#a814b5cf220527a0bfb07628816072754c9b3d3f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,9 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
-#git = "https://github.com/ProvableHQ/snarkVM.git"
-#rev = "8902106cc"
-version = "=4.9.0"
+git = "https://github.com/eranrund/snarkVM.git"
+rev = "a814b5cf2"
+#version = "=4.9.0"
 
 [workspace.dependencies.anyhow]
 version = "1.0"

--- a/cli/src/commands/start.rs
+++ b/cli/src/commands/start.rs
@@ -892,6 +892,11 @@ impl Start {
         }
 
         node.wait_for_signals(&signal_handler).await;
+
+        // Exit with an error if the node shut itself down due to a fatal error.
+        if signal_handler.is_failed() {
+            bail!("The node shut down due to a fatal error (see the logs above for details)");
+        }
         Ok(())
     }
 

--- a/node/bft/events/src/block_response.rs
+++ b/node/bft/events/src/block_response.rs
@@ -114,14 +114,19 @@ impl<N: Network> DataBlocks<N> {
     pub const MAXIMUM_NUMBER_OF_BLOCKS: u8 = 5;
 
     /// Ensures that the blocks are well-formed in a block response.
+    ///
+    /// An empty block response is well-formed: it is the peer's explicit signal that it cannot
+    /// serve the requested range (e.g. because the blocks' authority data was pruned).
     pub fn ensure_response_is_well_formed(
         &self,
         peer_ip: SocketAddr,
         start_height: u32,
         end_height: u32,
     ) -> Result<()> {
-        // Ensure the blocks are not empty.
-        ensure!(!self.0.is_empty(), "Peer '{peer_ip}' sent an empty block response ({start_height}..{end_height})");
+        // An empty response indicates the peer cannot serve the requested range.
+        if self.0.is_empty() {
+            return Ok(());
+        }
         // Check that the blocks are sequentially ordered.
         if !self.0.windows(2).all(|w| w[0].height() + 1 == w[1].height()) {
             bail!("Peer '{peer_ip}' sent an invalid block response (blocks are not sequentially ordered)")
@@ -255,5 +260,25 @@ pub mod prop_tests {
         assert_eq!(response.request, request);
         assert_eq!(response.latest_consensus_version, None);
         assert_eq!(response.blocks.deserialize_blocking().unwrap(), blocks);
+    }
+
+    /// An empty block response is the peer's explicit signal that it cannot serve the requested range.
+    #[test]
+    fn empty_response_is_well_formed() {
+        let peer_ip: std::net::SocketAddr = "127.0.0.1:1234".parse().unwrap();
+        let empty = DataBlocks::<CurrentNetwork>(vec![]);
+        empty.ensure_response_is_well_formed(peer_ip, 1, 3).unwrap();
+    }
+
+    /// A non-empty block response must still match the requested range exactly.
+    #[test]
+    fn nonempty_response_must_match_request_range() {
+        let mut rng = TestRng::default();
+        let peer_ip: std::net::SocketAddr = "127.0.0.1:1234".parse().unwrap();
+        let genesis = sample_genesis_block(&mut rng);
+        let height = genesis.height();
+        let blocks = DataBlocks(vec![genesis]);
+        blocks.ensure_response_is_well_formed(peer_ip, height, height + 1).unwrap();
+        blocks.ensure_response_is_well_formed(peer_ip, height + 1, height + 2).unwrap_err();
     }
 }

--- a/node/bft/events/src/lib.rs
+++ b/node/bft/events/src/lib.rs
@@ -79,7 +79,7 @@ use snarkvm::{
     prelude::{Address, Field, Signature},
 };
 
-use anyhow::{Result, bail, ensure};
+use anyhow::{Result, bail};
 use indexmap::{IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
 pub use std::io::{self, Result as IoResult};

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -627,16 +627,21 @@ impl<N: Network> Gateway<N> {
 
                 let self_ = self.clone();
                 let blocks = match task::spawn_blocking(move || {
-                    // Retrieve the blocks within the requested range.
+                    // Retrieve the blocks within the requested range. If any block is unavailable
+                    // (e.g. its authority data was pruned), send an empty block response to
+                    // explicitly signal that this node cannot serve the requested range, rather
+                    // than penalizing the requester.
                     match self_.ledger.get_blocks(start_height..end_height) {
-                        Ok(blocks) => Ok(DataBlocks(blocks)),
-                        Err(error) => bail!("Missing blocks {start_height} to {end_height} from ledger - {error}"),
+                        Ok(blocks) => DataBlocks(blocks),
+                        Err(error) => {
+                            warn!("Cannot serve block request {start_height}..{end_height} from ledger - {error}");
+                            DataBlocks(vec![])
+                        }
                     }
                 })
                 .await
                 {
-                    Ok(Ok(blocks)) => blocks,
-                    Ok(Err(error)) => return Err(error),
+                    Ok(blocks) => blocks,
                     Err(error) => return Err(anyhow!("[BlockRequest] {error}")),
                 };
 

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -32,7 +32,7 @@ use snarkos_node_router::{
     Routing,
     messages::{Message, UnconfirmedSolution, UnconfirmedTransaction},
 };
-use snarkos_node_sync::{BlockSync, Ping};
+use snarkos_node_sync::{BlockSync, Ping, STUCK_SYNC_SHUTDOWN_THRESHOLD};
 use snarkos_node_tcp::{
     P2P,
     protocols::{Disconnect, Handshake, OnConnect, Reading},
@@ -281,6 +281,15 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
 
                 // Perform the sync routine.
                 self_.try_issuing_block_requests().await;
+
+                // If the blocks this node needs have been unservable by every connected peer for
+                // too long, shut down: on restart, the node will fetch the missing range from the CDN.
+                if self_.sync.sync_stuck_below_peer_floors().is_some_and(|stuck| stuck >= STUCK_SYNC_SHUTDOWN_THRESHOLD)
+                {
+                    crate::log_stuck_sync_error();
+                    self_.signal_handler.stop_with_failure();
+                    break;
+                }
             }
 
             info!("Stopped block request generation");

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -205,14 +205,16 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Client<N, C> {
             }
         };
 
-        // Retrieve the blocks within the requested range.
+        // Retrieve the blocks within the requested range. If any block is unavailable (e.g. its
+        // authority data was pruned), send an empty block response to explicitly signal that this
+        // node cannot serve the requested range, rather than penalizing the requester.
         let blocks = match self.ledger.get_blocks(*start_height..*end_height) {
             Ok(blocks) => DataBlocks(blocks),
             Err(error) => {
                 let err =
-                    error.context(format!("Failed to retrieve blocks {start_height} to {end_height} from the ledger"));
-                error!("{}", flatten_error(&err));
-                return false;
+                    error.context(format!("Cannot serve block request {start_height}..{end_height} from the ledger"));
+                warn!("{}", flatten_error(&err));
+                DataBlocks(vec![])
             }
         };
 

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -68,6 +68,15 @@ pub fn log_clean_error(storage_mode: &StorageMode) {
     }
 }
 
+/// Logs an error explaining that no connected peer can serve the blocks this node needs, and how to recover.
+pub fn log_stuck_sync_error() {
+    error!(
+        "No connected peer can serve the blocks this node needs — they have likely been pruned network-wide. \
+        Shutting down; on restart, the node will automatically sync the missing blocks from the CDN. \
+        Alternatively, restore a recent ledger snapshot. Nodes running with --nocdn must restore a snapshot."
+    );
+}
+
 /// Starts the notification message loop.
 pub fn start_notification_message_loop() -> tokio::task::JoinHandle<()> {
     // let mut interval = tokio::time::interval(std::time::Duration::from_secs(180));

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -33,12 +33,12 @@ use snarkos_node_router::{
     Routing,
     messages::{PuzzleResponse, UnconfirmedSolution, UnconfirmedTransaction},
 };
-use snarkos_node_sync::{BlockSync, Ping};
+use snarkos_node_sync::{BlockSync, Ping, STUCK_SYNC_SHUTDOWN_THRESHOLD};
 use snarkos_node_tcp::{
     P2P,
     protocols::{Disconnect, Handshake, OnConnect, Reading},
 };
-use snarkos_utilities::{DevHotswapConfig, NodeDataDir, SignalHandler};
+use snarkos_utilities::{DevHotswapConfig, NodeDataDir, SignalHandler, Stoppable};
 
 use snarkvm::prelude::{
     Ledger,
@@ -76,6 +76,8 @@ pub struct Validator<N: Network, C: ConsensusStorage<N>> {
     pub(crate) handles: Arc<Mutex<Vec<JoinHandle<()>>>>,
     /// Keeps track of sending pings.
     ping: Arc<Ping<N>>,
+    /// The signal handler, used to shut the node down on fatal errors.
+    signal_handler: Arc<SignalHandler>,
 }
 
 impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
@@ -185,6 +187,7 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
             sync: sync.clone(),
             ping,
             handles: Default::default(),
+            signal_handler: signal_handler.clone(),
         };
 
         // Perform sync with CDN (if enabled).
@@ -223,6 +226,8 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
         node.start_consensus_handlers().await?;
         // Initialize the routing.
         node.initialize_routing().await;
+        // Initialize the stuck-sync monitor.
+        node.initialize_stuck_sync_monitor();
         // Initialize the notification message loop.
         node.handles.lock().push(crate::start_notification_message_loop());
 
@@ -496,6 +501,25 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
             }
         });
         Ok(())
+    }
+
+    /// Spawns a task that shuts the node down if the blocks it needs to sync have been
+    /// unservable by every connected peer for too long: on restart, the node will fetch
+    /// the missing range from the CDN.
+    fn initialize_stuck_sync_monitor(&self) {
+        let node = self.clone();
+        self.spawn(async move {
+            while !node.signal_handler.is_stopped() {
+                tokio::time::sleep(STUCK_SYNC_SHUTDOWN_THRESHOLD / 10).await;
+
+                if node.sync.sync_stuck_below_peer_floors().is_some_and(|stuck| stuck >= STUCK_SYNC_SHUTDOWN_THRESHOLD)
+                {
+                    crate::log_stuck_sync_error();
+                    node.signal_handler.stop_with_failure();
+                    break;
+                }
+            }
+        });
     }
 
     /// Spawns a task with the given future; it should only be used for long-running tasks.

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -193,14 +193,16 @@ impl<N: Network, C: ConsensusStorage<N>> Inbound<N> for Validator<N, C> {
             }
         };
 
-        // Retrieve the blocks within the requested range.
+        // Retrieve the blocks within the requested range. If any block is unavailable (e.g. its
+        // authority data was pruned), send an empty block response to explicitly signal that this
+        // node cannot serve the requested range, rather than penalizing the requester.
         let blocks = match self.ledger.get_blocks(*start_height..*end_height) {
             Ok(blocks) => DataBlocks(blocks),
             Err(err) => {
                 let err =
-                    err.context(format!("Failed to retrieve blocks {start_height} to {end_height} from the ledger"));
-                error!("{}", flatten_error(err));
-                return false;
+                    err.context(format!("Cannot serve block request {start_height}..{end_height} from the ledger"));
+                warn!("{}", flatten_error(err));
+                DataBlocks(vec![])
             }
         };
         // Send the `BlockResponse` message to the peer.

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -26,7 +26,7 @@ use snarkos_node_sync_locators::{CHECKPOINT_INTERVAL, NUM_RECENT_BLOCKS};
 
 use snarkvm::{
     console::network::{ConsensusVersion, Network},
-    ledger::{Block, CheckBlockError},
+    ledger::{Block, CheckBlockError, store::AUTHORITY_RETENTION_BLOCKS},
     utilities::flatten_error,
 };
 
@@ -91,6 +91,21 @@ const MAX_BLOCK_REQUESTS: usize = 50; // 50 requests
 
 /// The maximum number of blocks tolerated before the primary is considered behind its peers.
 pub const MAX_BLOCKS_BEHIND: u32 = 1; // blocks
+
+/// A peer's advertised tip is only a snapshot: by the time our block request arrives, the peer may
+/// have advanced by a few blocks and pruned a corresponding number of old ones. We therefore do not
+/// assume a peer serves exactly `tip - AUTHORITY_RETENTION_BLOCKS`, but leave this many blocks of slack.
+const RETENTION_SLACK: u32 = 1_000;
+
+/// The duration after which a node that cannot request its needed blocks from any peer
+/// (see [`BlockSync::sync_stuck_below_peer_floors`]) should give up and shut down.
+pub const STUCK_SYNC_SHUTDOWN_THRESHOLD: Duration = Duration::from_secs(5 * 60);
+
+/// Returns the lowest block height the peer with the given tip is assumed to still serve,
+/// given that peers prune authority data older than `AUTHORITY_RETENTION_BLOCKS` blocks.
+fn assumed_peer_floor(peer_tip: u32) -> u32 {
+    peer_tip.saturating_sub(AUTHORITY_RETENTION_BLOCKS.saturating_sub(RETENTION_SLACK))
+}
 
 /// This is a dummy IP address that is used to represent the local node.
 /// Note: This here does not need to be a real IP address, but it must be unique/distinct from all other connections.
@@ -250,6 +265,10 @@ pub struct BlockSync<N: Network> {
     /// responding but cannot keep up with the request rate.
     last_response_at: Mutex<HashMap<SocketAddr, Instant>>,
 
+    /// Tracks since when the blocks this node needs are below the assumed pruning floor of every
+    /// connected peer, i.e. no peer can serve them and sync cannot progress.
+    unservable_since: Mutex<Option<Instant>>,
+
     /// Condition variable that wakes up waiting tasks when the node is synced.
     synced_notify: Notify,
 }
@@ -275,6 +294,7 @@ impl<N: Network> BlockSync<N> {
             failed_requests: Default::default(),
             last_response_at: Default::default(),
             synced_notify: Default::default(),
+            unservable_since: Default::default(),
         }
     }
 
@@ -1048,6 +1068,72 @@ impl<N: Network> BlockSync<N> {
     ///    `Client::try_issuing_block_requests` which calls this function.
     ///  - Provers do not call this function.
     pub fn prepare_block_requests(&self) -> Vec<BlockRequestBatch<N>> {
+        let batches = self.prepare_block_requests_inner();
+        self.update_unservable_tracking(batches.is_empty());
+        batches
+    }
+
+    /// Records whether the blocks this node needs are below the assumed pruning floor of every
+    /// connected peer, in which case sync cannot progress (see [`Self::sync_stuck_below_peer_floors`]).
+    fn update_unservable_tracking(&self, no_new_batches: bool) {
+        let is_stuck = no_new_batches
+            && !self.is_block_synced()
+            && self.requests.read().is_empty()
+            && self.needed_blocks_below_all_peer_floors(self.ledger.latest_block_height());
+
+        if is_stuck {
+            let mut unservable_since = self.unservable_since.lock();
+            if unservable_since.is_none() {
+                *unservable_since = Some(Instant::now());
+                warn!(
+                    "The blocks this node needs are older than what any connected peer retains; block synchronization cannot progress"
+                );
+            }
+        } else {
+            *self.unservable_since.lock() = None;
+        }
+    }
+
+    /// Returns `true` if this node cannot sync because every peer has pruned the blocks it needs,
+    /// i.e. at least one peer is ahead of the given height, but every such peer's assumed pruning
+    /// floor is above the next needed block (`height + 1`).
+    ///
+    /// This state is unrecoverable via P2P: peers prune as they advance, so the gap between their
+    /// floors and this node only grows. It is distinct from having no useful peers at all (not
+    /// synced yet, isolated, or poorly connected), which is transient and resolves itself as peers
+    /// connect — so that case returns `false`.
+    fn needed_blocks_below_all_peer_floors(&self, height: u32) -> bool {
+        let locators = self.locators.read();
+        let mut any_peer_ahead = false;
+        for peer_locators in locators.values() {
+            let peer_tip = peer_locators.latest_locator_height();
+            // Peers at or below our height are irrelevant: they have no blocks we lack,
+            // so their retention floors tell us nothing about whether we are stuck.
+            if peer_tip > height {
+                any_peer_ahead = true;
+                // This is the same eligibility test as the candidate filter in `find_sync_peers_inner`,
+                // so the two cannot disagree: if any peer still retains our next needed block,
+                // the peer selection would find it too, and we are not stuck.
+                if assumed_peer_floor(peer_tip) <= height.saturating_add(1) {
+                    return false;
+                }
+            }
+        }
+        // At this point no peer can serve us. This is only fatal if peers ahead of us exist:
+        // then the blocks we need have been pruned network-wide. Otherwise we are merely
+        // synced or isolated, which is not grounds for giving up.
+        any_peer_ahead
+    }
+
+    /// Returns how long the blocks this node needs have been below the assumed pruning floor of
+    /// every connected peer, if that is currently the case. Such a node cannot sync via P2P, and
+    /// should fall back to the CDN (by restarting) or to restoring a snapshot.
+    pub fn sync_stuck_below_peer_floors(&self) -> Option<Duration> {
+        self.unservable_since.lock().map(|since| since.elapsed())
+    }
+
+    /// See [`Self::prepare_block_requests`].
+    fn prepare_block_requests_inner(&self) -> Vec<BlockRequestBatch<N>> {
         let _block_requests_lock = self.prepare_requests_lock.lock();
 
         // Used to print more information when we max out on requests.
@@ -1538,11 +1624,16 @@ impl<N: Network> BlockSync<N> {
 
         // Pick a set of peers above the latest ledger height, and include their locators.
         // This will sort the peers by locator height in descending order.
+        // Peers whose assumed pruning floor is above the next block we need are excluded,
+        // since they can no longer serve the authority data for that block.
         let candidate_locators: IndexMap<_, _> = self
             .locators
             .read()
             .iter()
-            .filter(|(_, locators)| locators.latest_locator_height() > current_height)
+            .filter(|(_, locators)| {
+                let peer_tip = locators.latest_locator_height();
+                peer_tip > current_height && assumed_peer_floor(peer_tip) <= current_height.saturating_add(1)
+            })
             .sorted_by(|(_, a), (_, b)| b.latest_locator_height().cmp(&a.latest_locator_height()))
             .take(NUM_SYNC_CANDIDATE_PEERS)
             .map(|(peer_ip, locators)| (*peer_ip, locators.clone()))
@@ -1839,6 +1930,7 @@ mod tests {
             metrics: Default::default(),
             prepare_requests_lock: Default::default(),
             last_response_at: Default::default(),
+            unservable_since: Default::default(),
         }
     }
 
@@ -2338,6 +2430,72 @@ mod tests {
         // The requests to the peer were removed and marked for re-issue to other peers.
         assert!(sync.requests.read().is_empty());
         assert_eq!(sync.failed_requests.lock().len(), num_requests);
+    }
+
+    /// Tests that peers whose assumed pruning floor is above the next needed block are not selected for sync.
+    #[test]
+    fn test_floor_excludes_peers_that_pruned_the_needed_blocks() {
+        let sync = sample_sync_at_height(0);
+
+        // A peer at tip 200,000 is assumed to have pruned everything below ~101,000, so it cannot serve block 1.
+        sync.update_peer_locators(sample_peer_ip(1), &sample_block_locators(200_000)).unwrap();
+
+        assert!(sync.prepare_block_requests().is_empty());
+        // The sync pool records that the needed blocks are below every peer's retention floor.
+        assert!(sync.sync_stuck_below_peer_floors().is_some());
+    }
+
+    /// Tests that a peer whose retained window covers the next needed block is selected for sync.
+    #[test]
+    fn test_floor_includes_peers_that_retain_the_needed_blocks() {
+        let sync = sample_sync_at_height(150_000);
+
+        // A peer at tip 200,000 is assumed to retain blocks from ~101,000, so it can serve block 150,001.
+        sync.update_peer_locators(sample_peer_ip(1), &sample_block_locators(200_000)).unwrap();
+
+        let (requests, _) = sync.prepare_block_requests().pop().unwrap();
+        assert!(!requests.is_empty());
+        assert!(sync.sync_stuck_below_peer_floors().is_none());
+    }
+
+    /// Tests the boundary of the assumed peer floor: `peer_tip − (AUTHORITY_RETENTION_BLOCKS − RETENTION_SLACK)`
+    /// must be at or below the next needed block for the peer to be eligible.
+    #[test]
+    fn test_floor_boundary() {
+        // The next needed block is 1,001. A peer at tip 100,001 has an assumed floor of exactly 1,001 — eligible.
+        let sync = sample_sync_at_height(1_000);
+        sync.update_peer_locators(sample_peer_ip(1), &sample_block_locators(100_001)).unwrap();
+        assert!(!sync.prepare_block_requests().is_empty());
+        assert!(sync.sync_stuck_below_peer_floors().is_none());
+
+        // A peer one block further ahead has an assumed floor of 1,002 — no longer eligible.
+        let sync = sample_sync_at_height(1_000);
+        sync.update_peer_locators(sample_peer_ip(1), &sample_block_locators(100_002)).unwrap();
+        assert!(sync.prepare_block_requests().is_empty());
+        assert!(sync.sync_stuck_below_peer_floors().is_some());
+    }
+
+    /// Tests the stuck-signal lifecycle: set while every peer is assumed to have pruned the needed
+    /// blocks, cleared when an eligible peer appears, and never set when there are no peers at all.
+    #[test]
+    fn test_stuck_signal_lifecycle() {
+        let sync = sample_sync_at_height(0);
+
+        // With no peers at all, the sync pool is not considered stuck.
+        assert!(sync.prepare_block_requests().is_empty());
+        assert!(sync.sync_stuck_below_peer_floors().is_none());
+
+        // With only a peer that pruned the needed blocks, the stuck signal is set and persists.
+        sync.update_peer_locators(sample_peer_ip(1), &sample_block_locators(200_000)).unwrap();
+        assert!(sync.prepare_block_requests().is_empty());
+        assert!(sync.sync_stuck_below_peer_floors().is_some());
+        assert!(sync.prepare_block_requests().is_empty());
+        assert!(sync.sync_stuck_below_peer_floors().is_some());
+
+        // Once a peer that retains the needed blocks appears, the signal clears.
+        sync.update_peer_locators(sample_peer_ip(2), &sample_block_locators(50_000)).unwrap();
+        assert!(!sync.prepare_block_requests().is_empty());
+        assert!(sync.sync_stuck_below_peer_floors().is_none());
     }
 
     #[test]

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -128,7 +128,7 @@ pub struct BlockRequestsSummary {
 
 #[derive(thiserror::Error, Debug)]
 pub enum InsertBlockResponseError<N: Network> {
-    #[error("Empty block response")]
+    #[error("Emppty block response (this could indicate the peer cannot serve the requested blocks)")]
     EmptyBlockResponse,
     #[error("The peer did not send a consensus version")]
     NoConsensusVersion,
@@ -161,7 +161,7 @@ pub enum InsertBlockResponseError<N: Network> {
 impl<N: Network> InsertBlockResponseError<N> {
     /// Returns `true` if the error does not indicate malicious or faulty behavior.
     pub fn is_benign(&self) -> bool {
-        matches!(self, Self::NoSuchRequest { .. } | Self::BlockSyncAlreadyAdvanced { .. })
+        matches!(self, Self::NoSuchRequest { .. } | Self::BlockSyncAlreadyAdvanced { .. } | Self::EmptyBlockResponse)
     }
 
     // Returns true if the peer's consensus version is ahead of ours.
@@ -2306,6 +2306,38 @@ mod tests {
 
         // Check that the number of requests is reduced based on the ledger height.
         assert_eq!(new_sync.requests.read().len(), (locator_height - ledger_height) as usize);
+    }
+
+    /// Tests that an empty block response — the peer's explicit "cannot serve this range" signal —
+    /// is treated as benign and re-issues the peer's outstanding requests.
+    #[test]
+    fn test_empty_block_response_is_benign_and_reissues_requests() {
+        let rng = &mut TestRng::default();
+        let sync = sample_sync_at_height(0);
+        let peer_ip = sample_peer_ip(1);
+
+        // Add a peer and construct outstanding block requests assigned to it.
+        sync.update_peer_locators(peer_ip, &sample_block_locators(10)).unwrap();
+        let (requests, sync_peers) = sync.prepare_block_requests().pop().unwrap();
+        assert!(!requests.is_empty());
+        for (height, (hash, previous_hash, num_sync_ips)) in requests.clone() {
+            // Construct the sync IPs.
+            let sync_ips: IndexSet<_> = sync_peers.keys().sample(rng, num_sync_ips).into_iter().copied().collect();
+            // Insert the block request.
+            sync.insert_block_request(height, (hash, previous_hash, sync_ips)).unwrap();
+        }
+        let num_requests = sync.requests.read().len();
+        assert_eq!(num_requests, requests.len());
+
+        // The peer responds with an empty block response, indicating it cannot serve the range.
+        let error = sync.insert_block_responses(peer_ip, vec![], None).unwrap_err();
+        assert!(matches!(error, InsertBlockResponseError::EmptyBlockResponse));
+        // An explicit "cannot serve" is not a protocol violation.
+        assert!(error.is_benign());
+
+        // The requests to the peer were removed and marked for re-issue to other peers.
+        assert!(sync.requests.read().is_empty());
+        assert_eq!(sync.failed_requests.lock().len(), num_requests);
     }
 
     #[test]

--- a/node/tests/block_request.rs
+++ b/node/tests/block_request.rs
@@ -1,0 +1,110 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![recursion_limit = "256"]
+
+#[allow(dead_code)]
+mod common;
+use common::test_peer::TestPeer;
+
+use snarkos_node_network::PeerPoolHandling;
+use snarkos_node_router::messages::{BlockRequest, Message};
+
+use deadline::deadline;
+use paste::paste;
+use pea2pea::{Pea2Pea, protocols::Writing};
+use std::time::Duration;
+
+macro_rules! test_block_request_handling {
+    ($($node_type:ident),*) => {
+        $(
+            paste! {
+                /// Tests that a node replies with an empty `BlockResponse` — the explicit
+                /// "cannot serve this range" signal — when asked for blocks it does not have,
+                /// instead of disconnecting the requester.
+                #[tokio::test]
+                async fn [<$node_type _sends_empty_response_when_blocks_are_unavailable>]() {
+                    // Spin up a full node with a genesis-only ledger.
+                    let node = $crate::common::node::$node_type().await;
+
+                    // Spin up a test peer (synthetic node).
+                    let peer = TestPeer::client().await;
+                    let peer_addr = peer.node().listening_addr().await.unwrap();
+
+                    // Connect the node to the test peer.
+                    node.router().connect(peer_addr).unwrap().await.unwrap().unwrap();
+
+                    // Check the peer counts.
+                    let node_clone = node.clone();
+                    deadline!(Duration::from_secs(5), move || node_clone.router().number_of_connected_peers() == 1);
+                    let peer_clone = peer.clone();
+                    deadline!(Duration::from_secs(5), move || peer_clone.node().num_connected() == 1);
+
+                    // Request blocks the node does not have (the ledger only contains genesis).
+                    let request = BlockRequest { start_height: 1, end_height: 3 };
+                    let node_addr = *peer.node().connected_addrs().first().unwrap();
+                    assert!(peer.unicast(node_addr, Message::BlockRequest(request)).is_ok());
+
+                    // The node replies with an empty block response instead of disconnecting.
+                    let peer_clone = peer.clone();
+                    deadline!(Duration::from_secs(5), move || {
+                        peer_clone.received_messages().into_iter().any(|message| match message {
+                            Message::BlockResponse(response) => {
+                                assert_eq!(response.request, request);
+                                let blocks = response.blocks.deserialize_blocking().unwrap();
+                                assert!(blocks.is_empty(), "expected an empty block response");
+                                true
+                            }
+                            _ => false,
+                        })
+                    });
+
+                    // The node remains connected to the peer.
+                    assert_eq!(node.router().number_of_connected_peers(), 1);
+                }
+
+                /// Tests that a malformed block request (empty range) still disconnects the requester.
+                #[tokio::test]
+                async fn [<$node_type _disconnects_on_malformed_block_request>]() {
+                    // Spin up a full node.
+                    let node = $crate::common::node::$node_type().await;
+
+                    // Spin up a test peer (synthetic node).
+                    let peer = TestPeer::client().await;
+                    let peer_addr = peer.node().listening_addr().await.unwrap();
+
+                    // Connect the node to the test peer.
+                    node.router().connect(peer_addr).unwrap().await.unwrap().unwrap();
+
+                    // Check the peer counts.
+                    let node_clone = node.clone();
+                    deadline!(Duration::from_secs(5), move || node_clone.router().number_of_connected_peers() == 1);
+                    let peer_clone = peer.clone();
+                    deadline!(Duration::from_secs(5), move || peer_clone.node().num_connected() == 1);
+
+                    // Send a malformed block request (start >= end).
+                    let node_addr = *peer.node().connected_addrs().first().unwrap();
+                    assert!(peer.unicast(node_addr, Message::BlockRequest(BlockRequest { start_height: 3, end_height: 3 })).is_ok());
+
+                    // The node disconnects the peer for the protocol violation.
+                    let node_clone = node.clone();
+                    deadline!(Duration::from_secs(5), move || node_clone.router().number_of_connected_peers() == 0);
+                }
+            }
+        )*
+    };
+}
+
+test_block_request_handling!(client, validator);

--- a/node/tests/common/test_peer.rs
+++ b/node/tests/common/test_peer.rs
@@ -31,6 +31,7 @@ use std::{
     io,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     str::FromStr,
+    sync::{Arc, Mutex},
 };
 
 use futures_util::{TryStreamExt, sink::SinkExt};
@@ -64,6 +65,7 @@ pub struct TestPeer {
     node: Node,
     node_type: NodeType,
     account: Account<CurrentNetwork>,
+    received_messages: Arc<Mutex<Vec<Message<CurrentNetwork>>>>,
 }
 
 impl Pea2Pea for TestPeer {
@@ -97,6 +99,7 @@ impl TestPeer {
             }),
             node_type,
             account,
+            received_messages: Default::default(),
         };
 
         peer.enable_handshake().await;
@@ -124,6 +127,11 @@ impl TestPeer {
 
     pub fn address(&self) -> Address<CurrentNetwork> {
         self.account.address()
+    }
+
+    /// Returns a copy of the messages received from connected nodes so far.
+    pub fn received_messages(&self) -> Vec<Message<CurrentNetwork>> {
+        self.received_messages.lock().unwrap().clone()
     }
 }
 
@@ -225,7 +233,9 @@ impl Reading for TestPeer {
         Default::default()
     }
 
-    async fn process_message(&self, _peer_ip: SocketAddr, _message: Self::Message) {}
+    async fn process_message(&self, _peer_ip: SocketAddr, message: Self::Message) {
+        self.received_messages.lock().unwrap().push(message);
+    }
 }
 
 impl OnDisconnect for TestPeer {

--- a/utilities/src/signals.rs
+++ b/utilities/src/signals.rs
@@ -72,6 +72,9 @@ pub struct SignalHandler {
     /// This receiver is used to wait for the node to be stopped.
     stopped_receiver: Mutex<Option<oneshot::Receiver<()>>>,
 
+    /// Whether the stop was caused by a fatal error, so the process can exit with a non-zero code.
+    failed: AtomicBool,
+
     /// An optional tokio runtime handle.
     pub handle: Option<Handle>,
 }
@@ -83,6 +86,7 @@ impl SignalHandler {
         let obj = Arc::new(Self {
             stopped_sender: RwLock::new(Some(stopped_sender)),
             stopped_receiver: Mutex::new(Some(stopped_receiver)),
+            failed: AtomicBool::new(false),
             handle,
         });
 
@@ -131,6 +135,17 @@ impl SignalHandler {
         }
 
         self.stop();
+    }
+
+    /// Initiates shutdown of the node due to a fatal error, so the process exits with a non-zero code.
+    pub fn stop_with_failure(&self) {
+        self.failed.store(true, Ordering::SeqCst);
+        self.stop();
+    }
+
+    /// Returns `true` if the node was stopped due to a fatal error.
+    pub fn is_failed(&self) -> bool {
+        self.failed.load(Ordering::SeqCst)
     }
 
     /// Waits until the signal handler was invoked or the stopped flag was set some other way.


### PR DESCRIPTION
This is a companion PR to https://github.com/ProvableHQ/snarkVM/pull/3329

The main benefits of the smaller state, is that initial participation and recovery will be much faster, making the network more robust.

It contains two major changes, presented as individual commits that hopefully make it easier to review/reason about.

---

## Background

The [companion snarkVM PR](https://github.com/ProvableHQ/snarkVM/pull/3329) prunes authority data (`authority_map` + `certificate_map`) for blocks older than `AUTHORITY_RETENTION_BLOCKS` (100,000 blocks, roughly three days at 2.5s block times). Per review discussion there, peers do **not** advertise whether they keep full history. Instead the protocol contract becomes implicit and uniform: every peer serves `[tip − AUTHORITY_RETENTION_BLOCKS, tip]`, and anything older is fetched from the trusted CDN (automatic on startup) or from a ledger snapshot (manual).

That design needs two things from snarkOS, which today does neither: a node must be able to *decline* to serve blocks it no longer has without punishing the requester, and a node must avoid asking peers for blocks they cannot possibly still hold - and know what to do when nobody can serve it.

## Commit 1: `Don't treat get_blocks as failure and penalize requesting peer`

Today, when a node fails to load the blocks in a `BlockRequest`, the handler returns `false`/`Err` and the inbound dispatcher turns that into "peer sent an invalid block request", disconnecting the **requester** for a protocol violation. The failure is attributed to the wrong side: with pruning, an honest node would disconnect every peer that legitimately asks for a range it has pruned (and even without pruning, it's not the requesters fault that `get_blocks` failed...).

This commit makes an unavailable range a normal, benign outcome:

- **Serving side**: In the client router, validator router, and BFT gateway, a `get_blocks` failure now logs a warning and replies with an **empty `BlockResponse`** rather than failing the message. An empty response is expressible in the existing wire format (`DataBlocks` serializes a `u8` count), so there is no format change and no new message variant.
- **Requesting side**: `DataBlocks::ensure_response_is_well_formed` now accepts an empty response, documented as the peer's explicit "I cannot serve this range" signal. Ordering and range checks still apply to non-empty responses.
- `InsertBlockResponseError::EmptyBlockResponse` is now classified as benign. The existing machinery then does the right thing without further changes: the peer's outstanding requests are removed and marked for re-issue to other peers, so failover is immediate rather than waiting out the 60s request timeout.

**Compatibility.** No wire format change. Against an un-upgraded requester, an empty response is rejected and that peer disconnects the *server* and retries elsewhere - noisier, but assumed to be better than today, where the server disconnects an innocent requester. Un-upgraded servers never emit empty responses, so their behavior is unchanged.

## Commit 2: `Don't request blocks that peers have pruned, and shut down when no peer can serve them`

With commit 1 alone, a node far behind the network would request pruned ranges, receive empty responses, re-issue to the same peers, and churn indefinitely. This commit "teaches" the requester the retention contract and gives it an exit.

- **Retention-aware peer selection**: `find_sync_peers_inner` now skips peers whose assumed pruning floor lies above the next block we need. The floor is derived from the peer's advertised tip: `tip − (AUTHORITY_RETENTION_BLOCKS − RETENTION_SLACK)`. The slack (1,000 blocks, chosen arbitrarily) exists because an advertised tip is only a snapshot - by the time our request arrives the peer may have advanced and pruned correspondingly, so we cannot assume it serves exactly `tip − retention`.
- **Stuck detection**: `BlockSync` records when peers ahead of us exist but every one of them has pruned what we need, exposed as `sync_stuck_below_peer_floors()`. This state cannot resolve itself - peers prune further with every block they produce, so the gap only widens. It is deliberately distinguished from simply having no useful peers (not yet connected, isolated), which is transient and does not count.
- **Fatal shutdown**: After the condition persists for five minutes, the node logs how to recover and shuts down gracefully via the new `SignalHandler::stop_with_failure()`, which causes the process to exit non-zero so a supervisor restarts it - at which point the existing startup CDN sync closes the gap automatically. Restoring a snapshot is the manual alternative; nodes run with `--nocdn` must use one.

The choice of shutdown over in-process CDN fetching was deliberate. Mid-run CDN sync would require reworking the one-shot `CdnBlockSync` lifecycle, re-routing its ledger writes through the advancement lock it currently bypasses, and adding a pause/resume surface to `BlockSync` - and it would be difficult to cover validators, where a mid-run CDN jump would strand BFT/DAG state. Restarting into the existing, well-tested startup path achieves the same outcome. This is a thing we can improve upon if we decide to invest resources in it, but in reality I think we are not going to experience nodes being down for almost 3 days and then suddenly coming back to life and trying to sync. If a node fell that far behind, it might as well restart. This keeps the code and potential edgecases smaller and easier to reason about. Its also worth emphasizing that CDN sync takes place every time a node restarts, so this is standard practice.

## Misc notes

- **Devnet validation is still outstanding** (`.ci/test_devnet.sh`). We'll need to make the 100k prune block window configurable (maybe via a build env var), and we'd need a way to trigger a node falling far behind and aborting.
- **The stuck detector is inferred from peer claims.** A peer advertising a tip far above the real chain is unverifiable. In a progressing network this is inert: every real block gives an honest peer a servable tip and resets the timer, but during a network halt, when no honest peer is ahead, a lying peer could push idle nodes to exit. I am not convinced this is a problem since the network will (should?) never halt for any meaningful duration of time... if this is a concern, we might need hardening around this such as requiring a majority to choose the next tip, or choosing the minimum out of all peer-reprted tips that are ahead of us instead of choosing the maximum (which is what I think the code currently does).
- **REST still answers misleadingly for pruned blocks** (`GET /block/{h}` 404s; `GET /blocks` fails the whole range) - a separate follow-up. I'm considering using HTTP code 410 Gone (`Gone client error response status code indicates that the target resource is no longer available at the origin server`) to differentiate between a block that never existed and a block that used to exist but are no longer available due to pruning.

Another thing worth mentioning is that this shifts the entire network (after an upgrade) to assuming no node can actually provide post-prune-window block, even though some might (due to having the `history` feature enabled). That was a deliberate decision that favors simplicity over having each peer return different ranges it can fulfill ([explicitly suggested](https://github.com/ProvableHQ/snarkVM/issues/3230#issuecomment-5090974483) in the companion PR).