### PR TITLE
Only error on DAG certificate replacement when the ID differs

### DIFF
--- a/node/bft/src/helpers/dag.rs
+++ b/node/bft/src/helpers/dag.rs
@@ -116,6 +116,10 @@ impl<N: Network> DAG<N> {
             // If a previous certificate existed for the author, log it.
             match previous {
                 None => trace!("Added new certificate for round {round} by author {author} to the DAG"),
+                // Re-inserting the same certificate is a no-op from a consensus perspective.
+                Some(previous) if previous.id() == certificate_id => {
+                    trace!("Certificate for round {round} by author {author} already existed in the DAG");
+                }
                 // A second certificate for one author in a round means the author equivocated. The
                 // DAG keeps whichever arrived last, so validators that saw both may now disagree.
                 Some(previous) => error!(


### PR DESCRIPTION
Closes https://github.com/ProvableHQ/snarkOS/issues/4373

Log an error when a certificate for the same round/author already exists in the DAG only if the certificate ID differs (equivocation). Note that this should already be caught in `fn process_batch_signature_from_peer`