### PR TITLE
[Tests] Make test_restart_majority less flaky

### DIFF
--- a/.ci/test_restart_majority.sh
+++ b/.ci/test_restart_majority.sh
@@ -43,6 +43,11 @@ max_validator_log_size_bytes=$((3 * 1024 * 1024))
 # Set this higher than the interval for the minority test, as more nodes need to sync.
 max_wait_per_block=20
 
+# How long a restarted node may take to become ready again.
+# Loading an existing ledger is dominated by deserializing the cached block tree,
+# which has been observed to take over two minutes on CI.
+max_restart_wait=300
+
 # Define a trap handler that cleans up all processes on exit.
 trap stop_nodes EXIT
 
@@ -93,10 +98,16 @@ for iter in $(seq 1 "$num_resets"); do
     # Add 1-second delay between starting nodes to avoid hitting rate limits
     sleep 1
   done
-done
 
-# Sleep for a few seconds to make sure the nodes are fully restarted and connected.
-sleep 5
+  # Block until the restarted nodes serve their REST API again.
+  # Note: loading an existing ledger can take a couple of minutes, so be generous here.
+  # Doing this inside the loop also ensures that the startup time is not deducted from
+  # the time budget that the next `wait_for_heights` gets.
+  if ! wait_for_nodes "$total_validators" 0 "$network_name" "$max_restart_wait"; then
+    log "❌ Test failed! Not all nodes became ready within $max_restart_wait seconds after restart #$iter."
+    exit 1
+  fi
+done
 
 log_check_since=$(epoch_now)
 latest_height=$(get_block_height 0 "$network_name")

--- a/.ci/utils.sh
+++ b/.ci/utils.sh
@@ -348,15 +348,17 @@ function check_heights() {
 
   for node_index in $(seq "$start_index" $((end_index-1))); do
     port=$((3030 + node_index))
-    height=$(curl -s "http://127.0.0.1:$port/v2/$network_name/block/height/latest" || echo "0")
-    
+    # Note: this yields an empty string when the node is unreachable, so that an
+    # unreachable node is not indistinguishable from one that is at height 0.
+    height=$(get_block_height_by_port "$port" "$network_name")
+
     # Track highest height for reporting
     if (is_integer "$height") && (( height > highest_height )); then
       highest_height=$height
     fi
-    
+
     if ! (is_integer "$height"); then
-      log "Node #${node_index} (port=$port) did not respont to height request"
+      log "Node #${node_index} (port=$port) did not respond to height request"
       all_reached=false
     elif (( height < min_height )); then
       log "Node #${node_index} (port=$port) only reached height $height, expected at least $min_height"

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -1160,10 +1160,16 @@ impl<N: Network> Primary<N> {
         let signer = signature.to_address();
 
         // Ensure the batch signature is signed by the validator.
-        if self.gateway.resolve_to_aleo_addr(peer_ip) != Some(signer) {
-            // Proceed to disconnect the validator.
-            self.gateway.disconnect(peer_ip);
-            bail!("Malicious peer - batch signature is from a different validator ({signer})");
+        match self.gateway.resolve_to_aleo_addr(peer_ip) {
+            // If the peer is a validator, then ensure the batch signature is from the validator.
+            Some(address) => {
+                if address != signer {
+                    // Proceed to disconnect the validator.
+                    self.gateway.disconnect(peer_ip);
+                    bail!("Malicious peer - batch signature is from a different validator ({signer})");
+                }
+            }
+            None => bail!("Batch signature from a disconnected validator"),
         }
         // Ensure the batch signature is not from the current primary.
         if self.gateway.account().address() == signer {


### PR DESCRIPTION
Fixes https://github.com/ProvableHQ/snarkOS/issues/4355.

I'm also going to look into possibly speeding up the loading of the block tree for small trees, as it's a pretty heavy tax right now.