### PR TITLE
chore(storage-service): drop vestigial snarkvm/test dev-dependency

### DIFF
--- a/node/bft/storage-service/Cargo.toml
+++ b/node/bft/storage-service/Cargo.toml
@@ -52,7 +52,3 @@ features = [ "ledger", "console", "rocks" ]
 [dependencies.tracing]
 workspace = true
 optional = true
-
-[dev-dependencies.snarkvm]
-workspace = true
-features = [ "test" ]


### PR DESCRIPTION
## Motivation

Currently, `cargo test --workspace` fails. Specifically, `snarkos-cli` test `test_parse_development_and_genesis` fails.

## Investigation

The storage service declares a dev dependency on `snarkvm` with feature test, but this causes `cargo test --workspace` to fail. This is because the feature affects the constant `MainnetV0::GENESIS_COINBASE_TARGET` in `snarkvm`. The test asserts that the true mainnet genesis block parses correctly, and it doesn't when GENESIS_COIBNASE_TARGET changes.

The `snarkvm` dev-dependency with feature "test" was introduced in 384e900a5 alongside `BFTPersistentStorage::open_testing`, which called `RocksDB::open_map_testing` -- an API gated behind snarkvm's `test` feature. That method was deleted in 02782a1ba, but the dev-dependency was left in place.

It turns out that removing this doesn't break anything and makes `cargo test --workspace` pass.

## Test Plan

`cargo test --workspace` passes after this change.