### PR TITLE
try to improve developer build and test cycles

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,11 @@
 rustflags = [
     # LLD is generally faster and might be the default for Rust in the future.
     # See here: https://github.com/rust-lang/rust/issues/71515
-    "-C", "link-arg=-fuse-ld=lld",
+    #
+    # skylake CPU family includes most SSE and AVX2 instructions from about 10 years ago
+    # without this, optimization cannot use almost any vector instructions, unless
+    # you explicitly set target-cpu yourself when building.
+    "-C", "link-arg=-fuse-ld=lld", "-C", "target-cpu=skylake"
 ]
 
 [env]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -420,7 +420,7 @@ incremental = true
 
 [profile.test]
 opt-level = 2
-lto = "thin"
+lto = "off"
 incremental = true
 debug = true
 debug-assertions = true


### PR DESCRIPTION
Some of the settings in our Cargo.toml and .cargo/config.toml make for a painful developer experience around build and test cycles.

1. For some reason, the test profile has "lto=thin".

I have never seen this in any project. Normally, LTO is only used in release mode, because recompiling after a code change is very difficult when lto has been used.

This seems to have been turned on as part of a larger commit by howard in 2020, with no comment on why.

https://github.com/ProvableHQ/snarkOS/commit/9a1e167174

The pattern that I have seen used successfully is, if some tests are too slow to run without optimizations, then they are gated on `cfg(debug_assertions)` in the code, and then they will only run when you invoke `cargo test --release`, which will build and run the tests in the release profile. Then CI will have one job that does `cargo test` and one that does `cargo test --release`.

The benefit of this is, `cargo test` can build and rebuild fast when you are changing the code. The tests that need optimizations to work can still get them, without forcing all test runs to always be optimized as if for release mode.

What I'd like to do is get rid of this `lto=thin` stuff as a part of `cargo test`. Then, if CI starts failing with tests that are too slow to pass, mark those to only run in `cargo test --release`, and also test that invocation in CI.

2. No effort has been made to enable the use of modern CPU instructions.

In C++ projects, it's extremely common to use `-march=native` when building and running tests. This flag tells the compiler to identify the CPU we are running on, and when generating code, allow the optimizer to use any instructions that are legal for that architecture.

In rust, unfortunately cargo doesn't really have an equivalent flag, or an easy way to run the only the tests using this. Your main option is to use -C target-arch=native as a RUSTFLAGS env value. However, RUSTFLAGS itself is somewhat fraught because there are many ways that env values can be clobbered, and they interact with the .cargo/config.toml file in somewhat unexpected ways.

Instead the default behavior of cargo is that when you run the tests on a typical x86-64 machine, it does not assume that sse2 or AVX2 is present. Even 7 years ago, it would assume that you might be targetting a CPU from 7 years before that.

For a lot of projects it doesn't truly matter, but for crypto projects that make heavy use of elliptic curves and finite field math etc., these vector instructions can become extremely important for performance, especially when using twisted edwards curves where these operations become part of serializing and deserializing curve points.

Putting skylake here is pretty safe because, the x86-64 machines that don't have those instructions are museum pieces today -- none of the developers or CI machines or cloud machines will fail to have these instructions. Actually we put this stuff in the mobilecoin .cargo/config.toml 7 years ago and we never experienced a crash because of it or got a report from someone saying that the program crashed with SIGILL (which is what happens if the CPU reads an instruction it doesn't support.)

https://github.com/mobilecoinfoundation/mobilecoin/blob/05cb699f8f4cc1bc21186392545820c5b38408db/.cargo/config.toml#L8

My hope is that, this will counteract / help pay for any reduction in overall performance of tests due to turning off LTO.
